### PR TITLE
[NematodeBench] Classical REINFORCE MLP on Foraging Small - 0.810

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ uv run scripts/benchmark_submit.py regenerate
 | Brain | Score | Success Rate | Learning Speed | Stability | Distance Efficiency | Sessions | Contributor | Date |
 |---|---|---|---|---|---|---|---|---|
 | ppo | 0.835 ± 0.007 | 96.7% ± 1.3% | 0.93 ± 0.01 | 0.95 ± 0.05 | 0.47 ± 0.02 | 12 | @chrisjz | 2025-12-28 |
+| mlp | 0.810 ± 0.014 | 95.1% ± 1.9% | 0.91 ± 0.02 | 0.99 ± 0.03 | 0.39 ± 0.04 | 12 | @chrisjz | 2025-12-29 |
 
 #### Foraging Small - Quantum
 

--- a/artifacts/benchmarks/20251229_105138/20251229_092236.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_092236.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_092236",
+  "timestamp": "2025-12-29T09:32:27.530326+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_092236",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.965,
+    "avg_steps": 221.96,
+    "avg_reward": 34.2824000000001,
+    "avg_foods_collected": 9.74,
+    "avg_distance_efficiency": 0.40037805476568694,
+    "completed_all_food": 193,
+    "starved": 6,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 9,
+    "runs_to_convergence": 8,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 219.04166666666666,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.4100962761165647,
+    "composite_benchmark_score": 0.8150288828349693,
+    "learning_speed": 0.925,
+    "learning_speed_episodes": 15,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3480737277,
+        "success": false,
+        "steps": 200,
+        "total_reward": -7.499999999999997,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 3480737278,
+        "success": false,
+        "steps": 200,
+        "total_reward": -3.179999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 3480737279,
+        "success": false,
+        "steps": 240,
+        "total_reward": 0.47999999999992227,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.11666666666666667
+      },
+      {
+        "run": 4,
+        "seed": 3480737280,
+        "success": false,
+        "steps": 280,
+        "total_reward": 0.8399999999999395,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.34558823529411764
+      },
+      {
+        "run": 5,
+        "seed": 3480737281,
+        "success": false,
+        "steps": 307,
+        "total_reward": 2.844999999999933,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.1310412396385247
+      },
+      {
+        "run": 6,
+        "seed": 3480737282,
+        "success": false,
+        "steps": 320,
+        "total_reward": 1.7999999999999492,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.13453196347031962
+      },
+      {
+        "run": 7,
+        "seed": 3480737283,
+        "success": true,
+        "steps": 289,
+        "total_reward": 28.13500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33554210116435884
+      },
+      {
+        "run": 8,
+        "seed": 3480737284,
+        "success": false,
+        "steps": 500,
+        "total_reward": 37.06000000000006,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.27375573252299407
+      },
+      {
+        "run": 9,
+        "seed": 3480737285,
+        "success": true,
+        "steps": 359,
+        "total_reward": 33.605000000000196,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2865153674961077
+      },
+      {
+        "run": 10,
+        "seed": 3480737286,
+        "success": true,
+        "steps": 435,
+        "total_reward": 34.87500000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20873426014029076
+      },
+      {
+        "run": 11,
+        "seed": 3480737287,
+        "success": true,
+        "steps": 412,
+        "total_reward": 36.390000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23921503906276498
+      },
+      {
+        "run": 12,
+        "seed": 3480737288,
+        "success": true,
+        "steps": 389,
+        "total_reward": 40.345000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20641909060235383
+      },
+      {
+        "run": 13,
+        "seed": 3480737289,
+        "success": true,
+        "steps": 325,
+        "total_reward": 33.555000000000184,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2867248842911891
+      },
+      {
+        "run": 14,
+        "seed": 3480737290,
+        "success": true,
+        "steps": 244,
+        "total_reward": 35.45000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3805581550802139
+      },
+      {
+        "run": 15,
+        "seed": 3480737291,
+        "success": true,
+        "steps": 260,
+        "total_reward": 36.100000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40767174854131377
+      },
+      {
+        "run": 16,
+        "seed": 3480737292,
+        "success": true,
+        "steps": 281,
+        "total_reward": 35.22500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35438007139473265
+      },
+      {
+        "run": 17,
+        "seed": 3480737293,
+        "success": true,
+        "steps": 273,
+        "total_reward": 33.41500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35474810051244743
+      },
+      {
+        "run": 18,
+        "seed": 3480737294,
+        "success": true,
+        "steps": 191,
+        "total_reward": 33.795000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4834277980881397
+      },
+      {
+        "run": 19,
+        "seed": 3480737295,
+        "success": true,
+        "steps": 247,
+        "total_reward": 37.155000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3354373654893152
+      },
+      {
+        "run": 20,
+        "seed": 3480737296,
+        "success": true,
+        "steps": 270,
+        "total_reward": 39.69000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4259249435988651
+      },
+      {
+        "run": 21,
+        "seed": 3480737297,
+        "success": true,
+        "steps": 339,
+        "total_reward": 39.695000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23518457778207943
+      },
+      {
+        "run": 22,
+        "seed": 3480737298,
+        "success": true,
+        "steps": 250,
+        "total_reward": 36.490000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3757073844030366
+      },
+      {
+        "run": 23,
+        "seed": 3480737299,
+        "success": true,
+        "steps": 306,
+        "total_reward": 31.55000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2666137578701246
+      },
+      {
+        "run": 24,
+        "seed": 3480737300,
+        "success": true,
+        "steps": 222,
+        "total_reward": 39.920000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3791368025623141
+      },
+      {
+        "run": 25,
+        "seed": 3480737301,
+        "success": true,
+        "steps": 259,
+        "total_reward": 33.23500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3868450662542483
+      },
+      {
+        "run": 26,
+        "seed": 3480737302,
+        "success": true,
+        "steps": 189,
+        "total_reward": 34.735000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3931706432392931
+      },
+      {
+        "run": 27,
+        "seed": 3480737303,
+        "success": true,
+        "steps": 266,
+        "total_reward": 34.07000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30652909345556406
+      },
+      {
+        "run": 28,
+        "seed": 3480737304,
+        "success": true,
+        "steps": 169,
+        "total_reward": 33.74500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5133366724880172
+      },
+      {
+        "run": 29,
+        "seed": 3480737305,
+        "success": true,
+        "steps": 282,
+        "total_reward": 38.51000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2916894484262639
+      },
+      {
+        "run": 30,
+        "seed": 3480737306,
+        "success": true,
+        "steps": 260,
+        "total_reward": 35.8300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30725848734862016
+      },
+      {
+        "run": 31,
+        "seed": 3480737307,
+        "success": true,
+        "steps": 320,
+        "total_reward": 36.440000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22961036776826252
+      },
+      {
+        "run": 32,
+        "seed": 3480737308,
+        "success": true,
+        "steps": 214,
+        "total_reward": 30.22000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3024110203978358
+      },
+      {
+        "run": 33,
+        "seed": 3480737309,
+        "success": true,
+        "steps": 261,
+        "total_reward": 37.30500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29186756176887757
+      },
+      {
+        "run": 34,
+        "seed": 3480737310,
+        "success": true,
+        "steps": 253,
+        "total_reward": 31.45500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30974663797350954
+      },
+      {
+        "run": 35,
+        "seed": 3480737311,
+        "success": true,
+        "steps": 207,
+        "total_reward": 39.545000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4322683003325711
+      },
+      {
+        "run": 36,
+        "seed": 3480737312,
+        "success": true,
+        "steps": 253,
+        "total_reward": 38.26500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41118251726302574
+      },
+      {
+        "run": 37,
+        "seed": 3480737313,
+        "success": true,
+        "steps": 220,
+        "total_reward": 26.690000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32620348486202144
+      },
+      {
+        "run": 38,
+        "seed": 3480737314,
+        "success": true,
+        "steps": 217,
+        "total_reward": 25.85500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28902273894281566
+      },
+      {
+        "run": 39,
+        "seed": 3480737315,
+        "success": true,
+        "steps": 190,
+        "total_reward": 34.28000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4706478937728938
+      },
+      {
+        "run": 40,
+        "seed": 3480737316,
+        "success": true,
+        "steps": 191,
+        "total_reward": 32.13500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4282511201040613
+      },
+      {
+        "run": 41,
+        "seed": 3480737317,
+        "success": true,
+        "steps": 191,
+        "total_reward": 36.42500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4497311827956989
+      },
+      {
+        "run": 42,
+        "seed": 3480737318,
+        "success": true,
+        "steps": 228,
+        "total_reward": 31.11000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35585187431203935
+      },
+      {
+        "run": 43,
+        "seed": 3480737319,
+        "success": true,
+        "steps": 243,
+        "total_reward": 38.135000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3946252802774542
+      },
+      {
+        "run": 44,
+        "seed": 3480737320,
+        "success": true,
+        "steps": 224,
+        "total_reward": 34.07000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35918694581619465
+      },
+      {
+        "run": 45,
+        "seed": 3480737321,
+        "success": true,
+        "steps": 183,
+        "total_reward": 38.145000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5248475437605873
+      },
+      {
+        "run": 46,
+        "seed": 3480737322,
+        "success": true,
+        "steps": 216,
+        "total_reward": 30.710000000000132,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3538275850771847
+      },
+      {
+        "run": 47,
+        "seed": 3480737323,
+        "success": true,
+        "steps": 231,
+        "total_reward": 35.39500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34853292321713375
+      },
+      {
+        "run": 48,
+        "seed": 3480737324,
+        "success": true,
+        "steps": 197,
+        "total_reward": 35.5950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42956938159879343
+      },
+      {
+        "run": 49,
+        "seed": 3480737325,
+        "success": true,
+        "steps": 215,
+        "total_reward": 36.29500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3831836801917938
+      },
+      {
+        "run": 50,
+        "seed": 3480737326,
+        "success": true,
+        "steps": 161,
+        "total_reward": 29.625000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45548044791465847
+      },
+      {
+        "run": 51,
+        "seed": 3480737327,
+        "success": true,
+        "steps": 226,
+        "total_reward": 35.5000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42800699300699296
+      },
+      {
+        "run": 52,
+        "seed": 3480737328,
+        "success": true,
+        "steps": 233,
+        "total_reward": 34.515000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3334490222421257
+      },
+      {
+        "run": 53,
+        "seed": 3480737329,
+        "success": true,
+        "steps": 234,
+        "total_reward": 41.34000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4039495870344398
+      },
+      {
+        "run": 54,
+        "seed": 3480737330,
+        "success": true,
+        "steps": 259,
+        "total_reward": 44.135000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35963837838808244
+      },
+      {
+        "run": 55,
+        "seed": 3480737331,
+        "success": true,
+        "steps": 185,
+        "total_reward": 35.56500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47361332624490515
+      },
+      {
+        "run": 56,
+        "seed": 3480737332,
+        "success": true,
+        "steps": 202,
+        "total_reward": 38.47000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.471119011707247
+      },
+      {
+        "run": 57,
+        "seed": 3480737333,
+        "success": true,
+        "steps": 282,
+        "total_reward": 41.870000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3496974052779006
+      },
+      {
+        "run": 58,
+        "seed": 3480737334,
+        "success": true,
+        "steps": 192,
+        "total_reward": 32.05000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3917777777777778
+      },
+      {
+        "run": 59,
+        "seed": 3480737335,
+        "success": true,
+        "steps": 211,
+        "total_reward": 42.79500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5226656601656602
+      },
+      {
+        "run": 60,
+        "seed": 3480737336,
+        "success": true,
+        "steps": 199,
+        "total_reward": 38.675000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4293707033038102
+      },
+      {
+        "run": 61,
+        "seed": 3480737337,
+        "success": true,
+        "steps": 301,
+        "total_reward": 44.20500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31535221022672116
+      },
+      {
+        "run": 62,
+        "seed": 3480737338,
+        "success": true,
+        "steps": 207,
+        "total_reward": 33.8550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3811471861471861
+      },
+      {
+        "run": 63,
+        "seed": 3480737339,
+        "success": true,
+        "steps": 191,
+        "total_reward": 36.15500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48015778081567556
+      },
+      {
+        "run": 64,
+        "seed": 3480737340,
+        "success": true,
+        "steps": 190,
+        "total_reward": 38.20000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43031959778046114
+      },
+      {
+        "run": 65,
+        "seed": 3480737341,
+        "success": true,
+        "steps": 242,
+        "total_reward": 37.040000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3904299129141232
+      },
+      {
+        "run": 66,
+        "seed": 3480737342,
+        "success": true,
+        "steps": 203,
+        "total_reward": 29.965000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44248856142992105
+      },
+      {
+        "run": 67,
+        "seed": 3480737343,
+        "success": true,
+        "steps": 200,
+        "total_reward": 40.380000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39834040639667234
+      },
+      {
+        "run": 68,
+        "seed": 3480737344,
+        "success": true,
+        "steps": 251,
+        "total_reward": 33.925000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3914953169122191
+      },
+      {
+        "run": 69,
+        "seed": 3480737345,
+        "success": true,
+        "steps": 267,
+        "total_reward": 43.82500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4099058743982843
+      },
+      {
+        "run": 70,
+        "seed": 3480737346,
+        "success": true,
+        "steps": 193,
+        "total_reward": 29.965000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3641034998151092
+      },
+      {
+        "run": 71,
+        "seed": 3480737347,
+        "success": true,
+        "steps": 204,
+        "total_reward": 35.57000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4190573874010407
+      },
+      {
+        "run": 72,
+        "seed": 3480737348,
+        "success": true,
+        "steps": 186,
+        "total_reward": 36.540000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43856742769651635
+      },
+      {
+        "run": 73,
+        "seed": 3480737349,
+        "success": true,
+        "steps": 246,
+        "total_reward": 40.370000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3588841077786311
+      },
+      {
+        "run": 74,
+        "seed": 3480737350,
+        "success": true,
+        "steps": 190,
+        "total_reward": 37.1100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45464351851851853
+      },
+      {
+        "run": 75,
+        "seed": 3480737351,
+        "success": true,
+        "steps": 208,
+        "total_reward": 35.23000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4186144329526683
+      },
+      {
+        "run": 76,
+        "seed": 3480737352,
+        "success": true,
+        "steps": 211,
+        "total_reward": 36.67500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4937532416649565
+      },
+      {
+        "run": 77,
+        "seed": 3480737353,
+        "success": true,
+        "steps": 206,
+        "total_reward": 35.66000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3900435498272189
+      },
+      {
+        "run": 78,
+        "seed": 3480737354,
+        "success": true,
+        "steps": 262,
+        "total_reward": 39.850000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38254238353644643
+      },
+      {
+        "run": 79,
+        "seed": 3480737355,
+        "success": true,
+        "steps": 205,
+        "total_reward": 33.605000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3998090544461512
+      },
+      {
+        "run": 80,
+        "seed": 3480737356,
+        "success": true,
+        "steps": 186,
+        "total_reward": 40.78000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48722883597883604
+      },
+      {
+        "run": 81,
+        "seed": 3480737357,
+        "success": true,
+        "steps": 278,
+        "total_reward": 38.47000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3391398973575585
+      },
+      {
+        "run": 82,
+        "seed": 3480737358,
+        "success": true,
+        "steps": 240,
+        "total_reward": 34.56000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39171810877214225
+      },
+      {
+        "run": 83,
+        "seed": 3480737359,
+        "success": true,
+        "steps": 184,
+        "total_reward": 32.280000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49806318681318684
+      },
+      {
+        "run": 84,
+        "seed": 3480737360,
+        "success": true,
+        "steps": 164,
+        "total_reward": 33.78000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4616278836106423
+      },
+      {
+        "run": 85,
+        "seed": 3480737361,
+        "success": true,
+        "steps": 238,
+        "total_reward": 36.09000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3722433827293307
+      },
+      {
+        "run": 86,
+        "seed": 3480737362,
+        "success": true,
+        "steps": 204,
+        "total_reward": 36.30000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4689099914159212
+      },
+      {
+        "run": 87,
+        "seed": 3480737363,
+        "success": true,
+        "steps": 194,
+        "total_reward": 38.64000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5341818999713737
+      },
+      {
+        "run": 88,
+        "seed": 3480737364,
+        "success": true,
+        "steps": 196,
+        "total_reward": 41.81000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5148326261444702
+      },
+      {
+        "run": 89,
+        "seed": 3480737365,
+        "success": true,
+        "steps": 192,
+        "total_reward": 30.98000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3899613324412086
+      },
+      {
+        "run": 90,
+        "seed": 3480737366,
+        "success": true,
+        "steps": 178,
+        "total_reward": 32.52000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4931765767757147
+      },
+      {
+        "run": 91,
+        "seed": 3480737367,
+        "success": true,
+        "steps": 233,
+        "total_reward": 34.50500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.392211139001055
+      },
+      {
+        "run": 92,
+        "seed": 3480737368,
+        "success": true,
+        "steps": 201,
+        "total_reward": 32.155000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3883678452888979
+      },
+      {
+        "run": 93,
+        "seed": 3480737369,
+        "success": true,
+        "steps": 163,
+        "total_reward": 30.115000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44524697868351126
+      },
+      {
+        "run": 94,
+        "seed": 3480737370,
+        "success": true,
+        "steps": 239,
+        "total_reward": 43.00500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46192857643286034
+      },
+      {
+        "run": 95,
+        "seed": 3480737371,
+        "success": true,
+        "steps": 157,
+        "total_reward": 32.06500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.521969353530886
+      },
+      {
+        "run": 96,
+        "seed": 3480737372,
+        "success": true,
+        "steps": 238,
+        "total_reward": 33.95000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3864198443624697
+      },
+      {
+        "run": 97,
+        "seed": 3480737373,
+        "success": true,
+        "steps": 160,
+        "total_reward": 32.02000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4755218753405252
+      },
+      {
+        "run": 98,
+        "seed": 3480737374,
+        "success": true,
+        "steps": 207,
+        "total_reward": 30.435000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4317390942390943
+      },
+      {
+        "run": 99,
+        "seed": 3480737375,
+        "success": true,
+        "steps": 257,
+        "total_reward": 37.865000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37617443186738614
+      },
+      {
+        "run": 100,
+        "seed": 3480737376,
+        "success": true,
+        "steps": 134,
+        "total_reward": 31.290000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5893525480367586
+      },
+      {
+        "run": 101,
+        "seed": 3480737377,
+        "success": true,
+        "steps": 229,
+        "total_reward": 40.92500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.417423822161198
+      },
+      {
+        "run": 102,
+        "seed": 3480737378,
+        "success": true,
+        "steps": 218,
+        "total_reward": 37.460000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4399101497058154
+      },
+      {
+        "run": 103,
+        "seed": 3480737379,
+        "success": true,
+        "steps": 221,
+        "total_reward": 37.96500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41310421627835076
+      },
+      {
+        "run": 104,
+        "seed": 3480737380,
+        "success": true,
+        "steps": 220,
+        "total_reward": 33.940000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3644883476429639
+      },
+      {
+        "run": 105,
+        "seed": 3480737381,
+        "success": true,
+        "steps": 197,
+        "total_reward": 37.735000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5091887357298231
+      },
+      {
+        "run": 106,
+        "seed": 3480737382,
+        "success": true,
+        "steps": 184,
+        "total_reward": 33.12000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5078317625824019
+      },
+      {
+        "run": 107,
+        "seed": 3480737383,
+        "success": true,
+        "steps": 226,
+        "total_reward": 40.21000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42933483183483184
+      },
+      {
+        "run": 108,
+        "seed": 3480737384,
+        "success": true,
+        "steps": 229,
+        "total_reward": 37.5350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3984480355975858
+      },
+      {
+        "run": 109,
+        "seed": 3480737385,
+        "success": true,
+        "steps": 177,
+        "total_reward": 34.01500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49100866690762324
+      },
+      {
+        "run": 110,
+        "seed": 3480737386,
+        "success": true,
+        "steps": 198,
+        "total_reward": 30.9400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3777271799949285
+      },
+      {
+        "run": 111,
+        "seed": 3480737387,
+        "success": true,
+        "steps": 191,
+        "total_reward": 31.655000000000182,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45090909090909087
+      },
+      {
+        "run": 112,
+        "seed": 3480737388,
+        "success": true,
+        "steps": 194,
+        "total_reward": 37.380000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44848590899735064
+      },
+      {
+        "run": 113,
+        "seed": 3480737389,
+        "success": true,
+        "steps": 226,
+        "total_reward": 37.15000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37393480057953743
+      },
+      {
+        "run": 114,
+        "seed": 3480737390,
+        "success": true,
+        "steps": 227,
+        "total_reward": 31.4850000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3333323168882629
+      },
+      {
+        "run": 115,
+        "seed": 3480737391,
+        "success": true,
+        "steps": 181,
+        "total_reward": 35.71500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47251615534224234
+      },
+      {
+        "run": 116,
+        "seed": 3480737392,
+        "success": true,
+        "steps": 231,
+        "total_reward": 34.805000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37543301047611394
+      },
+      {
+        "run": 117,
+        "seed": 3480737393,
+        "success": true,
+        "steps": 229,
+        "total_reward": 36.61500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42781363889641877
+      },
+      {
+        "run": 118,
+        "seed": 3480737394,
+        "success": true,
+        "steps": 226,
+        "total_reward": 34.150000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42942627425782903
+      },
+      {
+        "run": 119,
+        "seed": 3480737395,
+        "success": true,
+        "steps": 205,
+        "total_reward": 36.29500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4824267393429385
+      },
+      {
+        "run": 120,
+        "seed": 3480737396,
+        "success": true,
+        "steps": 185,
+        "total_reward": 33.0350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5626157210522535
+      },
+      {
+        "run": 121,
+        "seed": 3480737397,
+        "success": true,
+        "steps": 175,
+        "total_reward": 32.16500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42940764790764796
+      },
+      {
+        "run": 122,
+        "seed": 3480737398,
+        "success": true,
+        "steps": 156,
+        "total_reward": 33.920000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5751992159886897
+      },
+      {
+        "run": 123,
+        "seed": 3480737399,
+        "success": true,
+        "steps": 191,
+        "total_reward": 35.02500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4358075267600439
+      },
+      {
+        "run": 124,
+        "seed": 3480737400,
+        "success": true,
+        "steps": 180,
+        "total_reward": 32.40000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4471436601033375
+      },
+      {
+        "run": 125,
+        "seed": 3480737401,
+        "success": true,
+        "steps": 212,
+        "total_reward": 37.55000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41666077781867256
+      },
+      {
+        "run": 126,
+        "seed": 3480737402,
+        "success": true,
+        "steps": 181,
+        "total_reward": 36.25500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47363103850172816
+      },
+      {
+        "run": 127,
+        "seed": 3480737403,
+        "success": true,
+        "steps": 220,
+        "total_reward": 29.21000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3813141499023852
+      },
+      {
+        "run": 128,
+        "seed": 3480737404,
+        "success": true,
+        "steps": 219,
+        "total_reward": 33.795000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48949836093857835
+      },
+      {
+        "run": 129,
+        "seed": 3480737405,
+        "success": true,
+        "steps": 191,
+        "total_reward": 37.15500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.433640432457568
+      },
+      {
+        "run": 130,
+        "seed": 3480737406,
+        "success": true,
+        "steps": 230,
+        "total_reward": 37.8100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38272753323531655
+      },
+      {
+        "run": 131,
+        "seed": 3480737407,
+        "success": true,
+        "steps": 173,
+        "total_reward": 46.62500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6222655998971789
+      },
+      {
+        "run": 132,
+        "seed": 3480737408,
+        "success": true,
+        "steps": 215,
+        "total_reward": 22.68500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2400692263745295
+      },
+      {
+        "run": 133,
+        "seed": 3480737409,
+        "success": true,
+        "steps": 188,
+        "total_reward": 36.650000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4394825277062119
+      },
+      {
+        "run": 134,
+        "seed": 3480737410,
+        "success": true,
+        "steps": 243,
+        "total_reward": 32.58500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3014817755782567
+      },
+      {
+        "run": 135,
+        "seed": 3480737411,
+        "success": true,
+        "steps": 158,
+        "total_reward": 32.75000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49132224257224255
+      },
+      {
+        "run": 136,
+        "seed": 3480737412,
+        "success": true,
+        "steps": 184,
+        "total_reward": 32.19000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40552003552003557
+      },
+      {
+        "run": 137,
+        "seed": 3480737413,
+        "success": true,
+        "steps": 211,
+        "total_reward": 33.61500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35814440461499286
+      },
+      {
+        "run": 138,
+        "seed": 3480737414,
+        "success": true,
+        "steps": 174,
+        "total_reward": 34.77000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4525986023780141
+      },
+      {
+        "run": 139,
+        "seed": 3480737415,
+        "success": true,
+        "steps": 198,
+        "total_reward": 41.19000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4650904593629052
+      },
+      {
+        "run": 140,
+        "seed": 3480737416,
+        "success": true,
+        "steps": 183,
+        "total_reward": 29.74500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3754147143705967
+      },
+      {
+        "run": 141,
+        "seed": 3480737417,
+        "success": true,
+        "steps": 287,
+        "total_reward": 40.885000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37886700851890726
+      },
+      {
+        "run": 142,
+        "seed": 3480737418,
+        "success": true,
+        "steps": 185,
+        "total_reward": 37.22500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5022575408462505
+      },
+      {
+        "run": 143,
+        "seed": 3480737419,
+        "success": true,
+        "steps": 200,
+        "total_reward": 29.370000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4206782569282569
+      },
+      {
+        "run": 144,
+        "seed": 3480737420,
+        "success": true,
+        "steps": 171,
+        "total_reward": 31.625000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4523357870199975
+      },
+      {
+        "run": 145,
+        "seed": 3480737421,
+        "success": true,
+        "steps": 257,
+        "total_reward": 47.07500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39823076326912643
+      },
+      {
+        "run": 146,
+        "seed": 3480737422,
+        "success": true,
+        "steps": 181,
+        "total_reward": 26.855000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38950824029771397
+      },
+      {
+        "run": 147,
+        "seed": 3480737423,
+        "success": true,
+        "steps": 245,
+        "total_reward": 35.165000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30346708861234806
+      },
+      {
+        "run": 148,
+        "seed": 3480737424,
+        "success": true,
+        "steps": 169,
+        "total_reward": 33.24500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47962160302717577
+      },
+      {
+        "run": 149,
+        "seed": 3480737425,
+        "success": true,
+        "steps": 206,
+        "total_reward": 36.76000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4335084843751892
+      },
+      {
+        "run": 150,
+        "seed": 3480737426,
+        "success": true,
+        "steps": 209,
+        "total_reward": 35.66500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4977642482542664
+      },
+      {
+        "run": 151,
+        "seed": 3480737427,
+        "success": true,
+        "steps": 290,
+        "total_reward": 37.3900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32766230288241394
+      },
+      {
+        "run": 152,
+        "seed": 3480737428,
+        "success": true,
+        "steps": 162,
+        "total_reward": 27.99000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4400659161585935
+      },
+      {
+        "run": 153,
+        "seed": 3480737429,
+        "success": true,
+        "steps": 221,
+        "total_reward": 31.20500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3473532462868201
+      },
+      {
+        "run": 154,
+        "seed": 3480737430,
+        "success": true,
+        "steps": 281,
+        "total_reward": 31.34500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29480385413099536
+      },
+      {
+        "run": 155,
+        "seed": 3480737431,
+        "success": true,
+        "steps": 186,
+        "total_reward": 35.76000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43975
+      },
+      {
+        "run": 156,
+        "seed": 3480737432,
+        "success": true,
+        "steps": 199,
+        "total_reward": 34.1950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4666834277407836
+      },
+      {
+        "run": 157,
+        "seed": 3480737433,
+        "success": true,
+        "steps": 275,
+        "total_reward": 32.95500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4072434435334446
+      },
+      {
+        "run": 158,
+        "seed": 3480737434,
+        "success": true,
+        "steps": 219,
+        "total_reward": 34.835000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4409976659936626
+      },
+      {
+        "run": 159,
+        "seed": 3480737435,
+        "success": true,
+        "steps": 263,
+        "total_reward": 28.735000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3209997281379532
+      },
+      {
+        "run": 160,
+        "seed": 3480737436,
+        "success": true,
+        "steps": 182,
+        "total_reward": 32.380000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4839223722923448
+      },
+      {
+        "run": 161,
+        "seed": 3480737437,
+        "success": true,
+        "steps": 203,
+        "total_reward": 36.24500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42995078995078995
+      },
+      {
+        "run": 162,
+        "seed": 3480737438,
+        "success": true,
+        "steps": 225,
+        "total_reward": 43.745000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44355339775463615
+      },
+      {
+        "run": 163,
+        "seed": 3480737439,
+        "success": true,
+        "steps": 207,
+        "total_reward": 33.12500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39315404337143467
+      },
+      {
+        "run": 164,
+        "seed": 3480737440,
+        "success": true,
+        "steps": 234,
+        "total_reward": 29.800000000000185,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33619052950077577
+      },
+      {
+        "run": 165,
+        "seed": 3480737441,
+        "success": true,
+        "steps": 183,
+        "total_reward": 34.9350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4182119305105239
+      },
+      {
+        "run": 166,
+        "seed": 3480737442,
+        "success": true,
+        "steps": 220,
+        "total_reward": 38.010000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35944569545236954
+      },
+      {
+        "run": 167,
+        "seed": 3480737443,
+        "success": true,
+        "steps": 175,
+        "total_reward": 40.08500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.511750019845995
+      },
+      {
+        "run": 168,
+        "seed": 3480737444,
+        "success": true,
+        "steps": 216,
+        "total_reward": 39.870000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4244354234173236
+      },
+      {
+        "run": 169,
+        "seed": 3480737445,
+        "success": true,
+        "steps": 296,
+        "total_reward": 33.2800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.261031560680517
+      },
+      {
+        "run": 170,
+        "seed": 3480737446,
+        "success": true,
+        "steps": 193,
+        "total_reward": 35.14500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47540364752044395
+      },
+      {
+        "run": 171,
+        "seed": 3480737447,
+        "success": true,
+        "steps": 237,
+        "total_reward": 32.64500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3660807079899372
+      },
+      {
+        "run": 172,
+        "seed": 3480737448,
+        "success": true,
+        "steps": 225,
+        "total_reward": 40.445000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42447458455522974
+      },
+      {
+        "run": 173,
+        "seed": 3480737449,
+        "success": true,
+        "steps": 240,
+        "total_reward": 39.28000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.361738677988678
+      },
+      {
+        "run": 174,
+        "seed": 3480737450,
+        "success": true,
+        "steps": 181,
+        "total_reward": 34.88500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45326335944756996
+      },
+      {
+        "run": 175,
+        "seed": 3480737451,
+        "success": true,
+        "steps": 187,
+        "total_reward": 40.01500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4814523809523809
+      },
+      {
+        "run": 176,
+        "seed": 3480737452,
+        "success": true,
+        "steps": 152,
+        "total_reward": 32.41000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48470788714209767
+      },
+      {
+        "run": 177,
+        "seed": 3480737453,
+        "success": true,
+        "steps": 277,
+        "total_reward": 43.715000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38823687920812744
+      },
+      {
+        "run": 178,
+        "seed": 3480737454,
+        "success": true,
+        "steps": 188,
+        "total_reward": 36.330000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4451273272094111
+      },
+      {
+        "run": 179,
+        "seed": 3480737455,
+        "success": true,
+        "steps": 216,
+        "total_reward": 39.600000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40270104895104897
+      },
+      {
+        "run": 180,
+        "seed": 3480737456,
+        "success": true,
+        "steps": 193,
+        "total_reward": 33.56500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4366642785319256
+      },
+      {
+        "run": 181,
+        "seed": 3480737457,
+        "success": true,
+        "steps": 198,
+        "total_reward": 42.63000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49856713143010783
+      },
+      {
+        "run": 182,
+        "seed": 3480737458,
+        "success": true,
+        "steps": 187,
+        "total_reward": 40.81500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5550127046866178
+      },
+      {
+        "run": 183,
+        "seed": 3480737459,
+        "success": true,
+        "steps": 204,
+        "total_reward": 35.320000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4467953673564288
+      },
+      {
+        "run": 184,
+        "seed": 3480737460,
+        "success": true,
+        "steps": 179,
+        "total_reward": 36.43500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46146143251406413
+      },
+      {
+        "run": 185,
+        "seed": 3480737461,
+        "success": true,
+        "steps": 187,
+        "total_reward": 29.625000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4257105857105857
+      },
+      {
+        "run": 186,
+        "seed": 3480737462,
+        "success": true,
+        "steps": 181,
+        "total_reward": 36.795000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5295185451803099
+      },
+      {
+        "run": 187,
+        "seed": 3480737463,
+        "success": true,
+        "steps": 197,
+        "total_reward": 38.735000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47650898942945596
+      },
+      {
+        "run": 188,
+        "seed": 3480737464,
+        "success": true,
+        "steps": 271,
+        "total_reward": 38.19500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38574359600369135
+      },
+      {
+        "run": 189,
+        "seed": 3480737465,
+        "success": true,
+        "steps": 202,
+        "total_reward": 32.840000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3751334961334961
+      },
+      {
+        "run": 190,
+        "seed": 3480737466,
+        "success": true,
+        "steps": 254,
+        "total_reward": 34.180000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32007081467233267
+      },
+      {
+        "run": 191,
+        "seed": 3480737467,
+        "success": true,
+        "steps": 161,
+        "total_reward": 27.59500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3890697165153687
+      },
+      {
+        "run": 192,
+        "seed": 3480737468,
+        "success": true,
+        "steps": 234,
+        "total_reward": 38.590000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.442437519690408
+      },
+      {
+        "run": 193,
+        "seed": 3480737469,
+        "success": true,
+        "steps": 219,
+        "total_reward": 33.395000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3787783907491391
+      },
+      {
+        "run": 194,
+        "seed": 3480737470,
+        "success": true,
+        "steps": 144,
+        "total_reward": 33.18000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5313415985103825
+      },
+      {
+        "run": 195,
+        "seed": 3480737471,
+        "success": true,
+        "steps": 201,
+        "total_reward": 26.73500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3519596505477016
+      },
+      {
+        "run": 196,
+        "seed": 3480737472,
+        "success": true,
+        "steps": 203,
+        "total_reward": 40.96500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4580642920298093
+      },
+      {
+        "run": 197,
+        "seed": 3480737473,
+        "success": true,
+        "steps": 243,
+        "total_reward": 39.52500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37016446516446516
+      },
+      {
+        "run": 198,
+        "seed": 3480737474,
+        "success": true,
+        "steps": 178,
+        "total_reward": 32.46000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4406038223902001
+      },
+      {
+        "run": 199,
+        "seed": 3480737475,
+        "success": true,
+        "steps": 251,
+        "total_reward": 26.49500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36136206896551726
+      },
+      {
+        "run": 200,
+        "seed": 3480737476,
+        "success": true,
+        "steps": 178,
+        "total_reward": 31.750000000000153,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38087037037037036
+      }
+    ],
+    "avg_chemotaxis_index": 0.41239162397429224,
+    "avg_time_in_attractant": 0.7061958119871461,
+    "avg_approach_frequency": 0.41530751941667043,
+    "avg_path_efficiency": 0.04063349987966695,
+    "post_convergence_chemotaxis_index": 0.4298944838157018,
+    "post_convergence_time_in_attractant": 0.714947241907851,
+    "post_convergence_approach_frequency": 0.41820808822543826,
+    "post_convergence_path_efficiency": 0.041341726477844856,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_092239.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_092239.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_092239",
+  "timestamp": "2025-12-29T09:31:25.930342+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_092239",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.965,
+    "avg_steps": 193.86,
+    "avg_reward": 34.89960000000009,
+    "avg_foods_collected": 9.72,
+    "avg_distance_efficiency": 0.45369966988002797,
+    "completed_all_food": 193,
+    "starved": 7,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 7,
+    "runs_to_convergence": 6,
+    "post_convergence_success_rate": 0.9948453608247423,
+    "post_convergence_avg_steps": 191.02072538860102,
+    "post_convergence_avg_foods": 9.958762886597938,
+    "post_convergence_variance": 0.005128068870230628,
+    "post_convergence_distance_efficiency": 0.46448901934738684,
+    "composite_benchmark_score": 0.8287208156989976,
+    "learning_speed": 0.9299999999999999,
+    "learning_speed_episodes": 14,
+    "stability": 0.9280184249251305,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 1153438571,
+        "success": false,
+        "steps": 200,
+        "total_reward": -6.170000000000003,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 1153438572,
+        "success": false,
+        "steps": 240,
+        "total_reward": -7.989999999999993,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.04918032786885246
+      },
+      {
+        "run": 3,
+        "seed": 1153438573,
+        "success": false,
+        "steps": 280,
+        "total_reward": 3.959999999999976,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.1290414066931367
+      },
+      {
+        "run": 4,
+        "seed": 1153438574,
+        "success": false,
+        "steps": 240,
+        "total_reward": -1.8499999999999925,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.046052631578947366
+      },
+      {
+        "run": 5,
+        "seed": 1153438575,
+        "success": false,
+        "steps": 280,
+        "total_reward": -0.7700000000000156,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.05389830508474576
+      },
+      {
+        "run": 6,
+        "seed": 1153438576,
+        "success": false,
+        "steps": 440,
+        "total_reward": 20.160000000000185,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.1725234278770931
+      },
+      {
+        "run": 7,
+        "seed": 1153438577,
+        "success": true,
+        "steps": 456,
+        "total_reward": 33.69000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21607916808291802
+      },
+      {
+        "run": 8,
+        "seed": 1153438578,
+        "success": true,
+        "steps": 463,
+        "total_reward": 40.98499999999997,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2872608741383103
+      },
+      {
+        "run": 9,
+        "seed": 1153438579,
+        "success": true,
+        "steps": 336,
+        "total_reward": 30.570000000000153,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22459079041896382
+      },
+      {
+        "run": 10,
+        "seed": 1153438580,
+        "success": true,
+        "steps": 225,
+        "total_reward": 32.66500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4525261634500765
+      },
+      {
+        "run": 11,
+        "seed": 1153438581,
+        "success": true,
+        "steps": 179,
+        "total_reward": 28.195000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38010679013237414
+      },
+      {
+        "run": 12,
+        "seed": 1153438582,
+        "success": true,
+        "steps": 252,
+        "total_reward": 30.55000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3537811482729813
+      },
+      {
+        "run": 13,
+        "seed": 1153438583,
+        "success": true,
+        "steps": 363,
+        "total_reward": 36.09500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2660944924818585
+      },
+      {
+        "run": 14,
+        "seed": 1153438584,
+        "success": true,
+        "steps": 334,
+        "total_reward": 35.13000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.282148486298707
+      },
+      {
+        "run": 15,
+        "seed": 1153438585,
+        "success": true,
+        "steps": 320,
+        "total_reward": 41.590000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2781419343820326
+      },
+      {
+        "run": 16,
+        "seed": 1153438586,
+        "success": true,
+        "steps": 310,
+        "total_reward": 39.930000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27032671784712403
+      },
+      {
+        "run": 17,
+        "seed": 1153438587,
+        "success": true,
+        "steps": 315,
+        "total_reward": 36.33500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3237465265192703
+      },
+      {
+        "run": 18,
+        "seed": 1153438588,
+        "success": true,
+        "steps": 201,
+        "total_reward": 36.09500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42526512334783007
+      },
+      {
+        "run": 19,
+        "seed": 1153438589,
+        "success": true,
+        "steps": 221,
+        "total_reward": 26.405000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36064668745249506
+      },
+      {
+        "run": 20,
+        "seed": 1153438590,
+        "success": true,
+        "steps": 186,
+        "total_reward": 30.97000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4198740915567181
+      },
+      {
+        "run": 21,
+        "seed": 1153438591,
+        "success": true,
+        "steps": 230,
+        "total_reward": 33.550000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3890163755650925
+      },
+      {
+        "run": 22,
+        "seed": 1153438592,
+        "success": true,
+        "steps": 178,
+        "total_reward": 37.710000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5537240210769623
+      },
+      {
+        "run": 23,
+        "seed": 1153438593,
+        "success": true,
+        "steps": 191,
+        "total_reward": 36.72500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38936962552237153
+      },
+      {
+        "run": 24,
+        "seed": 1153438594,
+        "success": true,
+        "steps": 205,
+        "total_reward": 36.9250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45772795041770376
+      },
+      {
+        "run": 25,
+        "seed": 1153438595,
+        "success": true,
+        "steps": 276,
+        "total_reward": 35.32000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3331621924985769
+      },
+      {
+        "run": 26,
+        "seed": 1153438596,
+        "success": true,
+        "steps": 161,
+        "total_reward": 36.84500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5362919438037792
+      },
+      {
+        "run": 27,
+        "seed": 1153438597,
+        "success": true,
+        "steps": 221,
+        "total_reward": 35.67500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42468739593739596
+      },
+      {
+        "run": 28,
+        "seed": 1153438598,
+        "success": true,
+        "steps": 190,
+        "total_reward": 33.250000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43205856643356644
+      },
+      {
+        "run": 29,
+        "seed": 1153438599,
+        "success": true,
+        "steps": 211,
+        "total_reward": 38.73500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45798871667415425
+      },
+      {
+        "run": 30,
+        "seed": 1153438600,
+        "success": true,
+        "steps": 169,
+        "total_reward": 29.685000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4006422816949133
+      },
+      {
+        "run": 31,
+        "seed": 1153438601,
+        "success": true,
+        "steps": 190,
+        "total_reward": 34.51000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4344452779568379
+      },
+      {
+        "run": 32,
+        "seed": 1153438602,
+        "success": true,
+        "steps": 203,
+        "total_reward": 42.18500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4473418803418803
+      },
+      {
+        "run": 33,
+        "seed": 1153438603,
+        "success": true,
+        "steps": 202,
+        "total_reward": 35.590000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4687438705085764
+      },
+      {
+        "run": 34,
+        "seed": 1153438604,
+        "success": true,
+        "steps": 223,
+        "total_reward": 32.46500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29756450502393705
+      },
+      {
+        "run": 35,
+        "seed": 1153438605,
+        "success": true,
+        "steps": 238,
+        "total_reward": 39.190000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36354044991815887
+      },
+      {
+        "run": 36,
+        "seed": 1153438606,
+        "success": true,
+        "steps": 208,
+        "total_reward": 39.37000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4259322169059011
+      },
+      {
+        "run": 37,
+        "seed": 1153438607,
+        "success": true,
+        "steps": 208,
+        "total_reward": 42.870000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4922651784340589
+      },
+      {
+        "run": 38,
+        "seed": 1153438608,
+        "success": true,
+        "steps": 203,
+        "total_reward": 38.915000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4541626940311151
+      },
+      {
+        "run": 39,
+        "seed": 1153438609,
+        "success": true,
+        "steps": 158,
+        "total_reward": 31.460000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42598651348651345
+      },
+      {
+        "run": 40,
+        "seed": 1153438610,
+        "success": true,
+        "steps": 229,
+        "total_reward": 34.43500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31258100134121086
+      },
+      {
+        "run": 41,
+        "seed": 1153438611,
+        "success": true,
+        "steps": 168,
+        "total_reward": 34.0700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.533724897998215
+      },
+      {
+        "run": 42,
+        "seed": 1153438612,
+        "success": true,
+        "steps": 217,
+        "total_reward": 37.27500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4117857142857143
+      },
+      {
+        "run": 43,
+        "seed": 1153438613,
+        "success": true,
+        "steps": 184,
+        "total_reward": 39.33000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.53495670995671
+      },
+      {
+        "run": 44,
+        "seed": 1153438614,
+        "success": true,
+        "steps": 180,
+        "total_reward": 41.700000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5544101550623289
+      },
+      {
+        "run": 45,
+        "seed": 1153438615,
+        "success": true,
+        "steps": 197,
+        "total_reward": 41.32500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4889678295560649
+      },
+      {
+        "run": 46,
+        "seed": 1153438616,
+        "success": true,
+        "steps": 219,
+        "total_reward": 48.49500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49798148972716244
+      },
+      {
+        "run": 47,
+        "seed": 1153438617,
+        "success": true,
+        "steps": 177,
+        "total_reward": 33.49500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44584325396825397
+      },
+      {
+        "run": 48,
+        "seed": 1153438618,
+        "success": true,
+        "steps": 194,
+        "total_reward": 37.630000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47264172517755904
+      },
+      {
+        "run": 49,
+        "seed": 1153438619,
+        "success": true,
+        "steps": 177,
+        "total_reward": 30.2150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41821294881589
+      },
+      {
+        "run": 50,
+        "seed": 1153438620,
+        "success": true,
+        "steps": 193,
+        "total_reward": 32.6950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38864002437856426
+      },
+      {
+        "run": 51,
+        "seed": 1153438621,
+        "success": true,
+        "steps": 188,
+        "total_reward": 33.30000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48504378595674574
+      },
+      {
+        "run": 52,
+        "seed": 1153438622,
+        "success": true,
+        "steps": 175,
+        "total_reward": 34.70500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47458269329237074
+      },
+      {
+        "run": 53,
+        "seed": 1153438623,
+        "success": true,
+        "steps": 216,
+        "total_reward": 41.64000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42331030897207367
+      },
+      {
+        "run": 54,
+        "seed": 1153438624,
+        "success": true,
+        "steps": 175,
+        "total_reward": 36.65500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45797038874438256
+      },
+      {
+        "run": 55,
+        "seed": 1153438625,
+        "success": true,
+        "steps": 155,
+        "total_reward": 38.3250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.553372643438433
+      },
+      {
+        "run": 56,
+        "seed": 1153438626,
+        "success": true,
+        "steps": 206,
+        "total_reward": 29.14000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3911132039022506
+      },
+      {
+        "run": 57,
+        "seed": 1153438627,
+        "success": true,
+        "steps": 211,
+        "total_reward": 37.74500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38936091686091684
+      },
+      {
+        "run": 58,
+        "seed": 1153438628,
+        "success": true,
+        "steps": 198,
+        "total_reward": 38.7900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40077211052710143
+      },
+      {
+        "run": 59,
+        "seed": 1153438629,
+        "success": true,
+        "steps": 179,
+        "total_reward": 34.11500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4540361027861028
+      },
+      {
+        "run": 60,
+        "seed": 1153438630,
+        "success": true,
+        "steps": 187,
+        "total_reward": 39.595000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47339916580171454
+      },
+      {
+        "run": 61,
+        "seed": 1153438631,
+        "success": true,
+        "steps": 184,
+        "total_reward": 35.01000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42671703296703295
+      },
+      {
+        "run": 62,
+        "seed": 1153438632,
+        "success": true,
+        "steps": 196,
+        "total_reward": 29.080000000000148,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3830864397040868
+      },
+      {
+        "run": 63,
+        "seed": 1153438633,
+        "success": true,
+        "steps": 110,
+        "total_reward": 33.60000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6614360149654267
+      },
+      {
+        "run": 64,
+        "seed": 1153438634,
+        "success": true,
+        "steps": 164,
+        "total_reward": 35.3400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5205470085470085
+      },
+      {
+        "run": 65,
+        "seed": 1153438635,
+        "success": true,
+        "steps": 210,
+        "total_reward": 38.73000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4524275743636209
+      },
+      {
+        "run": 66,
+        "seed": 1153438636,
+        "success": true,
+        "steps": 224,
+        "total_reward": 38.63000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43591339443373106
+      },
+      {
+        "run": 67,
+        "seed": 1153438637,
+        "success": true,
+        "steps": 201,
+        "total_reward": 38.775000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4322084916421619
+      },
+      {
+        "run": 68,
+        "seed": 1153438638,
+        "success": true,
+        "steps": 170,
+        "total_reward": 32.39000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48593155382629066
+      },
+      {
+        "run": 69,
+        "seed": 1153438639,
+        "success": true,
+        "steps": 190,
+        "total_reward": 34.25000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4403230128630586
+      },
+      {
+        "run": 70,
+        "seed": 1153438640,
+        "success": true,
+        "steps": 156,
+        "total_reward": 35.280000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5507039197771463
+      },
+      {
+        "run": 71,
+        "seed": 1153438641,
+        "success": true,
+        "steps": 194,
+        "total_reward": 34.28000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4102980352980353
+      },
+      {
+        "run": 72,
+        "seed": 1153438642,
+        "success": true,
+        "steps": 177,
+        "total_reward": 28.57500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41487636878125755
+      },
+      {
+        "run": 73,
+        "seed": 1153438643,
+        "success": true,
+        "steps": 141,
+        "total_reward": 30.475000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5593471055088701
+      },
+      {
+        "run": 74,
+        "seed": 1153438644,
+        "success": true,
+        "steps": 148,
+        "total_reward": 33.51000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5366185987925118
+      },
+      {
+        "run": 75,
+        "seed": 1153438645,
+        "success": true,
+        "steps": 155,
+        "total_reward": 32.87500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49883604957134364
+      },
+      {
+        "run": 76,
+        "seed": 1153438646,
+        "success": true,
+        "steps": 209,
+        "total_reward": 36.90500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4473071455622943
+      },
+      {
+        "run": 77,
+        "seed": 1153438647,
+        "success": true,
+        "steps": 179,
+        "total_reward": 31.555000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42091459709880763
+      },
+      {
+        "run": 78,
+        "seed": 1153438648,
+        "success": true,
+        "steps": 174,
+        "total_reward": 41.58000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5079449037679588
+      },
+      {
+        "run": 79,
+        "seed": 1153438649,
+        "success": true,
+        "steps": 197,
+        "total_reward": 43.45500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4699057623961716
+      },
+      {
+        "run": 80,
+        "seed": 1153438650,
+        "success": true,
+        "steps": 220,
+        "total_reward": 40.330000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42226332269880656
+      },
+      {
+        "run": 81,
+        "seed": 1153438651,
+        "success": true,
+        "steps": 155,
+        "total_reward": 32.625000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.504315955624272
+      },
+      {
+        "run": 82,
+        "seed": 1153438652,
+        "success": true,
+        "steps": 196,
+        "total_reward": 33.17000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3542707614446745
+      },
+      {
+        "run": 83,
+        "seed": 1153438653,
+        "success": true,
+        "steps": 161,
+        "total_reward": 33.42500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45041324688383516
+      },
+      {
+        "run": 84,
+        "seed": 1153438654,
+        "success": true,
+        "steps": 172,
+        "total_reward": 36.41000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4792015183848215
+      },
+      {
+        "run": 85,
+        "seed": 1153438655,
+        "success": true,
+        "steps": 187,
+        "total_reward": 37.795000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4881809956766608
+      },
+      {
+        "run": 86,
+        "seed": 1153438656,
+        "success": true,
+        "steps": 174,
+        "total_reward": 27.98000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37599487137850307
+      },
+      {
+        "run": 87,
+        "seed": 1153438657,
+        "success": true,
+        "steps": 215,
+        "total_reward": 38.38500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46030182236064593
+      },
+      {
+        "run": 88,
+        "seed": 1153438658,
+        "success": true,
+        "steps": 203,
+        "total_reward": 41.435000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4563269138269138
+      },
+      {
+        "run": 89,
+        "seed": 1153438659,
+        "success": true,
+        "steps": 196,
+        "total_reward": 39.70000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4831570650700673
+      },
+      {
+        "run": 90,
+        "seed": 1153438660,
+        "success": true,
+        "steps": 168,
+        "total_reward": 37.96000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49825376527422566
+      },
+      {
+        "run": 91,
+        "seed": 1153438661,
+        "success": true,
+        "steps": 177,
+        "total_reward": 37.195000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5442898218930827
+      },
+      {
+        "run": 92,
+        "seed": 1153438662,
+        "success": true,
+        "steps": 190,
+        "total_reward": 35.35000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4141263008539896
+      },
+      {
+        "run": 93,
+        "seed": 1153438663,
+        "success": true,
+        "steps": 156,
+        "total_reward": 36.030000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5844280240831965
+      },
+      {
+        "run": 94,
+        "seed": 1153438664,
+        "success": true,
+        "steps": 151,
+        "total_reward": 38.48500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5669016870642258
+      },
+      {
+        "run": 95,
+        "seed": 1153438665,
+        "success": true,
+        "steps": 155,
+        "total_reward": 29.605000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5166789259127968
+      },
+      {
+        "run": 96,
+        "seed": 1153438666,
+        "success": true,
+        "steps": 187,
+        "total_reward": 41.015000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49901338313103016
+      },
+      {
+        "run": 97,
+        "seed": 1153438667,
+        "success": true,
+        "steps": 155,
+        "total_reward": 38.38500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5012085137085137
+      },
+      {
+        "run": 98,
+        "seed": 1153438668,
+        "success": true,
+        "steps": 163,
+        "total_reward": 37.085000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5268809523809523
+      },
+      {
+        "run": 99,
+        "seed": 1153438669,
+        "success": true,
+        "steps": 160,
+        "total_reward": 37.28000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5752169685359341
+      },
+      {
+        "run": 100,
+        "seed": 1153438670,
+        "success": true,
+        "steps": 195,
+        "total_reward": 42.73500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4965596567411083
+      },
+      {
+        "run": 101,
+        "seed": 1153438671,
+        "success": true,
+        "steps": 181,
+        "total_reward": 38.8550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5092455379587733
+      },
+      {
+        "run": 102,
+        "seed": 1153438672,
+        "success": true,
+        "steps": 180,
+        "total_reward": 35.2300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4132221227048813
+      },
+      {
+        "run": 103,
+        "seed": 1153438673,
+        "success": true,
+        "steps": 174,
+        "total_reward": 33.78000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4314026954148438
+      },
+      {
+        "run": 104,
+        "seed": 1153438674,
+        "success": true,
+        "steps": 186,
+        "total_reward": 36.67000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45627249692147387
+      },
+      {
+        "run": 105,
+        "seed": 1153438675,
+        "success": true,
+        "steps": 176,
+        "total_reward": 41.650000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4952035450383064
+      },
+      {
+        "run": 106,
+        "seed": 1153438676,
+        "success": true,
+        "steps": 151,
+        "total_reward": 40.19500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6542210975299211
+      },
+      {
+        "run": 107,
+        "seed": 1153438677,
+        "success": true,
+        "steps": 187,
+        "total_reward": 33.16500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4358711658711659
+      },
+      {
+        "run": 108,
+        "seed": 1153438678,
+        "success": true,
+        "steps": 183,
+        "total_reward": 38.36500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4436670106639147
+      },
+      {
+        "run": 109,
+        "seed": 1153438679,
+        "success": true,
+        "steps": 189,
+        "total_reward": 36.955000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41816892825097157
+      },
+      {
+        "run": 110,
+        "seed": 1153438680,
+        "success": true,
+        "steps": 230,
+        "total_reward": 27.45000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3655980130980131
+      },
+      {
+        "run": 111,
+        "seed": 1153438681,
+        "success": true,
+        "steps": 149,
+        "total_reward": 39.855000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5976666666666667
+      },
+      {
+        "run": 112,
+        "seed": 1153438682,
+        "success": true,
+        "steps": 225,
+        "total_reward": 37.035000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3629908926435296
+      },
+      {
+        "run": 113,
+        "seed": 1153438683,
+        "success": true,
+        "steps": 154,
+        "total_reward": 31.5600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4650893224422636
+      },
+      {
+        "run": 114,
+        "seed": 1153438684,
+        "success": true,
+        "steps": 163,
+        "total_reward": 35.58500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4996805971805972
+      },
+      {
+        "run": 115,
+        "seed": 1153438685,
+        "success": true,
+        "steps": 184,
+        "total_reward": 34.620000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43454986533933904
+      },
+      {
+        "run": 116,
+        "seed": 1153438686,
+        "success": true,
+        "steps": 189,
+        "total_reward": 35.515000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46104310192545483
+      },
+      {
+        "run": 117,
+        "seed": 1153438687,
+        "success": true,
+        "steps": 177,
+        "total_reward": 39.695000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5551291989664082
+      },
+      {
+        "run": 118,
+        "seed": 1153438688,
+        "success": true,
+        "steps": 171,
+        "total_reward": 37.00500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5123576276664512
+      },
+      {
+        "run": 119,
+        "seed": 1153438689,
+        "success": true,
+        "steps": 219,
+        "total_reward": 43.78500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5007738095238096
+      },
+      {
+        "run": 120,
+        "seed": 1153438690,
+        "success": true,
+        "steps": 122,
+        "total_reward": 31.220000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5773322510822511
+      },
+      {
+        "run": 121,
+        "seed": 1153438691,
+        "success": true,
+        "steps": 244,
+        "total_reward": 44.47999999999996,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39493301143301146
+      },
+      {
+        "run": 122,
+        "seed": 1153438692,
+        "success": true,
+        "steps": 136,
+        "total_reward": 38.2200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.62096716689108
+      },
+      {
+        "run": 123,
+        "seed": 1153438693,
+        "success": true,
+        "steps": 169,
+        "total_reward": 31.735000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4458671328671329
+      },
+      {
+        "run": 124,
+        "seed": 1153438694,
+        "success": true,
+        "steps": 158,
+        "total_reward": 34.370000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5395682578291273
+      },
+      {
+        "run": 125,
+        "seed": 1153438695,
+        "success": true,
+        "steps": 195,
+        "total_reward": 34.67500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46891042780748665
+      },
+      {
+        "run": 126,
+        "seed": 1153438696,
+        "success": true,
+        "steps": 169,
+        "total_reward": 34.88500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5074225447754859
+      },
+      {
+        "run": 127,
+        "seed": 1153438697,
+        "success": true,
+        "steps": 161,
+        "total_reward": 37.41500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5070847268673355
+      },
+      {
+        "run": 128,
+        "seed": 1153438698,
+        "success": true,
+        "steps": 143,
+        "total_reward": 35.78500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6222759856630824
+      },
+      {
+        "run": 129,
+        "seed": 1153438699,
+        "success": true,
+        "steps": 215,
+        "total_reward": 31.785000000000103,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3612892970042723
+      },
+      {
+        "run": 130,
+        "seed": 1153438700,
+        "success": true,
+        "steps": 173,
+        "total_reward": 39.69500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43515683695987234
+      },
+      {
+        "run": 131,
+        "seed": 1153438701,
+        "success": true,
+        "steps": 188,
+        "total_reward": 35.56000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5358145910884248
+      },
+      {
+        "run": 132,
+        "seed": 1153438702,
+        "success": true,
+        "steps": 192,
+        "total_reward": 35.75000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5005122926275817
+      },
+      {
+        "run": 133,
+        "seed": 1153438703,
+        "success": true,
+        "steps": 139,
+        "total_reward": 32.105000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5349786324786325
+      },
+      {
+        "run": 134,
+        "seed": 1153438704,
+        "success": true,
+        "steps": 147,
+        "total_reward": 34.675000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6012987012987013
+      },
+      {
+        "run": 135,
+        "seed": 1153438705,
+        "success": true,
+        "steps": 189,
+        "total_reward": 43.365000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5775420256696597
+      },
+      {
+        "run": 136,
+        "seed": 1153438706,
+        "success": true,
+        "steps": 158,
+        "total_reward": 34.660000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49130122328651743
+      },
+      {
+        "run": 137,
+        "seed": 1153438707,
+        "success": true,
+        "steps": 192,
+        "total_reward": 37.92000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4634618358636054
+      },
+      {
+        "run": 138,
+        "seed": 1153438708,
+        "success": true,
+        "steps": 268,
+        "total_reward": 40.07000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.382766924018454
+      },
+      {
+        "run": 139,
+        "seed": 1153438709,
+        "success": true,
+        "steps": 180,
+        "total_reward": 32.78000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4642559523809524
+      },
+      {
+        "run": 140,
+        "seed": 1153438710,
+        "success": true,
+        "steps": 254,
+        "total_reward": 39.820000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39059215927750407
+      },
+      {
+        "run": 141,
+        "seed": 1153438711,
+        "success": true,
+        "steps": 152,
+        "total_reward": 33.1200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5342323730191377
+      },
+      {
+        "run": 142,
+        "seed": 1153438712,
+        "success": true,
+        "steps": 185,
+        "total_reward": 45.75500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5358149449711235
+      },
+      {
+        "run": 143,
+        "seed": 1153438713,
+        "success": true,
+        "steps": 149,
+        "total_reward": 32.35500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5334999341616988
+      },
+      {
+        "run": 144,
+        "seed": 1153438714,
+        "success": false,
+        "steps": 225,
+        "total_reward": -2.6749999999999874,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.6428571428571428
+      },
+      {
+        "run": 145,
+        "seed": 1153438715,
+        "success": true,
+        "steps": 243,
+        "total_reward": 44.53500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38500874191543566
+      },
+      {
+        "run": 146,
+        "seed": 1153438716,
+        "success": true,
+        "steps": 123,
+        "total_reward": 35.965000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6030807019777609
+      },
+      {
+        "run": 147,
+        "seed": 1153438717,
+        "success": true,
+        "steps": 209,
+        "total_reward": 42.15500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4972146182744009
+      },
+      {
+        "run": 148,
+        "seed": 1153438718,
+        "success": true,
+        "steps": 150,
+        "total_reward": 35.58000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4861830440091309
+      },
+      {
+        "run": 149,
+        "seed": 1153438719,
+        "success": true,
+        "steps": 169,
+        "total_reward": 33.465000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47656348553407374
+      },
+      {
+        "run": 150,
+        "seed": 1153438720,
+        "success": true,
+        "steps": 204,
+        "total_reward": 27.660000000000185,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.403847481021394
+      },
+      {
+        "run": 151,
+        "seed": 1153438721,
+        "success": true,
+        "steps": 199,
+        "total_reward": 43.735000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4775180138932048
+      },
+      {
+        "run": 152,
+        "seed": 1153438722,
+        "success": true,
+        "steps": 167,
+        "total_reward": 42.74500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5354863011384751
+      },
+      {
+        "run": 153,
+        "seed": 1153438723,
+        "success": true,
+        "steps": 195,
+        "total_reward": 37.72500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44769626967459786
+      },
+      {
+        "run": 154,
+        "seed": 1153438724,
+        "success": true,
+        "steps": 189,
+        "total_reward": 47.305000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5556825985774195
+      },
+      {
+        "run": 155,
+        "seed": 1153438725,
+        "success": true,
+        "steps": 189,
+        "total_reward": 39.60500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4670334928229665
+      },
+      {
+        "run": 156,
+        "seed": 1153438726,
+        "success": true,
+        "steps": 168,
+        "total_reward": 30.740000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4430848662001913
+      },
+      {
+        "run": 157,
+        "seed": 1153438727,
+        "success": true,
+        "steps": 173,
+        "total_reward": 29.415000000000113,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4365943084693084
+      },
+      {
+        "run": 158,
+        "seed": 1153438728,
+        "success": true,
+        "steps": 196,
+        "total_reward": 45.32000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4726875950979853
+      },
+      {
+        "run": 159,
+        "seed": 1153438729,
+        "success": true,
+        "steps": 139,
+        "total_reward": 30.155000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5468360805860806
+      },
+      {
+        "run": 160,
+        "seed": 1153438730,
+        "success": true,
+        "steps": 162,
+        "total_reward": 37.44000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5106049783549784
+      },
+      {
+        "run": 161,
+        "seed": 1153438731,
+        "success": true,
+        "steps": 146,
+        "total_reward": 37.7000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6079182330827068
+      },
+      {
+        "run": 162,
+        "seed": 1153438732,
+        "success": true,
+        "steps": 151,
+        "total_reward": 35.45500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5170014674867616
+      },
+      {
+        "run": 163,
+        "seed": 1153438733,
+        "success": true,
+        "steps": 152,
+        "total_reward": 30.74000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47707719568013685
+      },
+      {
+        "run": 164,
+        "seed": 1153438734,
+        "success": true,
+        "steps": 169,
+        "total_reward": 30.735000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45227842419018893
+      },
+      {
+        "run": 165,
+        "seed": 1153438735,
+        "success": true,
+        "steps": 216,
+        "total_reward": 36.33000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39277553902084567
+      },
+      {
+        "run": 166,
+        "seed": 1153438736,
+        "success": true,
+        "steps": 227,
+        "total_reward": 37.32500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3835296574770259
+      },
+      {
+        "run": 167,
+        "seed": 1153438737,
+        "success": true,
+        "steps": 170,
+        "total_reward": 33.450000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4893595072437577
+      },
+      {
+        "run": 168,
+        "seed": 1153438738,
+        "success": true,
+        "steps": 192,
+        "total_reward": 37.090000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47320553221288514
+      },
+      {
+        "run": 169,
+        "seed": 1153438739,
+        "success": true,
+        "steps": 181,
+        "total_reward": 34.745000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4413751385490515
+      },
+      {
+        "run": 170,
+        "seed": 1153438740,
+        "success": true,
+        "steps": 199,
+        "total_reward": 33.025000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40424847510665085
+      },
+      {
+        "run": 171,
+        "seed": 1153438741,
+        "success": true,
+        "steps": 173,
+        "total_reward": 35.43500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6097148813718581
+      },
+      {
+        "run": 172,
+        "seed": 1153438742,
+        "success": true,
+        "steps": 207,
+        "total_reward": 34.045000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4147620320855615
+      },
+      {
+        "run": 173,
+        "seed": 1153438743,
+        "success": true,
+        "steps": 165,
+        "total_reward": 29.675000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40423896279159444
+      },
+      {
+        "run": 174,
+        "seed": 1153438744,
+        "success": true,
+        "steps": 183,
+        "total_reward": 36.78500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4823878230995609
+      },
+      {
+        "run": 175,
+        "seed": 1153438745,
+        "success": true,
+        "steps": 147,
+        "total_reward": 30.4150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48256410256410254
+      },
+      {
+        "run": 176,
+        "seed": 1153438746,
+        "success": true,
+        "steps": 162,
+        "total_reward": 37.82000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5084778478454199
+      },
+      {
+        "run": 177,
+        "seed": 1153438747,
+        "success": true,
+        "steps": 144,
+        "total_reward": 31.130000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.513015115659639
+      },
+      {
+        "run": 178,
+        "seed": 1153438748,
+        "success": true,
+        "steps": 163,
+        "total_reward": 29.36500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4563888888888889
+      },
+      {
+        "run": 179,
+        "seed": 1153438749,
+        "success": true,
+        "steps": 174,
+        "total_reward": 39.510000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.553881074168798
+      },
+      {
+        "run": 180,
+        "seed": 1153438750,
+        "success": true,
+        "steps": 138,
+        "total_reward": 30.540000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5306472612354965
+      },
+      {
+        "run": 181,
+        "seed": 1153438751,
+        "success": true,
+        "steps": 215,
+        "total_reward": 32.70500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39137616415842225
+      },
+      {
+        "run": 182,
+        "seed": 1153438752,
+        "success": true,
+        "steps": 184,
+        "total_reward": 36.780000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41458524027459953
+      },
+      {
+        "run": 183,
+        "seed": 1153438753,
+        "success": true,
+        "steps": 171,
+        "total_reward": 40.09500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5177537797517282
+      },
+      {
+        "run": 184,
+        "seed": 1153438754,
+        "success": true,
+        "steps": 152,
+        "total_reward": 27.37000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45426761347813976
+      },
+      {
+        "run": 185,
+        "seed": 1153438755,
+        "success": true,
+        "steps": 171,
+        "total_reward": 35.905000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5267142857142857
+      },
+      {
+        "run": 186,
+        "seed": 1153438756,
+        "success": true,
+        "steps": 243,
+        "total_reward": 37.31500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49603717850776674
+      },
+      {
+        "run": 187,
+        "seed": 1153438757,
+        "success": true,
+        "steps": 185,
+        "total_reward": 38.97500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4685141329258976
+      },
+      {
+        "run": 188,
+        "seed": 1153438758,
+        "success": true,
+        "steps": 161,
+        "total_reward": 34.525000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5333018207282914
+      },
+      {
+        "run": 189,
+        "seed": 1153438759,
+        "success": true,
+        "steps": 167,
+        "total_reward": 38.90500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6370887445887445
+      },
+      {
+        "run": 190,
+        "seed": 1153438760,
+        "success": true,
+        "steps": 156,
+        "total_reward": 36.950000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5397772322164905
+      },
+      {
+        "run": 191,
+        "seed": 1153438761,
+        "success": true,
+        "steps": 214,
+        "total_reward": 48.43000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.511275042625746
+      },
+      {
+        "run": 192,
+        "seed": 1153438762,
+        "success": true,
+        "steps": 176,
+        "total_reward": 35.42000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40851125004577693
+      },
+      {
+        "run": 193,
+        "seed": 1153438763,
+        "success": true,
+        "steps": 168,
+        "total_reward": 37.9900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49000000000000005
+      },
+      {
+        "run": 194,
+        "seed": 1153438764,
+        "success": true,
+        "steps": 233,
+        "total_reward": 42.67500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39380234900977934
+      },
+      {
+        "run": 195,
+        "seed": 1153438765,
+        "success": true,
+        "steps": 186,
+        "total_reward": 39.57000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5184336107362423
+      },
+      {
+        "run": 196,
+        "seed": 1153438766,
+        "success": true,
+        "steps": 176,
+        "total_reward": 43.4700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5325656509352161
+      },
+      {
+        "run": 197,
+        "seed": 1153438767,
+        "success": true,
+        "steps": 161,
+        "total_reward": 31.54500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44928484558919346
+      },
+      {
+        "run": 198,
+        "seed": 1153438768,
+        "success": true,
+        "steps": 166,
+        "total_reward": 36.67000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4786970099044402
+      },
+      {
+        "run": 199,
+        "seed": 1153438769,
+        "success": true,
+        "steps": 178,
+        "total_reward": 31.740000000000112,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45097926463780125
+      },
+      {
+        "run": 200,
+        "seed": 1153438770,
+        "success": true,
+        "steps": 158,
+        "total_reward": 32.660000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5131376518218623
+      }
+    ],
+    "avg_chemotaxis_index": 0.39516782206200496,
+    "avg_time_in_attractant": 0.6975839110310025,
+    "avg_approach_frequency": 0.44338249358386767,
+    "avg_path_efficiency": 0.04258556476362948,
+    "post_convergence_chemotaxis_index": 0.4041541963788747,
+    "post_convergence_time_in_attractant": 0.7020770981894373,
+    "post_convergence_approach_frequency": 0.44546563302239806,
+    "post_convergence_path_efficiency": 0.04327273302481633,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_092242.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_092242.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_092242",
+  "timestamp": "2025-12-29T09:32:30.001300+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_092242",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.955,
+    "avg_steps": 221.345,
+    "avg_reward": 34.574825000000104,
+    "avg_foods_collected": 9.665,
+    "avg_distance_efficiency": 0.39947818513331457,
+    "completed_all_food": 191,
+    "starved": 9,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 10,
+    "runs_to_convergence": 9,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 218.04712041884818,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.4112888950722226,
+    "composite_benchmark_score": 0.8143866685216669,
+    "learning_speed": 0.915,
+    "learning_speed_episodes": 17,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3873361179,
+        "success": false,
+        "steps": 280,
+        "total_reward": 3.0399999999999334,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.10591133004926108
+      },
+      {
+        "run": 2,
+        "seed": 3873361180,
+        "success": false,
+        "steps": 297,
+        "total_reward": 5.914999999999912,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.31563328033916266
+      },
+      {
+        "run": 3,
+        "seed": 3873361181,
+        "success": false,
+        "steps": 280,
+        "total_reward": -2.200000000000026,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.109152288072018
+      },
+      {
+        "run": 4,
+        "seed": 3873361182,
+        "success": false,
+        "steps": 280,
+        "total_reward": -0.41000000000001613,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.06458333333333333
+      },
+      {
+        "run": 5,
+        "seed": 3873361183,
+        "success": false,
+        "steps": 240,
+        "total_reward": -1.0800000000000214,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.06358381502890173
+      },
+      {
+        "run": 6,
+        "seed": 3873361184,
+        "success": false,
+        "steps": 301,
+        "total_reward": 3.154999999999937,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.16689311594202896
+      },
+      {
+        "run": 7,
+        "seed": 3873361185,
+        "success": false,
+        "steps": 296,
+        "total_reward": 4.359999999999925,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.1716269841269841
+      },
+      {
+        "run": 8,
+        "seed": 3873361186,
+        "success": false,
+        "steps": 280,
+        "total_reward": 0.8799999999999812,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.08632958801498128
+      },
+      {
+        "run": 9,
+        "seed": 3873361187,
+        "success": false,
+        "steps": 368,
+        "total_reward": 16.930000000000152,
+        "termination_reason": "starved",
+        "foods_collected": 5,
+        "distance_efficiency": 0.2557443329617243
+      },
+      {
+        "run": 10,
+        "seed": 3873361188,
+        "success": true,
+        "steps": 418,
+        "total_reward": 36.83000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21862586535160222
+      },
+      {
+        "run": 11,
+        "seed": 3873361189,
+        "success": true,
+        "steps": 433,
+        "total_reward": 37.26500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23602604937789712
+      },
+      {
+        "run": 12,
+        "seed": 3873361190,
+        "success": true,
+        "steps": 350,
+        "total_reward": 39.72000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26962098777210686
+      },
+      {
+        "run": 13,
+        "seed": 3873361191,
+        "success": true,
+        "steps": 449,
+        "total_reward": 34.27500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20194300754521038
+      },
+      {
+        "run": 14,
+        "seed": 3873361192,
+        "success": true,
+        "steps": 311,
+        "total_reward": 37.82500000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31632191896897777
+      },
+      {
+        "run": 15,
+        "seed": 3873361193,
+        "success": true,
+        "steps": 313,
+        "total_reward": 33.515000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3131804547817346
+      },
+      {
+        "run": 16,
+        "seed": 3873361194,
+        "success": true,
+        "steps": 289,
+        "total_reward": 44.245000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35519507732572186
+      },
+      {
+        "run": 17,
+        "seed": 3873361195,
+        "success": true,
+        "steps": 315,
+        "total_reward": 39.40500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34642986144006505
+      },
+      {
+        "run": 18,
+        "seed": 3873361196,
+        "success": true,
+        "steps": 310,
+        "total_reward": 31.060000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23986365198787557
+      },
+      {
+        "run": 19,
+        "seed": 3873361197,
+        "success": true,
+        "steps": 279,
+        "total_reward": 39.19500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35784616815550185
+      },
+      {
+        "run": 20,
+        "seed": 3873361198,
+        "success": true,
+        "steps": 267,
+        "total_reward": 34.515000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3688322983152205
+      },
+      {
+        "run": 21,
+        "seed": 3873361199,
+        "success": true,
+        "steps": 201,
+        "total_reward": 33.96500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4553047279517868
+      },
+      {
+        "run": 22,
+        "seed": 3873361200,
+        "success": true,
+        "steps": 239,
+        "total_reward": 35.01500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3238196069016003
+      },
+      {
+        "run": 23,
+        "seed": 3873361201,
+        "success": true,
+        "steps": 169,
+        "total_reward": 31.25500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4137505631623279
+      },
+      {
+        "run": 24,
+        "seed": 3873361202,
+        "success": true,
+        "steps": 170,
+        "total_reward": 34.38000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46416235334713596
+      },
+      {
+        "run": 25,
+        "seed": 3873361203,
+        "success": true,
+        "steps": 270,
+        "total_reward": 40.03000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37336345294149287
+      },
+      {
+        "run": 26,
+        "seed": 3873361204,
+        "success": true,
+        "steps": 231,
+        "total_reward": 40.405000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41799137137372433
+      },
+      {
+        "run": 27,
+        "seed": 3873361205,
+        "success": true,
+        "steps": 251,
+        "total_reward": 34.64500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3539189319452477
+      },
+      {
+        "run": 28,
+        "seed": 3873361206,
+        "success": true,
+        "steps": 258,
+        "total_reward": 39.31000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3899447207230226
+      },
+      {
+        "run": 29,
+        "seed": 3873361207,
+        "success": true,
+        "steps": 237,
+        "total_reward": 42.96500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4060581649722154
+      },
+      {
+        "run": 30,
+        "seed": 3873361208,
+        "success": true,
+        "steps": 251,
+        "total_reward": 36.63500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38940104081964544
+      },
+      {
+        "run": 31,
+        "seed": 3873361209,
+        "success": true,
+        "steps": 212,
+        "total_reward": 30.18000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4039680723548001
+      },
+      {
+        "run": 32,
+        "seed": 3873361210,
+        "success": true,
+        "steps": 206,
+        "total_reward": 28.86000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3351337791895067
+      },
+      {
+        "run": 33,
+        "seed": 3873361211,
+        "success": true,
+        "steps": 235,
+        "total_reward": 40.575000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3987241429874665
+      },
+      {
+        "run": 34,
+        "seed": 3873361212,
+        "success": true,
+        "steps": 217,
+        "total_reward": 34.575000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44546062125009495
+      },
+      {
+        "run": 35,
+        "seed": 3873361213,
+        "success": true,
+        "steps": 211,
+        "total_reward": 27.295000000000122,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31037570909370615
+      },
+      {
+        "run": 36,
+        "seed": 3873361214,
+        "success": true,
+        "steps": 231,
+        "total_reward": 39.53500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47719493568148935
+      },
+      {
+        "run": 37,
+        "seed": 3873361215,
+        "success": true,
+        "steps": 159,
+        "total_reward": 36.66500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5595380545380546
+      },
+      {
+        "run": 38,
+        "seed": 3873361216,
+        "success": true,
+        "steps": 248,
+        "total_reward": 34.320000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34485208296666536
+      },
+      {
+        "run": 39,
+        "seed": 3873361217,
+        "success": true,
+        "steps": 233,
+        "total_reward": 33.74500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4065127291009644
+      },
+      {
+        "run": 40,
+        "seed": 3873361218,
+        "success": true,
+        "steps": 222,
+        "total_reward": 29.94000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3008249348690525
+      },
+      {
+        "run": 41,
+        "seed": 3873361219,
+        "success": true,
+        "steps": 218,
+        "total_reward": 32.74000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34911943168808157
+      },
+      {
+        "run": 42,
+        "seed": 3873361220,
+        "success": true,
+        "steps": 279,
+        "total_reward": 35.32500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2980713675669905
+      },
+      {
+        "run": 43,
+        "seed": 3873361221,
+        "success": true,
+        "steps": 152,
+        "total_reward": 34.82000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47843887593887596
+      },
+      {
+        "run": 44,
+        "seed": 3873361222,
+        "success": true,
+        "steps": 192,
+        "total_reward": 36.85000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4163780105343573
+      },
+      {
+        "run": 45,
+        "seed": 3873361223,
+        "success": true,
+        "steps": 193,
+        "total_reward": 39.90500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4599081035923141
+      },
+      {
+        "run": 46,
+        "seed": 3873361224,
+        "success": true,
+        "steps": 217,
+        "total_reward": 40.82500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4299074074074074
+      },
+      {
+        "run": 47,
+        "seed": 3873361225,
+        "success": true,
+        "steps": 245,
+        "total_reward": 36.06500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33825834075130157
+      },
+      {
+        "run": 48,
+        "seed": 3873361226,
+        "success": true,
+        "steps": 192,
+        "total_reward": 31.87000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3984743187846636
+      },
+      {
+        "run": 49,
+        "seed": 3873361227,
+        "success": true,
+        "steps": 176,
+        "total_reward": 34.41000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5016713020008214
+      },
+      {
+        "run": 50,
+        "seed": 3873361228,
+        "success": true,
+        "steps": 217,
+        "total_reward": 38.2750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4287156774174378
+      },
+      {
+        "run": 51,
+        "seed": 3873361229,
+        "success": true,
+        "steps": 218,
+        "total_reward": 37.17000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3725681845036684
+      },
+      {
+        "run": 52,
+        "seed": 3873361230,
+        "success": true,
+        "steps": 245,
+        "total_reward": 34.9250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34161669334524275
+      },
+      {
+        "run": 53,
+        "seed": 3873361231,
+        "success": true,
+        "steps": 217,
+        "total_reward": 32.06500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38283771783771786
+      },
+      {
+        "run": 54,
+        "seed": 3873361232,
+        "success": true,
+        "steps": 240,
+        "total_reward": 35.64000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3515804013485261
+      },
+      {
+        "run": 55,
+        "seed": 3873361233,
+        "success": true,
+        "steps": 270,
+        "total_reward": 27.080000000000183,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3275194522253346
+      },
+      {
+        "run": 56,
+        "seed": 3873361234,
+        "success": true,
+        "steps": 229,
+        "total_reward": 44.5050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4109082094376212
+      },
+      {
+        "run": 57,
+        "seed": 3873361235,
+        "success": true,
+        "steps": 238,
+        "total_reward": 41.39000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4454130934990693
+      },
+      {
+        "run": 58,
+        "seed": 3873361236,
+        "success": true,
+        "steps": 198,
+        "total_reward": 37.910000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4322114983144395
+      },
+      {
+        "run": 59,
+        "seed": 3873361237,
+        "success": true,
+        "steps": 277,
+        "total_reward": 40.225000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3536692801762281
+      },
+      {
+        "run": 60,
+        "seed": 3873361238,
+        "success": true,
+        "steps": 240,
+        "total_reward": 36.30000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43863597100620694
+      },
+      {
+        "run": 61,
+        "seed": 3873361239,
+        "success": true,
+        "steps": 225,
+        "total_reward": 36.92500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4606143822371003
+      },
+      {
+        "run": 62,
+        "seed": 3873361240,
+        "success": true,
+        "steps": 172,
+        "total_reward": 26.410000000000057,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38686205864998435
+      },
+      {
+        "run": 63,
+        "seed": 3873361241,
+        "success": true,
+        "steps": 188,
+        "total_reward": 33.670000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4240948525159052
+      },
+      {
+        "run": 64,
+        "seed": 3873361242,
+        "success": true,
+        "steps": 162,
+        "total_reward": 36.060000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5176636903426511
+      },
+      {
+        "run": 65,
+        "seed": 3873361243,
+        "success": true,
+        "steps": 230,
+        "total_reward": 34.59000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.374416708042959
+      },
+      {
+        "run": 66,
+        "seed": 3873361244,
+        "success": true,
+        "steps": 226,
+        "total_reward": 43.71000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41539156268568034
+      },
+      {
+        "run": 67,
+        "seed": 3873361245,
+        "success": true,
+        "steps": 243,
+        "total_reward": 36.83500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3093533286636735
+      },
+      {
+        "run": 68,
+        "seed": 3873361246,
+        "success": true,
+        "steps": 250,
+        "total_reward": 36.0600000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4017613612441198
+      },
+      {
+        "run": 69,
+        "seed": 3873361247,
+        "success": true,
+        "steps": 259,
+        "total_reward": 41.045000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41684583602148917
+      },
+      {
+        "run": 70,
+        "seed": 3873361248,
+        "success": true,
+        "steps": 217,
+        "total_reward": 39.12500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4460435907105598
+      },
+      {
+        "run": 71,
+        "seed": 3873361249,
+        "success": true,
+        "steps": 249,
+        "total_reward": 38.62500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34368779830238944
+      },
+      {
+        "run": 72,
+        "seed": 3873361250,
+        "success": true,
+        "steps": 205,
+        "total_reward": 30.185000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35775028614828364
+      },
+      {
+        "run": 73,
+        "seed": 3873361251,
+        "success": true,
+        "steps": 216,
+        "total_reward": 31.670000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.441998844925934
+      },
+      {
+        "run": 74,
+        "seed": 3873361252,
+        "success": true,
+        "steps": 247,
+        "total_reward": 36.25500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39029904778003155
+      },
+      {
+        "run": 75,
+        "seed": 3873361253,
+        "success": true,
+        "steps": 197,
+        "total_reward": 41.705000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45714524300559456
+      },
+      {
+        "run": 76,
+        "seed": 3873361254,
+        "success": true,
+        "steps": 242,
+        "total_reward": 38.27000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3687517318755459
+      },
+      {
+        "run": 77,
+        "seed": 3873361255,
+        "success": true,
+        "steps": 242,
+        "total_reward": 42.41000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3734111947815316
+      },
+      {
+        "run": 78,
+        "seed": 3873361256,
+        "success": true,
+        "steps": 317,
+        "total_reward": 47.02500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3357551262113706
+      },
+      {
+        "run": 79,
+        "seed": 3873361257,
+        "success": true,
+        "steps": 212,
+        "total_reward": 34.310000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.375308229781914
+      },
+      {
+        "run": 80,
+        "seed": 3873361258,
+        "success": true,
+        "steps": 191,
+        "total_reward": 32.885000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4078478473710672
+      },
+      {
+        "run": 81,
+        "seed": 3873361259,
+        "success": true,
+        "steps": 207,
+        "total_reward": 32.11500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3758649151360149
+      },
+      {
+        "run": 82,
+        "seed": 3873361260,
+        "success": true,
+        "steps": 233,
+        "total_reward": 35.635000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44264782846652906
+      },
+      {
+        "run": 83,
+        "seed": 3873361261,
+        "success": true,
+        "steps": 210,
+        "total_reward": 37.980000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43737602144083576
+      },
+      {
+        "run": 84,
+        "seed": 3873361262,
+        "success": true,
+        "steps": 177,
+        "total_reward": 34.00500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43199164566558074
+      },
+      {
+        "run": 85,
+        "seed": 3873361263,
+        "success": true,
+        "steps": 192,
+        "total_reward": 35.30000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37526561158140104
+      },
+      {
+        "run": 86,
+        "seed": 3873361264,
+        "success": true,
+        "steps": 182,
+        "total_reward": 33.75000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46599180389502964
+      },
+      {
+        "run": 87,
+        "seed": 3873361265,
+        "success": true,
+        "steps": 227,
+        "total_reward": 31.24500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3742502303188802
+      },
+      {
+        "run": 88,
+        "seed": 3873361266,
+        "success": true,
+        "steps": 159,
+        "total_reward": 29.375000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4355508749562458
+      },
+      {
+        "run": 89,
+        "seed": 3873361267,
+        "success": true,
+        "steps": 255,
+        "total_reward": 46.285000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39043666892713136
+      },
+      {
+        "run": 90,
+        "seed": 3873361268,
+        "success": true,
+        "steps": 171,
+        "total_reward": 32.39500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43034128603594546
+      },
+      {
+        "run": 91,
+        "seed": 3873361269,
+        "success": true,
+        "steps": 145,
+        "total_reward": 29.635000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.538488515988516
+      },
+      {
+        "run": 92,
+        "seed": 3873361270,
+        "success": true,
+        "steps": 249,
+        "total_reward": 42.075000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3916962717234457
+      },
+      {
+        "run": 93,
+        "seed": 3873361271,
+        "success": true,
+        "steps": 189,
+        "total_reward": 38.575000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43656676611646184
+      },
+      {
+        "run": 94,
+        "seed": 3873361272,
+        "success": true,
+        "steps": 219,
+        "total_reward": 34.51500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3659464490109651
+      },
+      {
+        "run": 95,
+        "seed": 3873361273,
+        "success": true,
+        "steps": 199,
+        "total_reward": 35.655000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47427236417307944
+      },
+      {
+        "run": 96,
+        "seed": 3873361274,
+        "success": true,
+        "steps": 166,
+        "total_reward": 33.59000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5177024201288907
+      },
+      {
+        "run": 97,
+        "seed": 3873361275,
+        "success": true,
+        "steps": 239,
+        "total_reward": 38.91500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3579162892066118
+      },
+      {
+        "run": 98,
+        "seed": 3873361276,
+        "success": true,
+        "steps": 215,
+        "total_reward": 42.635000000000204,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5255260812458955
+      },
+      {
+        "run": 99,
+        "seed": 3873361277,
+        "success": true,
+        "steps": 177,
+        "total_reward": 29.545000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4232567755399378
+      },
+      {
+        "run": 100,
+        "seed": 3873361278,
+        "success": true,
+        "steps": 196,
+        "total_reward": 28.68000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4142987404752111
+      },
+      {
+        "run": 101,
+        "seed": 3873361279,
+        "success": true,
+        "steps": 216,
+        "total_reward": 32.86000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37696709088013436
+      },
+      {
+        "run": 102,
+        "seed": 3873361280,
+        "success": true,
+        "steps": 173,
+        "total_reward": 33.785000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5075803103465282
+      },
+      {
+        "run": 103,
+        "seed": 3873361281,
+        "success": true,
+        "steps": 185,
+        "total_reward": 36.535000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4400557513615294
+      },
+      {
+        "run": 104,
+        "seed": 3873361282,
+        "success": true,
+        "steps": 187,
+        "total_reward": 35.37500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46343822843822846
+      },
+      {
+        "run": 105,
+        "seed": 3873361283,
+        "success": true,
+        "steps": 194,
+        "total_reward": 29.120000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3709405299865826
+      },
+      {
+        "run": 106,
+        "seed": 3873361284,
+        "success": true,
+        "steps": 198,
+        "total_reward": 37.780000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43605274307959724
+      },
+      {
+        "run": 107,
+        "seed": 3873361285,
+        "success": true,
+        "steps": 190,
+        "total_reward": 29.98000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3601045713545713
+      },
+      {
+        "run": 108,
+        "seed": 3873361286,
+        "success": true,
+        "steps": 215,
+        "total_reward": 39.15500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45210400084947955
+      },
+      {
+        "run": 109,
+        "seed": 3873361287,
+        "success": true,
+        "steps": 207,
+        "total_reward": 32.49500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3748509135307058
+      },
+      {
+        "run": 110,
+        "seed": 3873361288,
+        "success": true,
+        "steps": 193,
+        "total_reward": 34.335000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40146362304930083
+      },
+      {
+        "run": 111,
+        "seed": 3873361289,
+        "success": true,
+        "steps": 178,
+        "total_reward": 39.2200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4761678057367712
+      },
+      {
+        "run": 112,
+        "seed": 3873361290,
+        "success": true,
+        "steps": 255,
+        "total_reward": 37.45500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3421021484017618
+      },
+      {
+        "run": 113,
+        "seed": 3873361291,
+        "success": true,
+        "steps": 156,
+        "total_reward": 39.80000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5623721234905446
+      },
+      {
+        "run": 114,
+        "seed": 3873361292,
+        "success": true,
+        "steps": 235,
+        "total_reward": 34.01500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36525822911395456
+      },
+      {
+        "run": 115,
+        "seed": 3873361293,
+        "success": true,
+        "steps": 176,
+        "total_reward": 37.870000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5519290931247454
+      },
+      {
+        "run": 116,
+        "seed": 3873361294,
+        "success": true,
+        "steps": 224,
+        "total_reward": 36.80000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4412680717028543
+      },
+      {
+        "run": 117,
+        "seed": 3873361295,
+        "success": true,
+        "steps": 272,
+        "total_reward": 40.650000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3325375677961885
+      },
+      {
+        "run": 118,
+        "seed": 3873361296,
+        "success": true,
+        "steps": 235,
+        "total_reward": 34.10500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3328404946334681
+      },
+      {
+        "run": 119,
+        "seed": 3873361297,
+        "success": true,
+        "steps": 193,
+        "total_reward": 35.79500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43760848180154516
+      },
+      {
+        "run": 120,
+        "seed": 3873361298,
+        "success": true,
+        "steps": 209,
+        "total_reward": 33.52500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43554604451395146
+      },
+      {
+        "run": 121,
+        "seed": 3873361299,
+        "success": true,
+        "steps": 190,
+        "total_reward": 36.35000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47620610738765273
+      },
+      {
+        "run": 122,
+        "seed": 3873361300,
+        "success": true,
+        "steps": 168,
+        "total_reward": 36.73000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5182508276037688
+      },
+      {
+        "run": 123,
+        "seed": 3873361301,
+        "success": true,
+        "steps": 247,
+        "total_reward": 35.16500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3888361283501948
+      },
+      {
+        "run": 124,
+        "seed": 3873361302,
+        "success": true,
+        "steps": 185,
+        "total_reward": 35.99500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41563554802685243
+      },
+      {
+        "run": 125,
+        "seed": 3873361303,
+        "success": true,
+        "steps": 240,
+        "total_reward": 37.17000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.360645993014414
+      },
+      {
+        "run": 126,
+        "seed": 3873361304,
+        "success": true,
+        "steps": 191,
+        "total_reward": 30.105000000000153,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3827970494417863
+      },
+      {
+        "run": 127,
+        "seed": 3873361305,
+        "success": true,
+        "steps": 195,
+        "total_reward": 38.52500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45479277015426584
+      },
+      {
+        "run": 128,
+        "seed": 3873361306,
+        "success": true,
+        "steps": 168,
+        "total_reward": 28.490000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39229080098645314
+      },
+      {
+        "run": 129,
+        "seed": 3873361307,
+        "success": true,
+        "steps": 177,
+        "total_reward": 33.8150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48901456539900473
+      },
+      {
+        "run": 130,
+        "seed": 3873361308,
+        "success": true,
+        "steps": 191,
+        "total_reward": 37.81500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41391669115198526
+      },
+      {
+        "run": 131,
+        "seed": 3873361309,
+        "success": true,
+        "steps": 187,
+        "total_reward": 35.8250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47606980056980064
+      },
+      {
+        "run": 132,
+        "seed": 3873361310,
+        "success": true,
+        "steps": 226,
+        "total_reward": 41.87000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38136604136604135
+      },
+      {
+        "run": 133,
+        "seed": 3873361311,
+        "success": true,
+        "steps": 235,
+        "total_reward": 43.16500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41373235897229704
+      },
+      {
+        "run": 134,
+        "seed": 3873361312,
+        "success": true,
+        "steps": 205,
+        "total_reward": 32.54500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41487955182072833
+      },
+      {
+        "run": 135,
+        "seed": 3873361313,
+        "success": true,
+        "steps": 239,
+        "total_reward": 35.97500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3231800616325788
+      },
+      {
+        "run": 136,
+        "seed": 3873361314,
+        "success": true,
+        "steps": 213,
+        "total_reward": 31.94500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3780986924952442
+      },
+      {
+        "run": 137,
+        "seed": 3873361315,
+        "success": true,
+        "steps": 161,
+        "total_reward": 34.255000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48339888181993446
+      },
+      {
+        "run": 138,
+        "seed": 3873361316,
+        "success": true,
+        "steps": 258,
+        "total_reward": 35.490000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32833179272834445
+      },
+      {
+        "run": 139,
+        "seed": 3873361317,
+        "success": true,
+        "steps": 201,
+        "total_reward": 32.91500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3985010021584952
+      },
+      {
+        "run": 140,
+        "seed": 3873361318,
+        "success": true,
+        "steps": 158,
+        "total_reward": 34.03000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5098169395963514
+      },
+      {
+        "run": 141,
+        "seed": 3873361319,
+        "success": true,
+        "steps": 180,
+        "total_reward": 37.620000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45706110120816
+      },
+      {
+        "run": 142,
+        "seed": 3873361320,
+        "success": true,
+        "steps": 331,
+        "total_reward": 40.17500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3679169819997937
+      },
+      {
+        "run": 143,
+        "seed": 3873361321,
+        "success": true,
+        "steps": 220,
+        "total_reward": 32.180000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3881014874813321
+      },
+      {
+        "run": 144,
+        "seed": 3873361322,
+        "success": true,
+        "steps": 203,
+        "total_reward": 37.78500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41963089542036913
+      },
+      {
+        "run": 145,
+        "seed": 3873361323,
+        "success": true,
+        "steps": 211,
+        "total_reward": 39.97500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4109499687955066
+      },
+      {
+        "run": 146,
+        "seed": 3873361324,
+        "success": true,
+        "steps": 149,
+        "total_reward": 35.125000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4905952380952381
+      },
+      {
+        "run": 147,
+        "seed": 3873361325,
+        "success": true,
+        "steps": 190,
+        "total_reward": 33.25000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45212184963236857
+      },
+      {
+        "run": 148,
+        "seed": 3873361326,
+        "success": true,
+        "steps": 229,
+        "total_reward": 41.195000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42729974638185964
+      },
+      {
+        "run": 149,
+        "seed": 3873361327,
+        "success": true,
+        "steps": 188,
+        "total_reward": 33.83000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.431011766011766
+      },
+      {
+        "run": 150,
+        "seed": 3873361328,
+        "success": true,
+        "steps": 229,
+        "total_reward": 36.315000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3596502778830365
+      },
+      {
+        "run": 151,
+        "seed": 3873361329,
+        "success": true,
+        "steps": 169,
+        "total_reward": 32.645000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4607012987012987
+      },
+      {
+        "run": 152,
+        "seed": 3873361330,
+        "success": true,
+        "steps": 186,
+        "total_reward": 38.36000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4639645481852613
+      },
+      {
+        "run": 153,
+        "seed": 3873361331,
+        "success": true,
+        "steps": 190,
+        "total_reward": 31.73000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3986743208482339
+      },
+      {
+        "run": 154,
+        "seed": 3873361332,
+        "success": true,
+        "steps": 216,
+        "total_reward": 47.14000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5070075195290535
+      },
+      {
+        "run": 155,
+        "seed": 3873361333,
+        "success": true,
+        "steps": 221,
+        "total_reward": 41.225000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4427753316441897
+      },
+      {
+        "run": 156,
+        "seed": 3873361334,
+        "success": true,
+        "steps": 212,
+        "total_reward": 35.69000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4488821485532012
+      },
+      {
+        "run": 157,
+        "seed": 3873361335,
+        "success": true,
+        "steps": 237,
+        "total_reward": 39.88500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43750951350137834
+      },
+      {
+        "run": 158,
+        "seed": 3873361336,
+        "success": true,
+        "steps": 217,
+        "total_reward": 41.35500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43930817198674343
+      },
+      {
+        "run": 159,
+        "seed": 3873361337,
+        "success": true,
+        "steps": 230,
+        "total_reward": 31.57000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3646256372353933
+      },
+      {
+        "run": 160,
+        "seed": 3873361338,
+        "success": true,
+        "steps": 165,
+        "total_reward": 36.51500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5031671944139975
+      },
+      {
+        "run": 161,
+        "seed": 3873361339,
+        "success": true,
+        "steps": 250,
+        "total_reward": 38.960000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3885158794316322
+      },
+      {
+        "run": 162,
+        "seed": 3873361340,
+        "success": true,
+        "steps": 206,
+        "total_reward": 41.55000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4721424082453495
+      },
+      {
+        "run": 163,
+        "seed": 3873361341,
+        "success": true,
+        "steps": 188,
+        "total_reward": 31.220000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3647113997113997
+      },
+      {
+        "run": 164,
+        "seed": 3873361342,
+        "success": true,
+        "steps": 189,
+        "total_reward": 35.06500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4440680446946431
+      },
+      {
+        "run": 165,
+        "seed": 3873361343,
+        "success": true,
+        "steps": 183,
+        "total_reward": 35.9750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5560131389078757
+      },
+      {
+        "run": 166,
+        "seed": 3873361344,
+        "success": true,
+        "steps": 154,
+        "total_reward": 34.140000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5578374259839778
+      },
+      {
+        "run": 167,
+        "seed": 3873361345,
+        "success": true,
+        "steps": 226,
+        "total_reward": 29.08000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3232345431772039
+      },
+      {
+        "run": 168,
+        "seed": 3873361346,
+        "success": true,
+        "steps": 211,
+        "total_reward": 42.905000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49548163283077074
+      },
+      {
+        "run": 169,
+        "seed": 3873361347,
+        "success": true,
+        "steps": 222,
+        "total_reward": 37.25000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.435510153010153
+      },
+      {
+        "run": 170,
+        "seed": 3873361348,
+        "success": true,
+        "steps": 190,
+        "total_reward": 26.32000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32588748208313423
+      },
+      {
+        "run": 171,
+        "seed": 3873361349,
+        "success": true,
+        "steps": 245,
+        "total_reward": 34.18500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3298329942488086
+      },
+      {
+        "run": 172,
+        "seed": 3873361350,
+        "success": true,
+        "steps": 229,
+        "total_reward": 45.71500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40178363066219136
+      },
+      {
+        "run": 173,
+        "seed": 3873361351,
+        "success": true,
+        "steps": 202,
+        "total_reward": 33.390000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44631161717904444
+      },
+      {
+        "run": 174,
+        "seed": 3873361352,
+        "success": true,
+        "steps": 163,
+        "total_reward": 32.59500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5305903674869192
+      },
+      {
+        "run": 175,
+        "seed": 3873361353,
+        "success": true,
+        "steps": 196,
+        "total_reward": 38.060000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40892410221357595
+      },
+      {
+        "run": 176,
+        "seed": 3873361354,
+        "success": true,
+        "steps": 181,
+        "total_reward": 38.26500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44888491714235423
+      },
+      {
+        "run": 177,
+        "seed": 3873361355,
+        "success": true,
+        "steps": 172,
+        "total_reward": 33.78000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4360093723397679
+      },
+      {
+        "run": 178,
+        "seed": 3873361356,
+        "success": true,
+        "steps": 196,
+        "total_reward": 29.460000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40522013040570837
+      },
+      {
+        "run": 179,
+        "seed": 3873361357,
+        "success": true,
+        "steps": 230,
+        "total_reward": 39.55000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43258205760527735
+      },
+      {
+        "run": 180,
+        "seed": 3873361358,
+        "success": true,
+        "steps": 234,
+        "total_reward": 34.880000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3461913934684333
+      },
+      {
+        "run": 181,
+        "seed": 3873361359,
+        "success": true,
+        "steps": 249,
+        "total_reward": 30.24500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49219484219484216
+      },
+      {
+        "run": 182,
+        "seed": 3873361360,
+        "success": true,
+        "steps": 265,
+        "total_reward": 44.50500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39365731126231013
+      },
+      {
+        "run": 183,
+        "seed": 3873361361,
+        "success": true,
+        "steps": 190,
+        "total_reward": 36.35000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5120605065432652
+      },
+      {
+        "run": 184,
+        "seed": 3873361362,
+        "success": true,
+        "steps": 177,
+        "total_reward": 33.92500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4757733877824065
+      },
+      {
+        "run": 185,
+        "seed": 3873361363,
+        "success": true,
+        "steps": 244,
+        "total_reward": 32.650000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3155997474747475
+      },
+      {
+        "run": 186,
+        "seed": 3873361364,
+        "success": true,
+        "steps": 156,
+        "total_reward": 28.180000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4379156485780805
+      },
+      {
+        "run": 187,
+        "seed": 3873361365,
+        "success": true,
+        "steps": 184,
+        "total_reward": 34.90000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47837824943088103
+      },
+      {
+        "run": 188,
+        "seed": 3873361366,
+        "success": true,
+        "steps": 220,
+        "total_reward": 36.25000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41112004205233904
+      },
+      {
+        "run": 189,
+        "seed": 3873361367,
+        "success": true,
+        "steps": 242,
+        "total_reward": 46.180000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39919040729176475
+      },
+      {
+        "run": 190,
+        "seed": 3873361368,
+        "success": true,
+        "steps": 192,
+        "total_reward": 43.21000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4974749887793366
+      },
+      {
+        "run": 191,
+        "seed": 3873361369,
+        "success": true,
+        "steps": 178,
+        "total_reward": 32.960000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4400517428827603
+      },
+      {
+        "run": 192,
+        "seed": 3873361370,
+        "success": true,
+        "steps": 225,
+        "total_reward": 33.95500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37904218588429117
+      },
+      {
+        "run": 193,
+        "seed": 3873361371,
+        "success": true,
+        "steps": 195,
+        "total_reward": 40.24500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48568784776188423
+      },
+      {
+        "run": 194,
+        "seed": 3873361372,
+        "success": true,
+        "steps": 183,
+        "total_reward": 36.53500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4334944946357989
+      },
+      {
+        "run": 195,
+        "seed": 3873361373,
+        "success": true,
+        "steps": 228,
+        "total_reward": 32.04000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3633299664993029
+      },
+      {
+        "run": 196,
+        "seed": 3873361374,
+        "success": true,
+        "steps": 225,
+        "total_reward": 39.415000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4183702905854608
+      },
+      {
+        "run": 197,
+        "seed": 3873361375,
+        "success": true,
+        "steps": 157,
+        "total_reward": 39.05500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5186229832968963
+      },
+      {
+        "run": 198,
+        "seed": 3873361376,
+        "success": true,
+        "steps": 180,
+        "total_reward": 39.12000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.492923436929859
+      },
+      {
+        "run": 199,
+        "seed": 3873361377,
+        "success": true,
+        "steps": 238,
+        "total_reward": 37.34000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35957470633941224
+      },
+      {
+        "run": 200,
+        "seed": 3873361378,
+        "success": true,
+        "steps": 218,
+        "total_reward": 32.46000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40960010048523027
+      }
+    ],
+    "avg_chemotaxis_index": 0.37085955891575473,
+    "avg_time_in_attractant": 0.6854297794578774,
+    "avg_approach_frequency": 0.402950708087716,
+    "avg_path_efficiency": 0.05598258788168095,
+    "post_convergence_chemotaxis_index": 0.38509456408764875,
+    "post_convergence_time_in_attractant": 0.6925472820438243,
+    "post_convergence_approach_frequency": 0.40532018942807163,
+    "post_convergence_path_efficiency": 0.05789987860332711,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_092245.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_092245.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_092245",
+  "timestamp": "2025-12-29T09:32:42.187676+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_092245",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.95,
+    "avg_steps": 223.285,
+    "avg_reward": 34.16292500000011,
+    "avg_foods_collected": 9.66,
+    "avg_distance_efficiency": 0.39222292188377156,
+    "completed_all_food": 190,
+    "starved": 9,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 11,
+    "runs_to_convergence": 10,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 218.2157894736842,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.40665548780285976,
+    "composite_benchmark_score": 0.811996646340858,
+    "learning_speed": 0.91,
+    "learning_speed_episodes": 18,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3044572106,
+        "success": false,
+        "steps": 240,
+        "total_reward": -7.079999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.06153846153846154
+      },
+      {
+        "run": 2,
+        "seed": 3044572107,
+        "success": false,
+        "steps": 240,
+        "total_reward": -5.79,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.08974358974358974
+      },
+      {
+        "run": 3,
+        "seed": 3044572108,
+        "success": false,
+        "steps": 240,
+        "total_reward": -6.979999999999989,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.0847457627118644
+      },
+      {
+        "run": 4,
+        "seed": 3044572109,
+        "success": false,
+        "steps": 240,
+        "total_reward": -4.069999999999994,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.05517241379310345
+      },
+      {
+        "run": 5,
+        "seed": 3044572110,
+        "success": false,
+        "steps": 320,
+        "total_reward": 3.9099999999999167,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.18568865681655752
+      },
+      {
+        "run": 6,
+        "seed": 3044572111,
+        "success": false,
+        "steps": 240,
+        "total_reward": -5.6499999999999915,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.10344827586206896
+      },
+      {
+        "run": 7,
+        "seed": 3044572112,
+        "success": false,
+        "steps": 338,
+        "total_reward": 7.369999999999973,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.14951899050474762
+      },
+      {
+        "run": 8,
+        "seed": 3044572113,
+        "success": false,
+        "steps": 360,
+        "total_reward": 10.100000000000055,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.11006042335046878
+      },
+      {
+        "run": 9,
+        "seed": 3044572114,
+        "success": false,
+        "steps": 478,
+        "total_reward": 15.250000000000195,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.134397196518077
+      },
+      {
+        "run": 10,
+        "seed": 3044572115,
+        "success": false,
+        "steps": 500,
+        "total_reward": 40.63000000000014,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.2057279233720083
+      },
+      {
+        "run": 11,
+        "seed": 3044572116,
+        "success": true,
+        "steps": 413,
+        "total_reward": 29.16500000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2213744023204391
+      },
+      {
+        "run": 12,
+        "seed": 3044572117,
+        "success": true,
+        "steps": 450,
+        "total_reward": 35.870000000000196,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.17173978114880797
+      },
+      {
+        "run": 13,
+        "seed": 3044572118,
+        "success": true,
+        "steps": 296,
+        "total_reward": 47.68000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32479208681938593
+      },
+      {
+        "run": 14,
+        "seed": 3044572119,
+        "success": true,
+        "steps": 338,
+        "total_reward": 34.840000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23069943739413223
+      },
+      {
+        "run": 15,
+        "seed": 3044572120,
+        "success": true,
+        "steps": 276,
+        "total_reward": 33.6300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29355438694799957
+      },
+      {
+        "run": 16,
+        "seed": 3044572121,
+        "success": true,
+        "steps": 232,
+        "total_reward": 29.350000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3475516029863856
+      },
+      {
+        "run": 17,
+        "seed": 3044572122,
+        "success": true,
+        "steps": 362,
+        "total_reward": 37.350000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23073516903745186
+      },
+      {
+        "run": 18,
+        "seed": 3044572123,
+        "success": true,
+        "steps": 349,
+        "total_reward": 41.705000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3129069031458737
+      },
+      {
+        "run": 19,
+        "seed": 3044572124,
+        "success": true,
+        "steps": 361,
+        "total_reward": 33.38500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21278441217092245
+      },
+      {
+        "run": 20,
+        "seed": 3044572125,
+        "success": true,
+        "steps": 283,
+        "total_reward": 37.575000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30882769243936664
+      },
+      {
+        "run": 21,
+        "seed": 3044572126,
+        "success": true,
+        "steps": 207,
+        "total_reward": 34.49500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3891964667312965
+      },
+      {
+        "run": 22,
+        "seed": 3044572127,
+        "success": true,
+        "steps": 236,
+        "total_reward": 38.64000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37850598719019773
+      },
+      {
+        "run": 23,
+        "seed": 3044572128,
+        "success": true,
+        "steps": 274,
+        "total_reward": 43.28000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3608858298564181
+      },
+      {
+        "run": 24,
+        "seed": 3044572129,
+        "success": true,
+        "steps": 254,
+        "total_reward": 32.19000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3113516352486941
+      },
+      {
+        "run": 25,
+        "seed": 3044572130,
+        "success": true,
+        "steps": 298,
+        "total_reward": 33.470000000000226,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34494025722917787
+      },
+      {
+        "run": 26,
+        "seed": 3044572131,
+        "success": true,
+        "steps": 251,
+        "total_reward": 34.70500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3895161166725508
+      },
+      {
+        "run": 27,
+        "seed": 3044572132,
+        "success": true,
+        "steps": 266,
+        "total_reward": 35.8300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2727114364393467
+      },
+      {
+        "run": 28,
+        "seed": 3044572133,
+        "success": true,
+        "steps": 198,
+        "total_reward": 32.320000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36739468864468866
+      },
+      {
+        "run": 29,
+        "seed": 3044572134,
+        "success": true,
+        "steps": 274,
+        "total_reward": 37.06000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3482523690791573
+      },
+      {
+        "run": 30,
+        "seed": 3044572135,
+        "success": true,
+        "steps": 201,
+        "total_reward": 31.1450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4527602707749766
+      },
+      {
+        "run": 31,
+        "seed": 3044572136,
+        "success": true,
+        "steps": 197,
+        "total_reward": 40.94500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45768459162321057
+      },
+      {
+        "run": 32,
+        "seed": 3044572137,
+        "success": true,
+        "steps": 216,
+        "total_reward": 33.630000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.390328154902623
+      },
+      {
+        "run": 33,
+        "seed": 3044572138,
+        "success": true,
+        "steps": 247,
+        "total_reward": 41.40500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37853503876643624
+      },
+      {
+        "run": 34,
+        "seed": 3044572139,
+        "success": true,
+        "steps": 304,
+        "total_reward": 46.71,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3465386664862248
+      },
+      {
+        "run": 35,
+        "seed": 3044572140,
+        "success": true,
+        "steps": 279,
+        "total_reward": 37.525000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.286994157777592
+      },
+      {
+        "run": 36,
+        "seed": 3044572141,
+        "success": true,
+        "steps": 196,
+        "total_reward": 37.81000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4301326365205676
+      },
+      {
+        "run": 37,
+        "seed": 3044572142,
+        "success": true,
+        "steps": 251,
+        "total_reward": 37.165000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34821563452967397
+      },
+      {
+        "run": 38,
+        "seed": 3044572143,
+        "success": true,
+        "steps": 192,
+        "total_reward": 32.6000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4440918954442193
+      },
+      {
+        "run": 39,
+        "seed": 3044572144,
+        "success": true,
+        "steps": 263,
+        "total_reward": 35.415000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37174821189468654
+      },
+      {
+        "run": 40,
+        "seed": 3044572145,
+        "success": true,
+        "steps": 281,
+        "total_reward": 40.195000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.346903548613419
+      },
+      {
+        "run": 41,
+        "seed": 3044572146,
+        "success": true,
+        "steps": 159,
+        "total_reward": 33.84500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5548229548229549
+      },
+      {
+        "run": 42,
+        "seed": 3044572147,
+        "success": true,
+        "steps": 182,
+        "total_reward": 34.36000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5043850593850594
+      },
+      {
+        "run": 43,
+        "seed": 3044572148,
+        "success": true,
+        "steps": 182,
+        "total_reward": 39.410000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45860528360528363
+      },
+      {
+        "run": 44,
+        "seed": 3044572149,
+        "success": true,
+        "steps": 259,
+        "total_reward": 34.62500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3121103092101968
+      },
+      {
+        "run": 45,
+        "seed": 3044572150,
+        "success": true,
+        "steps": 226,
+        "total_reward": 35.24000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32727284964328984
+      },
+      {
+        "run": 46,
+        "seed": 3044572151,
+        "success": true,
+        "steps": 162,
+        "total_reward": 34.77000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4807467532467532
+      },
+      {
+        "run": 47,
+        "seed": 3044572152,
+        "success": true,
+        "steps": 257,
+        "total_reward": 34.595000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3221618641215415
+      },
+      {
+        "run": 48,
+        "seed": 3044572153,
+        "success": true,
+        "steps": 211,
+        "total_reward": 29.555000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3116438063851857
+      },
+      {
+        "run": 49,
+        "seed": 3044572154,
+        "success": true,
+        "steps": 210,
+        "total_reward": 40.21000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4491060860453208
+      },
+      {
+        "run": 50,
+        "seed": 3044572155,
+        "success": true,
+        "steps": 219,
+        "total_reward": 33.46500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42770562770562776
+      },
+      {
+        "run": 51,
+        "seed": 3044572156,
+        "success": true,
+        "steps": 206,
+        "total_reward": 29.450000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39062193242868865
+      },
+      {
+        "run": 52,
+        "seed": 3044572157,
+        "success": true,
+        "steps": 196,
+        "total_reward": 35.19000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4530609163798018
+      },
+      {
+        "run": 53,
+        "seed": 3044572158,
+        "success": true,
+        "steps": 153,
+        "total_reward": 32.355000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5282688271480841
+      },
+      {
+        "run": 54,
+        "seed": 3044572159,
+        "success": true,
+        "steps": 204,
+        "total_reward": 33.51000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46055783686597634
+      },
+      {
+        "run": 55,
+        "seed": 3044572160,
+        "success": true,
+        "steps": 178,
+        "total_reward": 34.95000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43635955183921443
+      },
+      {
+        "run": 56,
+        "seed": 3044572161,
+        "success": true,
+        "steps": 237,
+        "total_reward": 35.6850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3674264868095032
+      },
+      {
+        "run": 57,
+        "seed": 3044572162,
+        "success": true,
+        "steps": 237,
+        "total_reward": 39.56500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4077005866277239
+      },
+      {
+        "run": 58,
+        "seed": 3044572163,
+        "success": true,
+        "steps": 168,
+        "total_reward": 30.230000000000118,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47381855640807047
+      },
+      {
+        "run": 59,
+        "seed": 3044572164,
+        "success": true,
+        "steps": 228,
+        "total_reward": 35.92000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3373427397566565
+      },
+      {
+        "run": 60,
+        "seed": 3044572165,
+        "success": true,
+        "steps": 224,
+        "total_reward": 34.71000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37795699823248546
+      },
+      {
+        "run": 61,
+        "seed": 3044572166,
+        "success": true,
+        "steps": 207,
+        "total_reward": 36.36500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39517129195668216
+      },
+      {
+        "run": 62,
+        "seed": 3044572167,
+        "success": true,
+        "steps": 244,
+        "total_reward": 35.200000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31449196415500763
+      },
+      {
+        "run": 63,
+        "seed": 3044572168,
+        "success": true,
+        "steps": 193,
+        "total_reward": 40.195000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46382548859522543
+      },
+      {
+        "run": 64,
+        "seed": 3044572169,
+        "success": true,
+        "steps": 241,
+        "total_reward": 41.915000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41838237472850776
+      },
+      {
+        "run": 65,
+        "seed": 3044572170,
+        "success": true,
+        "steps": 181,
+        "total_reward": 34.75500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46973788627713137
+      },
+      {
+        "run": 66,
+        "seed": 3044572171,
+        "success": true,
+        "steps": 252,
+        "total_reward": 39.12000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3720931693227708
+      },
+      {
+        "run": 67,
+        "seed": 3044572172,
+        "success": true,
+        "steps": 245,
+        "total_reward": 40.84500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38753721694364374
+      },
+      {
+        "run": 68,
+        "seed": 3044572173,
+        "success": true,
+        "steps": 213,
+        "total_reward": 33.7950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3607273253298296
+      },
+      {
+        "run": 69,
+        "seed": 3044572174,
+        "success": true,
+        "steps": 190,
+        "total_reward": 32.4100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48129994274731114
+      },
+      {
+        "run": 70,
+        "seed": 3044572175,
+        "success": true,
+        "steps": 244,
+        "total_reward": 42.64000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40947316214520113
+      },
+      {
+        "run": 71,
+        "seed": 3044572176,
+        "success": true,
+        "steps": 201,
+        "total_reward": 35.155000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38806163135110505
+      },
+      {
+        "run": 72,
+        "seed": 3044572177,
+        "success": true,
+        "steps": 217,
+        "total_reward": 25.24500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.322252058059199
+      },
+      {
+        "run": 73,
+        "seed": 3044572178,
+        "success": true,
+        "steps": 185,
+        "total_reward": 31.985000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39496841633865226
+      },
+      {
+        "run": 74,
+        "seed": 3044572179,
+        "success": true,
+        "steps": 232,
+        "total_reward": 49.770000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4166410015423173
+      },
+      {
+        "run": 75,
+        "seed": 3044572180,
+        "success": true,
+        "steps": 180,
+        "total_reward": 40.640000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48489037532515794
+      },
+      {
+        "run": 76,
+        "seed": 3044572181,
+        "success": true,
+        "steps": 195,
+        "total_reward": 32.34500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4606671776499363
+      },
+      {
+        "run": 77,
+        "seed": 3044572182,
+        "success": true,
+        "steps": 230,
+        "total_reward": 40.810000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49933136558269114
+      },
+      {
+        "run": 78,
+        "seed": 3044572183,
+        "success": true,
+        "steps": 188,
+        "total_reward": 28.80000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42477184065220275
+      },
+      {
+        "run": 79,
+        "seed": 3044572184,
+        "success": true,
+        "steps": 191,
+        "total_reward": 42.42500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5638627136159261
+      },
+      {
+        "run": 80,
+        "seed": 3044572185,
+        "success": true,
+        "steps": 232,
+        "total_reward": 37.98000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40946365914786964
+      },
+      {
+        "run": 81,
+        "seed": 3044572186,
+        "success": true,
+        "steps": 193,
+        "total_reward": 34.17500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3912293489495844
+      },
+      {
+        "run": 82,
+        "seed": 3044572187,
+        "success": true,
+        "steps": 204,
+        "total_reward": 37.100000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39395927601809955
+      },
+      {
+        "run": 83,
+        "seed": 3044572188,
+        "success": true,
+        "steps": 228,
+        "total_reward": 26.700000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37373994523994525
+      },
+      {
+        "run": 84,
+        "seed": 3044572189,
+        "success": true,
+        "steps": 239,
+        "total_reward": 35.675000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3775215243662223
+      },
+      {
+        "run": 85,
+        "seed": 3044572190,
+        "success": true,
+        "steps": 232,
+        "total_reward": 35.33000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39302640399389627
+      },
+      {
+        "run": 86,
+        "seed": 3044572191,
+        "success": true,
+        "steps": 190,
+        "total_reward": 38.5100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48581304766087374
+      },
+      {
+        "run": 87,
+        "seed": 3044572192,
+        "success": true,
+        "steps": 230,
+        "total_reward": 35.0600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36338168735643905
+      },
+      {
+        "run": 88,
+        "seed": 3044572193,
+        "success": true,
+        "steps": 208,
+        "total_reward": 30.77000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36548323817889034
+      },
+      {
+        "run": 89,
+        "seed": 3044572194,
+        "success": true,
+        "steps": 218,
+        "total_reward": 41.13000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39185204447218175
+      },
+      {
+        "run": 90,
+        "seed": 3044572195,
+        "success": true,
+        "steps": 186,
+        "total_reward": 38.61000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48625288926759513
+      },
+      {
+        "run": 91,
+        "seed": 3044572196,
+        "success": true,
+        "steps": 248,
+        "total_reward": 34.61000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3513368356789409
+      },
+      {
+        "run": 92,
+        "seed": 3044572197,
+        "success": true,
+        "steps": 236,
+        "total_reward": 38.210000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37852860091404983
+      },
+      {
+        "run": 93,
+        "seed": 3044572198,
+        "success": true,
+        "steps": 174,
+        "total_reward": 37.19000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5295887681704913
+      },
+      {
+        "run": 94,
+        "seed": 3044572199,
+        "success": true,
+        "steps": 198,
+        "total_reward": 35.47000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42896929824561403
+      },
+      {
+        "run": 95,
+        "seed": 3044572200,
+        "success": true,
+        "steps": 272,
+        "total_reward": 39.54000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35988863975576024
+      },
+      {
+        "run": 96,
+        "seed": 3044572201,
+        "success": true,
+        "steps": 254,
+        "total_reward": 35.67000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35959334238746005
+      },
+      {
+        "run": 97,
+        "seed": 3044572202,
+        "success": true,
+        "steps": 195,
+        "total_reward": 30.925000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38939360231271997
+      },
+      {
+        "run": 98,
+        "seed": 3044572203,
+        "success": true,
+        "steps": 242,
+        "total_reward": 38.38000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3546268923571555
+      },
+      {
+        "run": 99,
+        "seed": 3044572204,
+        "success": true,
+        "steps": 222,
+        "total_reward": 31.910000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3987867678262415
+      },
+      {
+        "run": 100,
+        "seed": 3044572205,
+        "success": true,
+        "steps": 235,
+        "total_reward": 36.19500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3293576704305773
+      },
+      {
+        "run": 101,
+        "seed": 3044572206,
+        "success": true,
+        "steps": 203,
+        "total_reward": 32.06500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4580357040834982
+      },
+      {
+        "run": 102,
+        "seed": 3044572207,
+        "success": true,
+        "steps": 237,
+        "total_reward": 40.755000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4054344189366568
+      },
+      {
+        "run": 103,
+        "seed": 3044572208,
+        "success": true,
+        "steps": 178,
+        "total_reward": 25.22000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4250017955900309
+      },
+      {
+        "run": 104,
+        "seed": 3044572209,
+        "success": true,
+        "steps": 258,
+        "total_reward": 39.53000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3251871784256014
+      },
+      {
+        "run": 105,
+        "seed": 3044572210,
+        "success": true,
+        "steps": 204,
+        "total_reward": 32.26000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37936309877486346
+      },
+      {
+        "run": 106,
+        "seed": 3044572211,
+        "success": true,
+        "steps": 183,
+        "total_reward": 28.22500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5218551587301588
+      },
+      {
+        "run": 107,
+        "seed": 3044572212,
+        "success": true,
+        "steps": 219,
+        "total_reward": 39.835000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36793442731570336
+      },
+      {
+        "run": 108,
+        "seed": 3044572213,
+        "success": true,
+        "steps": 168,
+        "total_reward": 37.80000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5518239118477235
+      },
+      {
+        "run": 109,
+        "seed": 3044572214,
+        "success": true,
+        "steps": 216,
+        "total_reward": 39.810000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44144984048209857
+      },
+      {
+        "run": 110,
+        "seed": 3044572215,
+        "success": true,
+        "steps": 159,
+        "total_reward": 36.665000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.51565985509383
+      },
+      {
+        "run": 111,
+        "seed": 3044572216,
+        "success": true,
+        "steps": 169,
+        "total_reward": 24.885000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3771431509666804
+      },
+      {
+        "run": 112,
+        "seed": 3044572217,
+        "success": true,
+        "steps": 197,
+        "total_reward": 36.815000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46360303580891815
+      },
+      {
+        "run": 113,
+        "seed": 3044572218,
+        "success": true,
+        "steps": 166,
+        "total_reward": 37.42000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4069208578631329
+      },
+      {
+        "run": 114,
+        "seed": 3044572219,
+        "success": true,
+        "steps": 214,
+        "total_reward": 38.160000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43382657175110007
+      },
+      {
+        "run": 115,
+        "seed": 3044572220,
+        "success": true,
+        "steps": 175,
+        "total_reward": 33.56500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4287519726650161
+      },
+      {
+        "run": 116,
+        "seed": 3044572221,
+        "success": true,
+        "steps": 209,
+        "total_reward": 31.885000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36590455177836406
+      },
+      {
+        "run": 117,
+        "seed": 3044572222,
+        "success": true,
+        "steps": 204,
+        "total_reward": 37.320000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4960622710622711
+      },
+      {
+        "run": 118,
+        "seed": 3044572223,
+        "success": true,
+        "steps": 178,
+        "total_reward": 36.86000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45563786384118865
+      },
+      {
+        "run": 119,
+        "seed": 3044572224,
+        "success": true,
+        "steps": 221,
+        "total_reward": 33.20500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37788759712761527
+      },
+      {
+        "run": 120,
+        "seed": 3044572225,
+        "success": true,
+        "steps": 199,
+        "total_reward": 32.415000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41107598420098423
+      },
+      {
+        "run": 121,
+        "seed": 3044572226,
+        "success": true,
+        "steps": 204,
+        "total_reward": 28.64000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34874124064341455
+      },
+      {
+        "run": 122,
+        "seed": 3044572227,
+        "success": true,
+        "steps": 211,
+        "total_reward": 37.89500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43835642135642133
+      },
+      {
+        "run": 123,
+        "seed": 3044572228,
+        "success": true,
+        "steps": 301,
+        "total_reward": 32.23500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25828223175384907
+      },
+      {
+        "run": 124,
+        "seed": 3044572229,
+        "success": true,
+        "steps": 261,
+        "total_reward": 35.115000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32329717439774364
+      },
+      {
+        "run": 125,
+        "seed": 3044572230,
+        "success": true,
+        "steps": 184,
+        "total_reward": 34.4300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40777777777777774
+      },
+      {
+        "run": 126,
+        "seed": 3044572231,
+        "success": true,
+        "steps": 195,
+        "total_reward": 41.555000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4782559105872154
+      },
+      {
+        "run": 127,
+        "seed": 3044572232,
+        "success": true,
+        "steps": 175,
+        "total_reward": 33.11500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41287456008044243
+      },
+      {
+        "run": 128,
+        "seed": 3044572233,
+        "success": true,
+        "steps": 230,
+        "total_reward": 38.41000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38726898038023355
+      },
+      {
+        "run": 129,
+        "seed": 3044572234,
+        "success": true,
+        "steps": 185,
+        "total_reward": 35.575000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4903155806182122
+      },
+      {
+        "run": 130,
+        "seed": 3044572235,
+        "success": true,
+        "steps": 169,
+        "total_reward": 32.95500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41161852036852037
+      },
+      {
+        "run": 131,
+        "seed": 3044572236,
+        "success": true,
+        "steps": 185,
+        "total_reward": 38.055000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4246765815883463
+      },
+      {
+        "run": 132,
+        "seed": 3044572237,
+        "success": true,
+        "steps": 200,
+        "total_reward": 33.790000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.396409980878066
+      },
+      {
+        "run": 133,
+        "seed": 3044572238,
+        "success": true,
+        "steps": 212,
+        "total_reward": 43.11000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42464237458295384
+      },
+      {
+        "run": 134,
+        "seed": 3044572239,
+        "success": true,
+        "steps": 184,
+        "total_reward": 36.50000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5168491704374057
+      },
+      {
+        "run": 135,
+        "seed": 3044572240,
+        "success": true,
+        "steps": 166,
+        "total_reward": 27.950000000000113,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4935922668662607
+      },
+      {
+        "run": 136,
+        "seed": 3044572241,
+        "success": true,
+        "steps": 193,
+        "total_reward": 40.765000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4221801574979943
+      },
+      {
+        "run": 137,
+        "seed": 3044572242,
+        "success": true,
+        "steps": 167,
+        "total_reward": 29.985000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40249492174492174
+      },
+      {
+        "run": 138,
+        "seed": 3044572243,
+        "success": true,
+        "steps": 232,
+        "total_reward": 34.90000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4425717226824406
+      },
+      {
+        "run": 139,
+        "seed": 3044572244,
+        "success": true,
+        "steps": 174,
+        "total_reward": 29.410000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4634923899629782
+      },
+      {
+        "run": 140,
+        "seed": 3044572245,
+        "success": true,
+        "steps": 179,
+        "total_reward": 33.745000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45118092566619916
+      },
+      {
+        "run": 141,
+        "seed": 3044572246,
+        "success": true,
+        "steps": 168,
+        "total_reward": 35.09000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5054275015602248
+      },
+      {
+        "run": 142,
+        "seed": 3044572247,
+        "success": true,
+        "steps": 255,
+        "total_reward": 43.0950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3727592574878448
+      },
+      {
+        "run": 143,
+        "seed": 3044572248,
+        "success": true,
+        "steps": 194,
+        "total_reward": 31.880000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39426095111578985
+      },
+      {
+        "run": 144,
+        "seed": 3044572249,
+        "success": true,
+        "steps": 170,
+        "total_reward": 31.26000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4603865818453105
+      },
+      {
+        "run": 145,
+        "seed": 3044572250,
+        "success": true,
+        "steps": 223,
+        "total_reward": 36.70500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38406032782084676
+      },
+      {
+        "run": 146,
+        "seed": 3044572251,
+        "success": true,
+        "steps": 222,
+        "total_reward": 31.480000000000143,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34952504412256735
+      },
+      {
+        "run": 147,
+        "seed": 3044572252,
+        "success": true,
+        "steps": 210,
+        "total_reward": 40.57000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4499217164504442
+      },
+      {
+        "run": 148,
+        "seed": 3044572253,
+        "success": true,
+        "steps": 182,
+        "total_reward": 39.49000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5234431599420157
+      },
+      {
+        "run": 149,
+        "seed": 3044572254,
+        "success": true,
+        "steps": 193,
+        "total_reward": 39.58500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4993115006467669
+      },
+      {
+        "run": 150,
+        "seed": 3044572255,
+        "success": true,
+        "steps": 198,
+        "total_reward": 37.83000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3846678561862301
+      },
+      {
+        "run": 151,
+        "seed": 3044572256,
+        "success": true,
+        "steps": 239,
+        "total_reward": 34.80500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3306039006039006
+      },
+      {
+        "run": 152,
+        "seed": 3044572257,
+        "success": true,
+        "steps": 179,
+        "total_reward": 41.44500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4890358599029999
+      },
+      {
+        "run": 153,
+        "seed": 3044572258,
+        "success": true,
+        "steps": 229,
+        "total_reward": 29.415000000000173,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4077189839146361
+      },
+      {
+        "run": 154,
+        "seed": 3044572259,
+        "success": true,
+        "steps": 173,
+        "total_reward": 30.82500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40178726897457545
+      },
+      {
+        "run": 155,
+        "seed": 3044572260,
+        "success": true,
+        "steps": 234,
+        "total_reward": 39.340000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36045472784447546
+      },
+      {
+        "run": 156,
+        "seed": 3044572261,
+        "success": true,
+        "steps": 209,
+        "total_reward": 35.81500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37740519781440496
+      },
+      {
+        "run": 157,
+        "seed": 3044572262,
+        "success": true,
+        "steps": 197,
+        "total_reward": 37.955000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4698744588744589
+      },
+      {
+        "run": 158,
+        "seed": 3044572263,
+        "success": true,
+        "steps": 194,
+        "total_reward": 37.250000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45243728990532056
+      },
+      {
+        "run": 159,
+        "seed": 3044572264,
+        "success": true,
+        "steps": 158,
+        "total_reward": 39.020000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6336717171717171
+      },
+      {
+        "run": 160,
+        "seed": 3044572265,
+        "success": true,
+        "steps": 193,
+        "total_reward": 31.16500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44877942333236864
+      },
+      {
+        "run": 161,
+        "seed": 3044572266,
+        "success": true,
+        "steps": 233,
+        "total_reward": 39.69500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4013352346383199
+      },
+      {
+        "run": 162,
+        "seed": 3044572267,
+        "success": true,
+        "steps": 219,
+        "total_reward": 27.545000000000133,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39286164457166417
+      },
+      {
+        "run": 163,
+        "seed": 3044572268,
+        "success": true,
+        "steps": 191,
+        "total_reward": 39.6550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47748925219787053
+      },
+      {
+        "run": 164,
+        "seed": 3044572269,
+        "success": true,
+        "steps": 248,
+        "total_reward": 28.85000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2966572889328307
+      },
+      {
+        "run": 165,
+        "seed": 3044572270,
+        "success": true,
+        "steps": 297,
+        "total_reward": 29.50500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34928540261052576
+      },
+      {
+        "run": 166,
+        "seed": 3044572271,
+        "success": true,
+        "steps": 203,
+        "total_reward": 37.64500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5332995746943116
+      },
+      {
+        "run": 167,
+        "seed": 3044572272,
+        "success": true,
+        "steps": 211,
+        "total_reward": 36.705000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.447166149068323
+      },
+      {
+        "run": 168,
+        "seed": 3044572273,
+        "success": true,
+        "steps": 241,
+        "total_reward": 35.13500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44479308677602314
+      },
+      {
+        "run": 169,
+        "seed": 3044572274,
+        "success": true,
+        "steps": 183,
+        "total_reward": 40.87500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5124074074074074
+      },
+      {
+        "run": 170,
+        "seed": 3044572275,
+        "success": true,
+        "steps": 184,
+        "total_reward": 37.14000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41414346618293985
+      },
+      {
+        "run": 171,
+        "seed": 3044572276,
+        "success": true,
+        "steps": 193,
+        "total_reward": 36.82500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48847646634411335
+      },
+      {
+        "run": 172,
+        "seed": 3044572277,
+        "success": true,
+        "steps": 170,
+        "total_reward": 38.13000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5465655006004952
+      },
+      {
+        "run": 173,
+        "seed": 3044572278,
+        "success": true,
+        "steps": 173,
+        "total_reward": 36.16500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48148453017570664
+      },
+      {
+        "run": 174,
+        "seed": 3044572279,
+        "success": true,
+        "steps": 224,
+        "total_reward": 35.62000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3603873308550082
+      },
+      {
+        "run": 175,
+        "seed": 3044572280,
+        "success": true,
+        "steps": 207,
+        "total_reward": 38.1750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44688020313020316
+      },
+      {
+        "run": 176,
+        "seed": 3044572281,
+        "success": true,
+        "steps": 230,
+        "total_reward": 41.050000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4399624894338293
+      },
+      {
+        "run": 177,
+        "seed": 3044572282,
+        "success": true,
+        "steps": 172,
+        "total_reward": 33.38000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47692599067599073
+      },
+      {
+        "run": 178,
+        "seed": 3044572283,
+        "success": true,
+        "steps": 183,
+        "total_reward": 26.47500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37863520377585713
+      },
+      {
+        "run": 179,
+        "seed": 3044572284,
+        "success": true,
+        "steps": 174,
+        "total_reward": 38.76000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.456323384218121
+      },
+      {
+        "run": 180,
+        "seed": 3044572285,
+        "success": true,
+        "steps": 203,
+        "total_reward": 39.00500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44316024765365886
+      },
+      {
+        "run": 181,
+        "seed": 3044572286,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.61500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42065489043120624
+      },
+      {
+        "run": 182,
+        "seed": 3044572287,
+        "success": true,
+        "steps": 195,
+        "total_reward": 32.5650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40410252982311806
+      },
+      {
+        "run": 183,
+        "seed": 3044572288,
+        "success": true,
+        "steps": 295,
+        "total_reward": 36.0850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2563390568237999
+      },
+      {
+        "run": 184,
+        "seed": 3044572289,
+        "success": true,
+        "steps": 206,
+        "total_reward": 31.330000000000158,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43174473900083654
+      },
+      {
+        "run": 185,
+        "seed": 3044572290,
+        "success": true,
+        "steps": 214,
+        "total_reward": 36.5200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39525304883664014
+      },
+      {
+        "run": 186,
+        "seed": 3044572291,
+        "success": true,
+        "steps": 236,
+        "total_reward": 37.7900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3915845662543455
+      },
+      {
+        "run": 187,
+        "seed": 3044572292,
+        "success": true,
+        "steps": 203,
+        "total_reward": 35.23500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3812199594836895
+      },
+      {
+        "run": 188,
+        "seed": 3044572293,
+        "success": true,
+        "steps": 162,
+        "total_reward": 38.13000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5727999559854453
+      },
+      {
+        "run": 189,
+        "seed": 3044572294,
+        "success": true,
+        "steps": 237,
+        "total_reward": 29.075000000000152,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3345616889729589
+      },
+      {
+        "run": 190,
+        "seed": 3044572295,
+        "success": true,
+        "steps": 235,
+        "total_reward": 37.07500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34766356884491895
+      },
+      {
+        "run": 191,
+        "seed": 3044572296,
+        "success": true,
+        "steps": 183,
+        "total_reward": 34.48500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4746476530715661
+      },
+      {
+        "run": 192,
+        "seed": 3044572297,
+        "success": true,
+        "steps": 230,
+        "total_reward": 39.910000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39092833163041896
+      },
+      {
+        "run": 193,
+        "seed": 3044572298,
+        "success": true,
+        "steps": 252,
+        "total_reward": 39.94000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4037522574044313
+      },
+      {
+        "run": 194,
+        "seed": 3044572299,
+        "success": true,
+        "steps": 172,
+        "total_reward": 31.550000000000132,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4219194139194139
+      },
+      {
+        "run": 195,
+        "seed": 3044572300,
+        "success": true,
+        "steps": 170,
+        "total_reward": 35.240000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.533036719472478
+      },
+      {
+        "run": 196,
+        "seed": 3044572301,
+        "success": true,
+        "steps": 229,
+        "total_reward": 38.68500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40211837898370406
+      },
+      {
+        "run": 197,
+        "seed": 3044572302,
+        "success": true,
+        "steps": 210,
+        "total_reward": 30.47000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35728863611928124
+      },
+      {
+        "run": 198,
+        "seed": 3044572303,
+        "success": true,
+        "steps": 234,
+        "total_reward": 33.48000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3069876127770864
+      },
+      {
+        "run": 199,
+        "seed": 3044572304,
+        "success": true,
+        "steps": 249,
+        "total_reward": 41.91500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3619042245998768
+      },
+      {
+        "run": 200,
+        "seed": 3044572305,
+        "success": true,
+        "steps": 209,
+        "total_reward": 32.33500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3955163538787681
+      }
+    ],
+    "avg_chemotaxis_index": 0.39707204693768583,
+    "avg_time_in_attractant": 0.6985360234688429,
+    "avg_approach_frequency": 0.4076740012585005,
+    "avg_path_efficiency": 0.04044045517350188,
+    "post_convergence_chemotaxis_index": 0.41100991620460653,
+    "post_convergence_time_in_attractant": 0.7055049581023033,
+    "post_convergence_approach_frequency": 0.4121218127711735,
+    "post_convergence_path_efficiency": 0.04136540532423696,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_093722.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_093722.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_093722",
+  "timestamp": "2025-12-29T09:50:46.934770+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_093722",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.91,
+    "avg_steps": 294.985,
+    "avg_reward": 32.98617500000012,
+    "avg_foods_collected": 9.32,
+    "avg_distance_efficiency": 0.3052288586955186,
+    "completed_all_food": 182,
+    "starved": 15,
+    "max_steps_reached": 3,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 20,
+    "runs_to_convergence": 19,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 294.35911602209944,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.32013641451838043,
+    "composite_benchmark_score": 0.7770409243555142,
+    "learning_speed": 0.865,
+    "learning_speed_episodes": 27,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 2639263735,
+        "success": false,
+        "steps": 206,
+        "total_reward": -7.309999999999993,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 1.1666666666666667
+      },
+      {
+        "run": 2,
+        "seed": 2639263736,
+        "success": false,
+        "steps": 200,
+        "total_reward": -4.609999999999994,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 2639263737,
+        "success": false,
+        "steps": 240,
+        "total_reward": -2.360000000000002,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.05
+      },
+      {
+        "run": 4,
+        "seed": 2639263738,
+        "success": false,
+        "steps": 273,
+        "total_reward": 1.4549999999999628,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.11077664057796509
+      },
+      {
+        "run": 5,
+        "seed": 2639263739,
+        "success": false,
+        "steps": 240,
+        "total_reward": -3.8900000000000015,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.07207207207207207
+      },
+      {
+        "run": 6,
+        "seed": 2639263740,
+        "success": false,
+        "steps": 200,
+        "total_reward": -3.709999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 7,
+        "seed": 2639263741,
+        "success": false,
+        "steps": 240,
+        "total_reward": -3.3899999999999935,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.1111111111111111
+      },
+      {
+        "run": 8,
+        "seed": 2639263742,
+        "success": false,
+        "steps": 240,
+        "total_reward": 0.8299999999999876,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.1111111111111111
+      },
+      {
+        "run": 9,
+        "seed": 2639263743,
+        "success": false,
+        "steps": 200,
+        "total_reward": -6.039999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 10,
+        "seed": 2639263744,
+        "success": false,
+        "steps": 417,
+        "total_reward": 17.145000000000145,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.19354583373437514
+      },
+      {
+        "run": 11,
+        "seed": 2639263745,
+        "success": true,
+        "steps": 485,
+        "total_reward": 38.555000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2048396544220691
+      },
+      {
+        "run": 12,
+        "seed": 2639263746,
+        "success": false,
+        "steps": 200,
+        "total_reward": -4.319999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 13,
+        "seed": 2639263747,
+        "success": false,
+        "steps": 240,
+        "total_reward": 0.23999999999998778,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.17307692307692307
+      },
+      {
+        "run": 14,
+        "seed": 2639263748,
+        "success": false,
+        "steps": 240,
+        "total_reward": -6.259999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.10666666666666667
+      },
+      {
+        "run": 15,
+        "seed": 2639263749,
+        "success": false,
+        "steps": 277,
+        "total_reward": 1.2149999999999537,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.14835803545480966
+      },
+      {
+        "run": 16,
+        "seed": 2639263750,
+        "success": false,
+        "steps": 320,
+        "total_reward": 8.500000000000036,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.11487278391810697
+      },
+      {
+        "run": 17,
+        "seed": 2639263751,
+        "success": false,
+        "steps": 500,
+        "total_reward": 29.20000000000026,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.1634425618858532
+      },
+      {
+        "run": 18,
+        "seed": 2639263752,
+        "success": false,
+        "steps": 500,
+        "total_reward": 32.60000000000033,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.2200046685340803
+      },
+      {
+        "run": 19,
+        "seed": 2639263753,
+        "success": false,
+        "steps": 500,
+        "total_reward": 32.74000000000028,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.15453598204504837
+      },
+      {
+        "run": 20,
+        "seed": 2639263754,
+        "success": true,
+        "steps": 380,
+        "total_reward": 37.20000000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25889001077930474
+      },
+      {
+        "run": 21,
+        "seed": 2639263755,
+        "success": true,
+        "steps": 324,
+        "total_reward": 44.18000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32947098794924884
+      },
+      {
+        "run": 22,
+        "seed": 2639263756,
+        "success": true,
+        "steps": 360,
+        "total_reward": 34.2200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2328660834633002
+      },
+      {
+        "run": 23,
+        "seed": 2639263757,
+        "success": true,
+        "steps": 334,
+        "total_reward": 36.2200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2680011708312525
+      },
+      {
+        "run": 24,
+        "seed": 2639263758,
+        "success": true,
+        "steps": 429,
+        "total_reward": 33.34500000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2541630225361974
+      },
+      {
+        "run": 25,
+        "seed": 2639263759,
+        "success": true,
+        "steps": 477,
+        "total_reward": 30.755000000000177,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24604011892583894
+      },
+      {
+        "run": 26,
+        "seed": 2639263760,
+        "success": true,
+        "steps": 470,
+        "total_reward": 43.40000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23524024335694813
+      },
+      {
+        "run": 27,
+        "seed": 2639263761,
+        "success": true,
+        "steps": 385,
+        "total_reward": 34.69500000000028,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21429291431566458
+      },
+      {
+        "run": 28,
+        "seed": 2639263762,
+        "success": true,
+        "steps": 412,
+        "total_reward": 35.93000000000028,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20746861093496122
+      },
+      {
+        "run": 29,
+        "seed": 2639263763,
+        "success": true,
+        "steps": 318,
+        "total_reward": 38.1300000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29250483798277915
+      },
+      {
+        "run": 30,
+        "seed": 2639263764,
+        "success": true,
+        "steps": 370,
+        "total_reward": 32.81000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22537458831830032
+      },
+      {
+        "run": 31,
+        "seed": 2639263765,
+        "success": true,
+        "steps": 317,
+        "total_reward": 38.60499999999998,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3428014122315593
+      },
+      {
+        "run": 32,
+        "seed": 2639263766,
+        "success": true,
+        "steps": 367,
+        "total_reward": 39.175000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2976281423363948
+      },
+      {
+        "run": 33,
+        "seed": 2639263767,
+        "success": true,
+        "steps": 280,
+        "total_reward": 35.93000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3087926029726136
+      },
+      {
+        "run": 34,
+        "seed": 2639263768,
+        "success": true,
+        "steps": 256,
+        "total_reward": 26.78000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30473619411808894
+      },
+      {
+        "run": 35,
+        "seed": 2639263769,
+        "success": true,
+        "steps": 340,
+        "total_reward": 41.17000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26730535219543816
+      },
+      {
+        "run": 36,
+        "seed": 2639263770,
+        "success": true,
+        "steps": 338,
+        "total_reward": 40.600000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2781003731783408
+      },
+      {
+        "run": 37,
+        "seed": 2639263771,
+        "success": true,
+        "steps": 353,
+        "total_reward": 39.98500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31848706647254743
+      },
+      {
+        "run": 38,
+        "seed": 2639263772,
+        "success": true,
+        "steps": 314,
+        "total_reward": 41.53000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3021365427961932
+      },
+      {
+        "run": 39,
+        "seed": 2639263773,
+        "success": true,
+        "steps": 289,
+        "total_reward": 34.00500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3015487363513679
+      },
+      {
+        "run": 40,
+        "seed": 2639263774,
+        "success": true,
+        "steps": 351,
+        "total_reward": 33.835000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2664141900716853
+      },
+      {
+        "run": 41,
+        "seed": 2639263775,
+        "success": true,
+        "steps": 441,
+        "total_reward": 34.96500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24020490380624762
+      },
+      {
+        "run": 42,
+        "seed": 2639263776,
+        "success": true,
+        "steps": 330,
+        "total_reward": 38.17000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2738225066479647
+      },
+      {
+        "run": 43,
+        "seed": 2639263777,
+        "success": true,
+        "steps": 370,
+        "total_reward": 31.870000000000175,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2369023812394056
+      },
+      {
+        "run": 44,
+        "seed": 2639263778,
+        "success": true,
+        "steps": 272,
+        "total_reward": 35.68000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3449432992481773
+      },
+      {
+        "run": 45,
+        "seed": 2639263779,
+        "success": true,
+        "steps": 234,
+        "total_reward": 36.85000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3805149831099488
+      },
+      {
+        "run": 46,
+        "seed": 2639263780,
+        "success": true,
+        "steps": 338,
+        "total_reward": 35.41000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22618401624215578
+      },
+      {
+        "run": 47,
+        "seed": 2639263781,
+        "success": true,
+        "steps": 357,
+        "total_reward": 32.46500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3023272354885258
+      },
+      {
+        "run": 48,
+        "seed": 2639263782,
+        "success": true,
+        "steps": 222,
+        "total_reward": 33.18000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4357035572786347
+      },
+      {
+        "run": 49,
+        "seed": 2639263783,
+        "success": true,
+        "steps": 345,
+        "total_reward": 42.88500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2835515821148249
+      },
+      {
+        "run": 50,
+        "seed": 2639263784,
+        "success": true,
+        "steps": 256,
+        "total_reward": 42.14000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37434158670440865
+      },
+      {
+        "run": 51,
+        "seed": 2639263785,
+        "success": true,
+        "steps": 251,
+        "total_reward": 31.935000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3498798574613792
+      },
+      {
+        "run": 52,
+        "seed": 2639263786,
+        "success": true,
+        "steps": 242,
+        "total_reward": 36.51000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.350438730139878
+      },
+      {
+        "run": 53,
+        "seed": 2639263787,
+        "success": true,
+        "steps": 338,
+        "total_reward": 41.4000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2843037988632265
+      },
+      {
+        "run": 54,
+        "seed": 2639263788,
+        "success": true,
+        "steps": 299,
+        "total_reward": 35.86500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37235490160985163
+      },
+      {
+        "run": 55,
+        "seed": 2639263789,
+        "success": true,
+        "steps": 285,
+        "total_reward": 37.42500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2996070713570714
+      },
+      {
+        "run": 56,
+        "seed": 2639263790,
+        "success": true,
+        "steps": 188,
+        "total_reward": 30.850000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4009126984126984
+      },
+      {
+        "run": 57,
+        "seed": 2639263791,
+        "success": true,
+        "steps": 268,
+        "total_reward": 39.00000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4088711185328832
+      },
+      {
+        "run": 58,
+        "seed": 2639263792,
+        "success": true,
+        "steps": 225,
+        "total_reward": 37.28500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3772430876534088
+      },
+      {
+        "run": 59,
+        "seed": 2639263793,
+        "success": true,
+        "steps": 336,
+        "total_reward": 45.780000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31342751308863026
+      },
+      {
+        "run": 60,
+        "seed": 2639263794,
+        "success": true,
+        "steps": 363,
+        "total_reward": 45.25500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2716423665706566
+      },
+      {
+        "run": 61,
+        "seed": 2639263795,
+        "success": true,
+        "steps": 236,
+        "total_reward": 31.29000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4091199709094446
+      },
+      {
+        "run": 62,
+        "seed": 2639263796,
+        "success": true,
+        "steps": 226,
+        "total_reward": 37.410000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39995657412762675
+      },
+      {
+        "run": 63,
+        "seed": 2639263797,
+        "success": true,
+        "steps": 250,
+        "total_reward": 39.12000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36174574858251596
+      },
+      {
+        "run": 64,
+        "seed": 2639263798,
+        "success": true,
+        "steps": 387,
+        "total_reward": 37.195000000000185,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30372230161526054
+      },
+      {
+        "run": 65,
+        "seed": 2639263799,
+        "success": true,
+        "steps": 229,
+        "total_reward": 30.215000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31571588986208654
+      },
+      {
+        "run": 66,
+        "seed": 2639263800,
+        "success": true,
+        "steps": 223,
+        "total_reward": 36.365000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4109095265570807
+      },
+      {
+        "run": 67,
+        "seed": 2639263801,
+        "success": true,
+        "steps": 292,
+        "total_reward": 33.62000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2872937545756652
+      },
+      {
+        "run": 68,
+        "seed": 2639263802,
+        "success": true,
+        "steps": 440,
+        "total_reward": 41.41000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2794509974806706
+      },
+      {
+        "run": 69,
+        "seed": 2639263803,
+        "success": true,
+        "steps": 407,
+        "total_reward": 32.88500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24490320359885578
+      },
+      {
+        "run": 70,
+        "seed": 2639263804,
+        "success": true,
+        "steps": 320,
+        "total_reward": 37.32000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27981766856812407
+      },
+      {
+        "run": 71,
+        "seed": 2639263805,
+        "success": true,
+        "steps": 326,
+        "total_reward": 37.74000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24219080819606162
+      },
+      {
+        "run": 72,
+        "seed": 2639263806,
+        "success": true,
+        "steps": 251,
+        "total_reward": 34.625000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37055146041667225
+      },
+      {
+        "run": 73,
+        "seed": 2639263807,
+        "success": true,
+        "steps": 371,
+        "total_reward": 37.97500000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30491770561225173
+      },
+      {
+        "run": 74,
+        "seed": 2639263808,
+        "success": true,
+        "steps": 276,
+        "total_reward": 36.12000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32574962993533
+      },
+      {
+        "run": 75,
+        "seed": 2639263809,
+        "success": true,
+        "steps": 338,
+        "total_reward": 32.73000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2797318668354474
+      },
+      {
+        "run": 76,
+        "seed": 2639263810,
+        "success": true,
+        "steps": 267,
+        "total_reward": 29.165000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3120164753397692
+      },
+      {
+        "run": 77,
+        "seed": 2639263811,
+        "success": true,
+        "steps": 285,
+        "total_reward": 31.835000000000107,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3230423120182799
+      },
+      {
+        "run": 78,
+        "seed": 2639263812,
+        "success": true,
+        "steps": 209,
+        "total_reward": 31.925000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40933986990021476
+      },
+      {
+        "run": 79,
+        "seed": 2639263813,
+        "success": true,
+        "steps": 266,
+        "total_reward": 39.040000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3263553113553114
+      },
+      {
+        "run": 80,
+        "seed": 2639263814,
+        "success": true,
+        "steps": 288,
+        "total_reward": 28.610000000000127,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27308258608181213
+      },
+      {
+        "run": 81,
+        "seed": 2639263815,
+        "success": true,
+        "steps": 340,
+        "total_reward": 31.32000000000032,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3012676463892815
+      },
+      {
+        "run": 82,
+        "seed": 2639263816,
+        "success": true,
+        "steps": 288,
+        "total_reward": 38.440000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3405563265531764
+      },
+      {
+        "run": 83,
+        "seed": 2639263817,
+        "success": true,
+        "steps": 338,
+        "total_reward": 33.50000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2912047646182984
+      },
+      {
+        "run": 84,
+        "seed": 2639263818,
+        "success": true,
+        "steps": 287,
+        "total_reward": 42.06500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39161829446337887
+      },
+      {
+        "run": 85,
+        "seed": 2639263819,
+        "success": true,
+        "steps": 242,
+        "total_reward": 35.43000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31105654034808
+      },
+      {
+        "run": 86,
+        "seed": 2639263820,
+        "success": true,
+        "steps": 277,
+        "total_reward": 32.04500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32347226250452055
+      },
+      {
+        "run": 87,
+        "seed": 2639263821,
+        "success": true,
+        "steps": 248,
+        "total_reward": 41.59000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3569213662275642
+      },
+      {
+        "run": 88,
+        "seed": 2639263822,
+        "success": true,
+        "steps": 247,
+        "total_reward": 38.43500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35930877697182045
+      },
+      {
+        "run": 89,
+        "seed": 2639263823,
+        "success": true,
+        "steps": 300,
+        "total_reward": 39.040000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3744920845707317
+      },
+      {
+        "run": 90,
+        "seed": 2639263824,
+        "success": true,
+        "steps": 206,
+        "total_reward": 36.390000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4618975468975469
+      },
+      {
+        "run": 91,
+        "seed": 2639263825,
+        "success": true,
+        "steps": 368,
+        "total_reward": 38.06000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25017994302020397
+      },
+      {
+        "run": 92,
+        "seed": 2639263826,
+        "success": true,
+        "steps": 317,
+        "total_reward": 34.68500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24324896667001933
+      },
+      {
+        "run": 93,
+        "seed": 2639263827,
+        "success": true,
+        "steps": 306,
+        "total_reward": 38.93000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31591404979892185
+      },
+      {
+        "run": 94,
+        "seed": 2639263828,
+        "success": true,
+        "steps": 258,
+        "total_reward": 36.05000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29361966228497666
+      },
+      {
+        "run": 95,
+        "seed": 2639263829,
+        "success": true,
+        "steps": 301,
+        "total_reward": 41.49500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31230141325536065
+      },
+      {
+        "run": 96,
+        "seed": 2639263830,
+        "success": true,
+        "steps": 223,
+        "total_reward": 35.4050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41605019584863656
+      },
+      {
+        "run": 97,
+        "seed": 2639263831,
+        "success": true,
+        "steps": 256,
+        "total_reward": 39.16000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3617625618887891
+      },
+      {
+        "run": 98,
+        "seed": 2639263832,
+        "success": true,
+        "steps": 301,
+        "total_reward": 32.09500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2543032103123381
+      },
+      {
+        "run": 99,
+        "seed": 2639263833,
+        "success": true,
+        "steps": 299,
+        "total_reward": 36.86500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27338742613891304
+      },
+      {
+        "run": 100,
+        "seed": 2639263834,
+        "success": true,
+        "steps": 370,
+        "total_reward": 38.09000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2793670082040201
+      },
+      {
+        "run": 101,
+        "seed": 2639263835,
+        "success": true,
+        "steps": 310,
+        "total_reward": 34.46000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2667704397052223
+      },
+      {
+        "run": 102,
+        "seed": 2639263836,
+        "success": true,
+        "steps": 263,
+        "total_reward": 37.93500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3347052881758764
+      },
+      {
+        "run": 103,
+        "seed": 2639263837,
+        "success": true,
+        "steps": 228,
+        "total_reward": 31.350000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3267481816852526
+      },
+      {
+        "run": 104,
+        "seed": 2639263838,
+        "success": true,
+        "steps": 396,
+        "total_reward": 45.09000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25439401270235246
+      },
+      {
+        "run": 105,
+        "seed": 2639263839,
+        "success": true,
+        "steps": 283,
+        "total_reward": 28.68500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2692632221669499
+      },
+      {
+        "run": 106,
+        "seed": 2639263840,
+        "success": true,
+        "steps": 266,
+        "total_reward": 33.75000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36885969537106733
+      },
+      {
+        "run": 107,
+        "seed": 2639263841,
+        "success": true,
+        "steps": 302,
+        "total_reward": 43.39000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3173195123917868
+      },
+      {
+        "run": 108,
+        "seed": 2639263842,
+        "success": true,
+        "steps": 256,
+        "total_reward": 35.66000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.360875505824103
+      },
+      {
+        "run": 109,
+        "seed": 2639263843,
+        "success": true,
+        "steps": 228,
+        "total_reward": 32.50000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3490127846010199
+      },
+      {
+        "run": 110,
+        "seed": 2639263844,
+        "success": true,
+        "steps": 243,
+        "total_reward": 37.83500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4037023083299679
+      },
+      {
+        "run": 111,
+        "seed": 2639263845,
+        "success": true,
+        "steps": 286,
+        "total_reward": 33.39000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32684741149636787
+      },
+      {
+        "run": 112,
+        "seed": 2639263846,
+        "success": true,
+        "steps": 241,
+        "total_reward": 35.515000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3656111237690185
+      },
+      {
+        "run": 113,
+        "seed": 2639263847,
+        "success": true,
+        "steps": 346,
+        "total_reward": 38.400000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2390808098470277
+      },
+      {
+        "run": 114,
+        "seed": 2639263848,
+        "success": true,
+        "steps": 315,
+        "total_reward": 37.43500000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2655467008511966
+      },
+      {
+        "run": 115,
+        "seed": 2639263849,
+        "success": true,
+        "steps": 299,
+        "total_reward": 23.215000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.18684926069222849
+      },
+      {
+        "run": 116,
+        "seed": 2639263850,
+        "success": true,
+        "steps": 356,
+        "total_reward": 41.22000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27717276066879526
+      },
+      {
+        "run": 117,
+        "seed": 2639263851,
+        "success": true,
+        "steps": 274,
+        "total_reward": 33.27000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35994492984767584
+      },
+      {
+        "run": 118,
+        "seed": 2639263852,
+        "success": true,
+        "steps": 281,
+        "total_reward": 30.02500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29215302413444827
+      },
+      {
+        "run": 119,
+        "seed": 2639263853,
+        "success": true,
+        "steps": 267,
+        "total_reward": 32.42500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3413263856455614
+      },
+      {
+        "run": 120,
+        "seed": 2639263854,
+        "success": true,
+        "steps": 297,
+        "total_reward": 32.835000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2775637052384794
+      },
+      {
+        "run": 121,
+        "seed": 2639263855,
+        "success": true,
+        "steps": 300,
+        "total_reward": 36.95000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.320117760146102
+      },
+      {
+        "run": 122,
+        "seed": 2639263856,
+        "success": true,
+        "steps": 284,
+        "total_reward": 26.560000000000137,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2587455694384294
+      },
+      {
+        "run": 123,
+        "seed": 2639263857,
+        "success": true,
+        "steps": 362,
+        "total_reward": 33.82000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2360962885478329
+      },
+      {
+        "run": 124,
+        "seed": 2639263858,
+        "success": true,
+        "steps": 236,
+        "total_reward": 29.82000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3369408524255086
+      },
+      {
+        "run": 125,
+        "seed": 2639263859,
+        "success": true,
+        "steps": 265,
+        "total_reward": 37.335000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33617600851197177
+      },
+      {
+        "run": 126,
+        "seed": 2639263860,
+        "success": true,
+        "steps": 323,
+        "total_reward": 28.48500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22780680247808358
+      },
+      {
+        "run": 127,
+        "seed": 2639263861,
+        "success": true,
+        "steps": 249,
+        "total_reward": 46.65500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4326275463666768
+      },
+      {
+        "run": 128,
+        "seed": 2639263862,
+        "success": true,
+        "steps": 242,
+        "total_reward": 33.10000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3385778889726258
+      },
+      {
+        "run": 129,
+        "seed": 2639263863,
+        "success": true,
+        "steps": 260,
+        "total_reward": 29.100000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2801387827858416
+      },
+      {
+        "run": 130,
+        "seed": 2639263864,
+        "success": true,
+        "steps": 293,
+        "total_reward": 36.045000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29737888385528294
+      },
+      {
+        "run": 131,
+        "seed": 2639263865,
+        "success": true,
+        "steps": 278,
+        "total_reward": 30.030000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2643568601049419
+      },
+      {
+        "run": 132,
+        "seed": 2639263866,
+        "success": true,
+        "steps": 290,
+        "total_reward": 41.46000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34272625734296214
+      },
+      {
+        "run": 133,
+        "seed": 2639263867,
+        "success": true,
+        "steps": 247,
+        "total_reward": 34.355000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36030518731352906
+      },
+      {
+        "run": 134,
+        "seed": 2639263868,
+        "success": true,
+        "steps": 215,
+        "total_reward": 28.43500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3533759175001144
+      },
+      {
+        "run": 135,
+        "seed": 2639263869,
+        "success": true,
+        "steps": 268,
+        "total_reward": 32.340000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3071169148569371
+      },
+      {
+        "run": 136,
+        "seed": 2639263870,
+        "success": true,
+        "steps": 241,
+        "total_reward": 39.44499999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3812192353496701
+      },
+      {
+        "run": 137,
+        "seed": 2639263871,
+        "success": true,
+        "steps": 244,
+        "total_reward": 38.350000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38331509934255925
+      },
+      {
+        "run": 138,
+        "seed": 2639263872,
+        "success": true,
+        "steps": 284,
+        "total_reward": 35.68000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3324198484279393
+      },
+      {
+        "run": 139,
+        "seed": 2639263873,
+        "success": true,
+        "steps": 217,
+        "total_reward": 32.915000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48908188474751946
+      },
+      {
+        "run": 140,
+        "seed": 2639263874,
+        "success": true,
+        "steps": 243,
+        "total_reward": 40.385000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3954340415427372
+      },
+      {
+        "run": 141,
+        "seed": 2639263875,
+        "success": true,
+        "steps": 282,
+        "total_reward": 48.97000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4169581143494187
+      },
+      {
+        "run": 142,
+        "seed": 2639263876,
+        "success": true,
+        "steps": 239,
+        "total_reward": 26.405000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3938647953957852
+      },
+      {
+        "run": 143,
+        "seed": 2639263877,
+        "success": true,
+        "steps": 256,
+        "total_reward": 35.73000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34585621185215504
+      },
+      {
+        "run": 144,
+        "seed": 2639263878,
+        "success": true,
+        "steps": 266,
+        "total_reward": 35.77000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34747071462916346
+      },
+      {
+        "run": 145,
+        "seed": 2639263879,
+        "success": true,
+        "steps": 261,
+        "total_reward": 32.03500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3667166317528784
+      },
+      {
+        "run": 146,
+        "seed": 2639263880,
+        "success": true,
+        "steps": 298,
+        "total_reward": 30.760000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2699285329210894
+      },
+      {
+        "run": 147,
+        "seed": 2639263881,
+        "success": true,
+        "steps": 255,
+        "total_reward": 31.305000000000163,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35823422390244947
+      },
+      {
+        "run": 148,
+        "seed": 2639263882,
+        "success": true,
+        "steps": 285,
+        "total_reward": 37.28500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3219214209688477
+      },
+      {
+        "run": 149,
+        "seed": 2639263883,
+        "success": true,
+        "steps": 372,
+        "total_reward": 44.22000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3886081411836558
+      },
+      {
+        "run": 150,
+        "seed": 2639263884,
+        "success": true,
+        "steps": 292,
+        "total_reward": 30.030000000000218,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3302798484120356
+      },
+      {
+        "run": 151,
+        "seed": 2639263885,
+        "success": true,
+        "steps": 260,
+        "total_reward": 33.0600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3037334417425951
+      },
+      {
+        "run": 152,
+        "seed": 2639263886,
+        "success": true,
+        "steps": 269,
+        "total_reward": 33.98500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28260603526907874
+      },
+      {
+        "run": 153,
+        "seed": 2639263887,
+        "success": true,
+        "steps": 273,
+        "total_reward": 40.565000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3625843515321609
+      },
+      {
+        "run": 154,
+        "seed": 2639263888,
+        "success": true,
+        "steps": 349,
+        "total_reward": 43.025000000000205,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30853418888585127
+      },
+      {
+        "run": 155,
+        "seed": 2639263889,
+        "success": true,
+        "steps": 226,
+        "total_reward": 34.83000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4953963190805296
+      },
+      {
+        "run": 156,
+        "seed": 2639263890,
+        "success": true,
+        "steps": 361,
+        "total_reward": 37.72500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2341932327636032
+      },
+      {
+        "run": 157,
+        "seed": 2639263891,
+        "success": true,
+        "steps": 439,
+        "total_reward": 35.93500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21431862156772766
+      },
+      {
+        "run": 158,
+        "seed": 2639263892,
+        "success": true,
+        "steps": 284,
+        "total_reward": 36.43000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3159738709713134
+      },
+      {
+        "run": 159,
+        "seed": 2639263893,
+        "success": true,
+        "steps": 340,
+        "total_reward": 39.22000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2754876136337302
+      },
+      {
+        "run": 160,
+        "seed": 2639263894,
+        "success": true,
+        "steps": 283,
+        "total_reward": 37.21500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36215681271415034
+      },
+      {
+        "run": 161,
+        "seed": 2639263895,
+        "success": true,
+        "steps": 282,
+        "total_reward": 35.890000000000185,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32128492304769873
+      },
+      {
+        "run": 162,
+        "seed": 2639263896,
+        "success": true,
+        "steps": 276,
+        "total_reward": 36.69000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3269912511126126
+      },
+      {
+        "run": 163,
+        "seed": 2639263897,
+        "success": true,
+        "steps": 251,
+        "total_reward": 36.21500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3285442268131055
+      },
+      {
+        "run": 164,
+        "seed": 2639263898,
+        "success": true,
+        "steps": 381,
+        "total_reward": 28.175000000000157,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23666126537543825
+      },
+      {
+        "run": 165,
+        "seed": 2639263899,
+        "success": true,
+        "steps": 283,
+        "total_reward": 34.74500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3328419078099305
+      },
+      {
+        "run": 166,
+        "seed": 2639263900,
+        "success": true,
+        "steps": 264,
+        "total_reward": 38.300000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36116265267441894
+      },
+      {
+        "run": 167,
+        "seed": 2639263901,
+        "success": true,
+        "steps": 283,
+        "total_reward": 31.055000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31180520856991445
+      },
+      {
+        "run": 168,
+        "seed": 2639263902,
+        "success": true,
+        "steps": 195,
+        "total_reward": 37.69500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5006418194808288
+      },
+      {
+        "run": 169,
+        "seed": 2639263903,
+        "success": true,
+        "steps": 256,
+        "total_reward": 31.91000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3373547399112281
+      },
+      {
+        "run": 170,
+        "seed": 2639263904,
+        "success": true,
+        "steps": 310,
+        "total_reward": 40.9300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2961401324171633
+      },
+      {
+        "run": 171,
+        "seed": 2639263905,
+        "success": true,
+        "steps": 269,
+        "total_reward": 32.76500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3420432155028929
+      },
+      {
+        "run": 172,
+        "seed": 2639263906,
+        "success": true,
+        "steps": 263,
+        "total_reward": 29.965000000000167,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30743190143190147
+      },
+      {
+        "run": 173,
+        "seed": 2639263907,
+        "success": true,
+        "steps": 318,
+        "total_reward": 36.11000000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3538587324405812
+      },
+      {
+        "run": 174,
+        "seed": 2639263908,
+        "success": true,
+        "steps": 180,
+        "total_reward": 32.52000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4284398790864308
+      },
+      {
+        "run": 175,
+        "seed": 2639263909,
+        "success": true,
+        "steps": 325,
+        "total_reward": 39.94500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37742672221395623
+      },
+      {
+        "run": 176,
+        "seed": 2639263910,
+        "success": true,
+        "steps": 279,
+        "total_reward": 38.995000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3551196467586274
+      },
+      {
+        "run": 177,
+        "seed": 2639263911,
+        "success": true,
+        "steps": 330,
+        "total_reward": 31.830000000000148,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2520496601981495
+      },
+      {
+        "run": 178,
+        "seed": 2639263912,
+        "success": true,
+        "steps": 242,
+        "total_reward": 36.300000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.371484828984829
+      },
+      {
+        "run": 179,
+        "seed": 2639263913,
+        "success": true,
+        "steps": 311,
+        "total_reward": 46.145000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3438685191593002
+      },
+      {
+        "run": 180,
+        "seed": 2639263914,
+        "success": true,
+        "steps": 300,
+        "total_reward": 29.35000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28926445561785563
+      },
+      {
+        "run": 181,
+        "seed": 2639263915,
+        "success": true,
+        "steps": 244,
+        "total_reward": 40.240000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4076517354707524
+      },
+      {
+        "run": 182,
+        "seed": 2639263916,
+        "success": true,
+        "steps": 336,
+        "total_reward": 34.71000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24562324603501073
+      },
+      {
+        "run": 183,
+        "seed": 2639263917,
+        "success": true,
+        "steps": 296,
+        "total_reward": 30.99000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26705265854990057
+      },
+      {
+        "run": 184,
+        "seed": 2639263918,
+        "success": true,
+        "steps": 304,
+        "total_reward": 39.66000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3090306915306915
+      },
+      {
+        "run": 185,
+        "seed": 2639263919,
+        "success": true,
+        "steps": 245,
+        "total_reward": 31.325000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3517784299034299
+      },
+      {
+        "run": 186,
+        "seed": 2639263920,
+        "success": true,
+        "steps": 303,
+        "total_reward": 32.18500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25335625406132606
+      },
+      {
+        "run": 187,
+        "seed": 2639263921,
+        "success": true,
+        "steps": 242,
+        "total_reward": 30.320000000000128,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35836664502371496
+      },
+      {
+        "run": 188,
+        "seed": 2639263922,
+        "success": true,
+        "steps": 218,
+        "total_reward": 32.94000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3974167578706678
+      },
+      {
+        "run": 189,
+        "seed": 2639263923,
+        "success": true,
+        "steps": 302,
+        "total_reward": 32.710000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29326576201576204
+      },
+      {
+        "run": 190,
+        "seed": 2639263924,
+        "success": true,
+        "steps": 333,
+        "total_reward": 34.20500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28395306138300097
+      },
+      {
+        "run": 191,
+        "seed": 2639263925,
+        "success": true,
+        "steps": 233,
+        "total_reward": 37.56500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38055269677911185
+      },
+      {
+        "run": 192,
+        "seed": 2639263926,
+        "success": true,
+        "steps": 268,
+        "total_reward": 37.570000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33137050084418507
+      },
+      {
+        "run": 193,
+        "seed": 2639263927,
+        "success": true,
+        "steps": 284,
+        "total_reward": 37.00000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31076108742228514
+      },
+      {
+        "run": 194,
+        "seed": 2639263928,
+        "success": true,
+        "steps": 268,
+        "total_reward": 34.41000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36354100857190097
+      },
+      {
+        "run": 195,
+        "seed": 2639263929,
+        "success": true,
+        "steps": 335,
+        "total_reward": 37.93500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23572381126460823
+      },
+      {
+        "run": 196,
+        "seed": 2639263930,
+        "success": true,
+        "steps": 272,
+        "total_reward": 37.91000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.417665332235175
+      },
+      {
+        "run": 197,
+        "seed": 2639263931,
+        "success": true,
+        "steps": 250,
+        "total_reward": 30.600000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2615017252746811
+      },
+      {
+        "run": 198,
+        "seed": 2639263932,
+        "success": true,
+        "steps": 307,
+        "total_reward": 34.95500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31956931864215526
+      },
+      {
+        "run": 199,
+        "seed": 2639263933,
+        "success": true,
+        "steps": 329,
+        "total_reward": 40.41500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26402103654204495
+      },
+      {
+        "run": 200,
+        "seed": 2639263934,
+        "success": true,
+        "steps": 261,
+        "total_reward": 36.21500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3145616568466467
+      }
+    ],
+    "avg_chemotaxis_index": 0.36874544282665644,
+    "avg_time_in_attractant": 0.6843727214133283,
+    "avg_approach_frequency": 0.35923183832188355,
+    "avg_path_efficiency": 0.030207285647864585,
+    "post_convergence_chemotaxis_index": 0.40178552007860635,
+    "post_convergence_time_in_attractant": 0.7008927600393032,
+    "post_convergence_approach_frequency": 0.3612523087439583,
+    "post_convergence_path_efficiency": 0.030180390756122045,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_093725.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_093725.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_093725",
+  "timestamp": "2025-12-29T09:47:14.786607+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_093725",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.95,
+    "avg_steps": 220.76,
+    "avg_reward": 34.1452000000001,
+    "avg_foods_collected": 9.62,
+    "avg_distance_efficiency": 0.39987303747677716,
+    "completed_all_food": 190,
+    "starved": 9,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 12,
+    "runs_to_convergence": 11,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 215.97354497354496,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.41483409544452143,
+    "composite_benchmark_score": 0.8134502286333564,
+    "learning_speed": 0.91,
+    "learning_speed_episodes": 18,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3823494742,
+        "success": false,
+        "steps": 240,
+        "total_reward": -3.8200000000000047,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.041666666666666664
+      },
+      {
+        "run": 2,
+        "seed": 3823494743,
+        "success": false,
+        "steps": 280,
+        "total_reward": -0.6300000000000274,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.06714396284829721
+      },
+      {
+        "run": 3,
+        "seed": 3823494744,
+        "success": false,
+        "steps": 280,
+        "total_reward": -0.17000000000002125,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.12181894034209428
+      },
+      {
+        "run": 4,
+        "seed": 3823494745,
+        "success": false,
+        "steps": 360,
+        "total_reward": 7.259999999999987,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.21253356257949033
+      },
+      {
+        "run": 5,
+        "seed": 3823494746,
+        "success": false,
+        "steps": 200,
+        "total_reward": -6.199999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 6,
+        "seed": 3823494747,
+        "success": false,
+        "steps": 280,
+        "total_reward": 2.099999999999927,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.11370481927710843
+      },
+      {
+        "run": 7,
+        "seed": 3823494748,
+        "success": false,
+        "steps": 320,
+        "total_reward": 5.36999999999991,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.11494282971109365
+      },
+      {
+        "run": 8,
+        "seed": 3823494749,
+        "success": false,
+        "steps": 240,
+        "total_reward": -1.7500000000000249,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.15
+      },
+      {
+        "run": 9,
+        "seed": 3823494750,
+        "success": false,
+        "steps": 240,
+        "total_reward": -1.3100000000000023,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.049079754601226995
+      },
+      {
+        "run": 10,
+        "seed": 3823494751,
+        "success": true,
+        "steps": 393,
+        "total_reward": 37.195000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37047675222437604
+      },
+      {
+        "run": 11,
+        "seed": 3823494752,
+        "success": false,
+        "steps": 500,
+        "total_reward": 30.87000000000027,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.32959616809053077
+      },
+      {
+        "run": 12,
+        "seed": 3823494753,
+        "success": true,
+        "steps": 388,
+        "total_reward": 42.770000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29164843441839305
+      },
+      {
+        "run": 13,
+        "seed": 3823494754,
+        "success": true,
+        "steps": 293,
+        "total_reward": 44.455000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3745729563871712
+      },
+      {
+        "run": 14,
+        "seed": 3823494755,
+        "success": true,
+        "steps": 345,
+        "total_reward": 34.88500000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3301389823721442
+      },
+      {
+        "run": 15,
+        "seed": 3823494756,
+        "success": true,
+        "steps": 331,
+        "total_reward": 43.525000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39323570487189075
+      },
+      {
+        "run": 16,
+        "seed": 3823494757,
+        "success": true,
+        "steps": 283,
+        "total_reward": 33.67500000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28516511213364837
+      },
+      {
+        "run": 17,
+        "seed": 3823494758,
+        "success": true,
+        "steps": 290,
+        "total_reward": 44.180000000000184,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3928829886392836
+      },
+      {
+        "run": 18,
+        "seed": 3823494759,
+        "success": true,
+        "steps": 315,
+        "total_reward": 38.19500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28252756302291904
+      },
+      {
+        "run": 19,
+        "seed": 3823494760,
+        "success": true,
+        "steps": 316,
+        "total_reward": 38.9800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2857638739122367
+      },
+      {
+        "run": 20,
+        "seed": 3823494761,
+        "success": true,
+        "steps": 307,
+        "total_reward": 28.765000000000175,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2624006651151048
+      },
+      {
+        "run": 21,
+        "seed": 3823494762,
+        "success": true,
+        "steps": 344,
+        "total_reward": 32.93000000000028,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27135793795364566
+      },
+      {
+        "run": 22,
+        "seed": 3823494763,
+        "success": true,
+        "steps": 262,
+        "total_reward": 31.590000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29438396350248375
+      },
+      {
+        "run": 23,
+        "seed": 3823494764,
+        "success": true,
+        "steps": 337,
+        "total_reward": 34.685000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2686162574668024
+      },
+      {
+        "run": 24,
+        "seed": 3823494765,
+        "success": true,
+        "steps": 264,
+        "total_reward": 39.1000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4190754608294931
+      },
+      {
+        "run": 25,
+        "seed": 3823494766,
+        "success": true,
+        "steps": 212,
+        "total_reward": 33.8900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3720532439554179
+      },
+      {
+        "run": 26,
+        "seed": 3823494767,
+        "success": true,
+        "steps": 320,
+        "total_reward": 38.08000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3269597257322425
+      },
+      {
+        "run": 27,
+        "seed": 3823494768,
+        "success": true,
+        "steps": 233,
+        "total_reward": 35.12500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35063616298910416
+      },
+      {
+        "run": 28,
+        "seed": 3823494769,
+        "success": true,
+        "steps": 226,
+        "total_reward": 29.250000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3113492169430664
+      },
+      {
+        "run": 29,
+        "seed": 3823494770,
+        "success": true,
+        "steps": 234,
+        "total_reward": 32.050000000000175,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2894411569177009
+      },
+      {
+        "run": 30,
+        "seed": 3823494771,
+        "success": true,
+        "steps": 211,
+        "total_reward": 38.725000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49133336311217957
+      },
+      {
+        "run": 31,
+        "seed": 3823494772,
+        "success": true,
+        "steps": 282,
+        "total_reward": 34.66000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30973333022700367
+      },
+      {
+        "run": 32,
+        "seed": 3823494773,
+        "success": true,
+        "steps": 306,
+        "total_reward": 39.480000000000175,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2958082408370284
+      },
+      {
+        "run": 33,
+        "seed": 3823494774,
+        "success": true,
+        "steps": 289,
+        "total_reward": 41.86500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3851148851148851
+      },
+      {
+        "run": 34,
+        "seed": 3823494775,
+        "success": true,
+        "steps": 196,
+        "total_reward": 43.48000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.513881584254255
+      },
+      {
+        "run": 35,
+        "seed": 3823494776,
+        "success": true,
+        "steps": 230,
+        "total_reward": 36.01000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33442357642357645
+      },
+      {
+        "run": 36,
+        "seed": 3823494777,
+        "success": true,
+        "steps": 335,
+        "total_reward": 37.08500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24965345729329544
+      },
+      {
+        "run": 37,
+        "seed": 3823494778,
+        "success": true,
+        "steps": 230,
+        "total_reward": 35.99000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3861412973409758
+      },
+      {
+        "run": 38,
+        "seed": 3823494779,
+        "success": true,
+        "steps": 213,
+        "total_reward": 31.75500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46704228243021345
+      },
+      {
+        "run": 39,
+        "seed": 3823494780,
+        "success": true,
+        "steps": 208,
+        "total_reward": 28.170000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33814145289209224
+      },
+      {
+        "run": 40,
+        "seed": 3823494781,
+        "success": true,
+        "steps": 253,
+        "total_reward": 31.975000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36155839655839656
+      },
+      {
+        "run": 41,
+        "seed": 3823494782,
+        "success": true,
+        "steps": 232,
+        "total_reward": 37.27000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37049065213538895
+      },
+      {
+        "run": 42,
+        "seed": 3823494783,
+        "success": true,
+        "steps": 271,
+        "total_reward": 35.19500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33879573204573205
+      },
+      {
+        "run": 43,
+        "seed": 3823494784,
+        "success": true,
+        "steps": 198,
+        "total_reward": 37.80000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4582204396910279
+      },
+      {
+        "run": 44,
+        "seed": 3823494785,
+        "success": true,
+        "steps": 225,
+        "total_reward": 36.21500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35335511744477477
+      },
+      {
+        "run": 45,
+        "seed": 3823494786,
+        "success": true,
+        "steps": 189,
+        "total_reward": 35.235000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4302389673090407
+      },
+      {
+        "run": 46,
+        "seed": 3823494787,
+        "success": true,
+        "steps": 219,
+        "total_reward": 33.885000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35108478776125834
+      },
+      {
+        "run": 47,
+        "seed": 3823494788,
+        "success": true,
+        "steps": 221,
+        "total_reward": 38.76500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4987914349756455
+      },
+      {
+        "run": 48,
+        "seed": 3823494789,
+        "success": true,
+        "steps": 172,
+        "total_reward": 43.970000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4955759226153963
+      },
+      {
+        "run": 49,
+        "seed": 3823494790,
+        "success": true,
+        "steps": 278,
+        "total_reward": 39.71000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33625763424150523
+      },
+      {
+        "run": 50,
+        "seed": 3823494791,
+        "success": true,
+        "steps": 174,
+        "total_reward": 40.470000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4982607330255388
+      },
+      {
+        "run": 51,
+        "seed": 3823494792,
+        "success": true,
+        "steps": 214,
+        "total_reward": 32.13000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4179512695766566
+      },
+      {
+        "run": 52,
+        "seed": 3823494793,
+        "success": true,
+        "steps": 228,
+        "total_reward": 39.04000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3820043599611677
+      },
+      {
+        "run": 53,
+        "seed": 3823494794,
+        "success": true,
+        "steps": 154,
+        "total_reward": 29.680000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46847862663652134
+      },
+      {
+        "run": 54,
+        "seed": 3823494795,
+        "success": true,
+        "steps": 169,
+        "total_reward": 32.88500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47469305929260164
+      },
+      {
+        "run": 55,
+        "seed": 3823494796,
+        "success": true,
+        "steps": 230,
+        "total_reward": 32.95000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44499412624412626
+      },
+      {
+        "run": 56,
+        "seed": 3823494797,
+        "success": true,
+        "steps": 187,
+        "total_reward": 33.76500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43223743637536743
+      },
+      {
+        "run": 57,
+        "seed": 3823494798,
+        "success": true,
+        "steps": 207,
+        "total_reward": 36.4750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44943119800055076
+      },
+      {
+        "run": 58,
+        "seed": 3823494799,
+        "success": true,
+        "steps": 213,
+        "total_reward": 35.43500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4224479686979687
+      },
+      {
+        "run": 59,
+        "seed": 3823494800,
+        "success": true,
+        "steps": 256,
+        "total_reward": 36.7900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36156466426590267
+      },
+      {
+        "run": 60,
+        "seed": 3823494801,
+        "success": true,
+        "steps": 211,
+        "total_reward": 37.255000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4161749164822628
+      },
+      {
+        "run": 61,
+        "seed": 3823494802,
+        "success": true,
+        "steps": 197,
+        "total_reward": 37.84500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43740400775694893
+      },
+      {
+        "run": 62,
+        "seed": 3823494803,
+        "success": true,
+        "steps": 196,
+        "total_reward": 30.150000000000112,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3514850427350428
+      },
+      {
+        "run": 63,
+        "seed": 3823494804,
+        "success": true,
+        "steps": 172,
+        "total_reward": 30.270000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3983518491742176
+      },
+      {
+        "run": 64,
+        "seed": 3823494805,
+        "success": true,
+        "steps": 210,
+        "total_reward": 34.750000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43328777629692966
+      },
+      {
+        "run": 65,
+        "seed": 3823494806,
+        "success": true,
+        "steps": 182,
+        "total_reward": 38.69000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49693216775235155
+      },
+      {
+        "run": 66,
+        "seed": 3823494807,
+        "success": true,
+        "steps": 214,
+        "total_reward": 35.69000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41482418547635935
+      },
+      {
+        "run": 67,
+        "seed": 3823494808,
+        "success": true,
+        "steps": 177,
+        "total_reward": 42.26500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49305297557619543
+      },
+      {
+        "run": 68,
+        "seed": 3823494809,
+        "success": true,
+        "steps": 181,
+        "total_reward": 37.125000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5369001880031292
+      },
+      {
+        "run": 69,
+        "seed": 3823494810,
+        "success": true,
+        "steps": 227,
+        "total_reward": 39.385000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47547417365834815
+      },
+      {
+        "run": 70,
+        "seed": 3823494811,
+        "success": true,
+        "steps": 264,
+        "total_reward": 30.750000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2882075429148234
+      },
+      {
+        "run": 71,
+        "seed": 3823494812,
+        "success": true,
+        "steps": 179,
+        "total_reward": 34.21500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44528838116846536
+      },
+      {
+        "run": 72,
+        "seed": 3823494813,
+        "success": true,
+        "steps": 176,
+        "total_reward": 33.78000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49460200668896326
+      },
+      {
+        "run": 73,
+        "seed": 3823494814,
+        "success": true,
+        "steps": 251,
+        "total_reward": 40.62500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40597072082146707
+      },
+      {
+        "run": 74,
+        "seed": 3823494815,
+        "success": true,
+        "steps": 206,
+        "total_reward": 37.75000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40664211032632086
+      },
+      {
+        "run": 75,
+        "seed": 3823494816,
+        "success": true,
+        "steps": 230,
+        "total_reward": 41.500000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4232815981856903
+      },
+      {
+        "run": 76,
+        "seed": 3823494817,
+        "success": true,
+        "steps": 171,
+        "total_reward": 34.26500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4912070575356579
+      },
+      {
+        "run": 77,
+        "seed": 3823494818,
+        "success": true,
+        "steps": 304,
+        "total_reward": 28.620000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24512261276620045
+      },
+      {
+        "run": 78,
+        "seed": 3823494819,
+        "success": true,
+        "steps": 228,
+        "total_reward": 45.77000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4723358908780904
+      },
+      {
+        "run": 79,
+        "seed": 3823494820,
+        "success": true,
+        "steps": 262,
+        "total_reward": 43.50000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3781994738680785
+      },
+      {
+        "run": 80,
+        "seed": 3823494821,
+        "success": true,
+        "steps": 162,
+        "total_reward": 26.020000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4925614366713438
+      },
+      {
+        "run": 81,
+        "seed": 3823494822,
+        "success": true,
+        "steps": 230,
+        "total_reward": 36.030000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3756340931021238
+      },
+      {
+        "run": 82,
+        "seed": 3823494823,
+        "success": true,
+        "steps": 237,
+        "total_reward": 43.77500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4624069204706636
+      },
+      {
+        "run": 83,
+        "seed": 3823494824,
+        "success": true,
+        "steps": 207,
+        "total_reward": 34.1450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4044844825224082
+      },
+      {
+        "run": 84,
+        "seed": 3823494825,
+        "success": true,
+        "steps": 218,
+        "total_reward": 31.58000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41307464615645395
+      },
+      {
+        "run": 85,
+        "seed": 3823494826,
+        "success": true,
+        "steps": 176,
+        "total_reward": 36.50000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4521149119912239
+      },
+      {
+        "run": 86,
+        "seed": 3823494827,
+        "success": true,
+        "steps": 237,
+        "total_reward": 36.425000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38326710232432903
+      },
+      {
+        "run": 87,
+        "seed": 3823494828,
+        "success": true,
+        "steps": 223,
+        "total_reward": 36.24500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39287680821720583
+      },
+      {
+        "run": 88,
+        "seed": 3823494829,
+        "success": true,
+        "steps": 199,
+        "total_reward": 36.885000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4612309733277475
+      },
+      {
+        "run": 89,
+        "seed": 3823494830,
+        "success": true,
+        "steps": 163,
+        "total_reward": 33.36500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5061167434715822
+      },
+      {
+        "run": 90,
+        "seed": 3823494831,
+        "success": true,
+        "steps": 206,
+        "total_reward": 39.5900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4445214617571597
+      },
+      {
+        "run": 91,
+        "seed": 3823494832,
+        "success": true,
+        "steps": 210,
+        "total_reward": 43.060000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4399892498805542
+      },
+      {
+        "run": 92,
+        "seed": 3823494833,
+        "success": true,
+        "steps": 171,
+        "total_reward": 37.70500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46289965100259217
+      },
+      {
+        "run": 93,
+        "seed": 3823494834,
+        "success": true,
+        "steps": 231,
+        "total_reward": 40.33500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5541877405180015
+      },
+      {
+        "run": 94,
+        "seed": 3823494835,
+        "success": true,
+        "steps": 181,
+        "total_reward": 37.67500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.450803137780692
+      },
+      {
+        "run": 95,
+        "seed": 3823494836,
+        "success": true,
+        "steps": 238,
+        "total_reward": 38.40000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36905573823732396
+      },
+      {
+        "run": 96,
+        "seed": 3823494837,
+        "success": true,
+        "steps": 150,
+        "total_reward": 31.730000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4809049773755656
+      },
+      {
+        "run": 97,
+        "seed": 3823494838,
+        "success": true,
+        "steps": 195,
+        "total_reward": 33.20500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36304358737957265
+      },
+      {
+        "run": 98,
+        "seed": 3823494839,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.93500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44093795093795096
+      },
+      {
+        "run": 99,
+        "seed": 3823494840,
+        "success": true,
+        "steps": 204,
+        "total_reward": 48.88000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5154720028797728
+      },
+      {
+        "run": 100,
+        "seed": 3823494841,
+        "success": true,
+        "steps": 260,
+        "total_reward": 38.160000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34259557970764865
+      },
+      {
+        "run": 101,
+        "seed": 3823494842,
+        "success": true,
+        "steps": 188,
+        "total_reward": 35.38000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4215294583277929
+      },
+      {
+        "run": 102,
+        "seed": 3823494843,
+        "success": true,
+        "steps": 244,
+        "total_reward": 39.430000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36537921434886034
+      },
+      {
+        "run": 103,
+        "seed": 3823494844,
+        "success": true,
+        "steps": 210,
+        "total_reward": 36.08000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4487457946668473
+      },
+      {
+        "run": 104,
+        "seed": 3823494845,
+        "success": true,
+        "steps": 211,
+        "total_reward": 39.635000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4020831342570473
+      },
+      {
+        "run": 105,
+        "seed": 3823494846,
+        "success": true,
+        "steps": 204,
+        "total_reward": 34.600000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.411486648206977
+      },
+      {
+        "run": 106,
+        "seed": 3823494847,
+        "success": true,
+        "steps": 180,
+        "total_reward": 36.8100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4792606259895263
+      },
+      {
+        "run": 107,
+        "seed": 3823494848,
+        "success": true,
+        "steps": 242,
+        "total_reward": 40.31000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.388003663003663
+      },
+      {
+        "run": 108,
+        "seed": 3823494849,
+        "success": true,
+        "steps": 164,
+        "total_reward": 38.02000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5231363703376087
+      },
+      {
+        "run": 109,
+        "seed": 3823494850,
+        "success": true,
+        "steps": 200,
+        "total_reward": 34.51000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45848873933084455
+      },
+      {
+        "run": 110,
+        "seed": 3823494851,
+        "success": true,
+        "steps": 166,
+        "total_reward": 32.02000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4456260955995301
+      },
+      {
+        "run": 111,
+        "seed": 3823494852,
+        "success": true,
+        "steps": 200,
+        "total_reward": 33.760000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5130741943241943
+      },
+      {
+        "run": 112,
+        "seed": 3823494853,
+        "success": true,
+        "steps": 196,
+        "total_reward": 39.250000000000036,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42994634390750963
+      },
+      {
+        "run": 113,
+        "seed": 3823494854,
+        "success": true,
+        "steps": 235,
+        "total_reward": 31.23500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31688199130304395
+      },
+      {
+        "run": 114,
+        "seed": 3823494855,
+        "success": true,
+        "steps": 189,
+        "total_reward": 35.48500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43385343105170693
+      },
+      {
+        "run": 115,
+        "seed": 3823494856,
+        "success": true,
+        "steps": 177,
+        "total_reward": 32.525000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40960391756730424
+      },
+      {
+        "run": 116,
+        "seed": 3823494857,
+        "success": true,
+        "steps": 140,
+        "total_reward": 32.58000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5577545787545788
+      },
+      {
+        "run": 117,
+        "seed": 3823494858,
+        "success": true,
+        "steps": 214,
+        "total_reward": 31.52000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3729567382508559
+      },
+      {
+        "run": 118,
+        "seed": 3823494859,
+        "success": true,
+        "steps": 191,
+        "total_reward": 38.42500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5350926146436982
+      },
+      {
+        "run": 119,
+        "seed": 3823494860,
+        "success": true,
+        "steps": 215,
+        "total_reward": 38.9250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38090590781767253
+      },
+      {
+        "run": 120,
+        "seed": 3823494861,
+        "success": true,
+        "steps": 208,
+        "total_reward": 34.420000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35684824434824436
+      },
+      {
+        "run": 121,
+        "seed": 3823494862,
+        "success": true,
+        "steps": 150,
+        "total_reward": 32.50000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48802652026336235
+      },
+      {
+        "run": 122,
+        "seed": 3823494863,
+        "success": true,
+        "steps": 258,
+        "total_reward": 38.80000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3346579853428209
+      },
+      {
+        "run": 123,
+        "seed": 3823494864,
+        "success": true,
+        "steps": 200,
+        "total_reward": 40.390000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4545285878196629
+      },
+      {
+        "run": 124,
+        "seed": 3823494865,
+        "success": true,
+        "steps": 193,
+        "total_reward": 40.74500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45938303138640474
+      },
+      {
+        "run": 125,
+        "seed": 3823494866,
+        "success": true,
+        "steps": 205,
+        "total_reward": 27.25500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33382363132363135
+      },
+      {
+        "run": 126,
+        "seed": 3823494867,
+        "success": true,
+        "steps": 175,
+        "total_reward": 35.50500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4767549786287927
+      },
+      {
+        "run": 127,
+        "seed": 3823494868,
+        "success": true,
+        "steps": 209,
+        "total_reward": 32.89500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39975632054763965
+      },
+      {
+        "run": 128,
+        "seed": 3823494869,
+        "success": true,
+        "steps": 235,
+        "total_reward": 25.935000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23468314481217706
+      },
+      {
+        "run": 129,
+        "seed": 3823494870,
+        "success": true,
+        "steps": 204,
+        "total_reward": 33.56000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37880166193959297
+      },
+      {
+        "run": 130,
+        "seed": 3823494871,
+        "success": true,
+        "steps": 201,
+        "total_reward": 36.365000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3856233165811171
+      },
+      {
+        "run": 131,
+        "seed": 3823494872,
+        "success": true,
+        "steps": 201,
+        "total_reward": 32.35500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33585509829755356
+      },
+      {
+        "run": 132,
+        "seed": 3823494873,
+        "success": true,
+        "steps": 158,
+        "total_reward": 34.97000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5275990990990991
+      },
+      {
+        "run": 133,
+        "seed": 3823494874,
+        "success": true,
+        "steps": 209,
+        "total_reward": 30.355000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3614333412985531
+      },
+      {
+        "run": 134,
+        "seed": 3823494875,
+        "success": true,
+        "steps": 190,
+        "total_reward": 33.17000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45328833441736666
+      },
+      {
+        "run": 135,
+        "seed": 3823494876,
+        "success": true,
+        "steps": 169,
+        "total_reward": 37.73500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5139495798319327
+      },
+      {
+        "run": 136,
+        "seed": 3823494877,
+        "success": true,
+        "steps": 233,
+        "total_reward": 36.985000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36200752254528
+      },
+      {
+        "run": 137,
+        "seed": 3823494878,
+        "success": true,
+        "steps": 194,
+        "total_reward": 34.91000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40033248883077255
+      },
+      {
+        "run": 138,
+        "seed": 3823494879,
+        "success": true,
+        "steps": 237,
+        "total_reward": 30.23500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3460781415859487
+      },
+      {
+        "run": 139,
+        "seed": 3823494880,
+        "success": true,
+        "steps": 141,
+        "total_reward": 40.0050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6473813014942047
+      },
+      {
+        "run": 140,
+        "seed": 3823494881,
+        "success": true,
+        "steps": 178,
+        "total_reward": 29.210000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37364468864468864
+      },
+      {
+        "run": 141,
+        "seed": 3823494882,
+        "success": true,
+        "steps": 141,
+        "total_reward": 31.205000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5417500000000001
+      },
+      {
+        "run": 142,
+        "seed": 3823494883,
+        "success": true,
+        "steps": 208,
+        "total_reward": 32.47000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4516478987168642
+      },
+      {
+        "run": 143,
+        "seed": 3823494884,
+        "success": true,
+        "steps": 193,
+        "total_reward": 30.94500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41136959055437317
+      },
+      {
+        "run": 144,
+        "seed": 3823494885,
+        "success": true,
+        "steps": 207,
+        "total_reward": 29.865000000000123,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.363633658008658
+      },
+      {
+        "run": 145,
+        "seed": 3823494886,
+        "success": true,
+        "steps": 168,
+        "total_reward": 40.37000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5633663327413327
+      },
+      {
+        "run": 146,
+        "seed": 3823494887,
+        "success": true,
+        "steps": 243,
+        "total_reward": 26.58500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31473149785649784
+      },
+      {
+        "run": 147,
+        "seed": 3823494888,
+        "success": true,
+        "steps": 201,
+        "total_reward": 30.495000000000132,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3921222891241866
+      },
+      {
+        "run": 148,
+        "seed": 3823494889,
+        "success": true,
+        "steps": 182,
+        "total_reward": 35.9400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45442328286406247
+      },
+      {
+        "run": 149,
+        "seed": 3823494890,
+        "success": true,
+        "steps": 152,
+        "total_reward": 35.8200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5572405817081274
+      },
+      {
+        "run": 150,
+        "seed": 3823494891,
+        "success": true,
+        "steps": 161,
+        "total_reward": 30.44500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48927843406745836
+      },
+      {
+        "run": 151,
+        "seed": 3823494892,
+        "success": true,
+        "steps": 245,
+        "total_reward": 38.75500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3882480761691288
+      },
+      {
+        "run": 152,
+        "seed": 3823494893,
+        "success": true,
+        "steps": 198,
+        "total_reward": 33.200000000000166,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48091492319254153
+      },
+      {
+        "run": 153,
+        "seed": 3823494894,
+        "success": true,
+        "steps": 193,
+        "total_reward": 33.785000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4643571637503657
+      },
+      {
+        "run": 154,
+        "seed": 3823494895,
+        "success": true,
+        "steps": 207,
+        "total_reward": 34.605000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.394435528924693
+      },
+      {
+        "run": 155,
+        "seed": 3823494896,
+        "success": true,
+        "steps": 223,
+        "total_reward": 32.43500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3722913305790544
+      },
+      {
+        "run": 156,
+        "seed": 3823494897,
+        "success": true,
+        "steps": 204,
+        "total_reward": 31.690000000000133,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35336060086060084
+      },
+      {
+        "run": 157,
+        "seed": 3823494898,
+        "success": true,
+        "steps": 210,
+        "total_reward": 31.33000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35154769914495315
+      },
+      {
+        "run": 158,
+        "seed": 3823494899,
+        "success": true,
+        "steps": 249,
+        "total_reward": 37.985000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37759772528050983
+      },
+      {
+        "run": 159,
+        "seed": 3823494900,
+        "success": true,
+        "steps": 262,
+        "total_reward": 34.86000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32341706550868043
+      },
+      {
+        "run": 160,
+        "seed": 3823494901,
+        "success": true,
+        "steps": 185,
+        "total_reward": 34.42500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44182228446934324
+      },
+      {
+        "run": 161,
+        "seed": 3823494902,
+        "success": true,
+        "steps": 181,
+        "total_reward": 37.06500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46957219960815283
+      },
+      {
+        "run": 162,
+        "seed": 3823494903,
+        "success": true,
+        "steps": 196,
+        "total_reward": 35.41000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41455133669967426
+      },
+      {
+        "run": 163,
+        "seed": 3823494904,
+        "success": true,
+        "steps": 186,
+        "total_reward": 35.01000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40968099224882487
+      },
+      {
+        "run": 164,
+        "seed": 3823494905,
+        "success": true,
+        "steps": 226,
+        "total_reward": 29.190000000000143,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38679846651886124
+      },
+      {
+        "run": 165,
+        "seed": 3823494906,
+        "success": true,
+        "steps": 206,
+        "total_reward": 33.43000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.391599030255377
+      },
+      {
+        "run": 166,
+        "seed": 3823494907,
+        "success": true,
+        "steps": 184,
+        "total_reward": 36.2300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44960690045248863
+      },
+      {
+        "run": 167,
+        "seed": 3823494908,
+        "success": true,
+        "steps": 234,
+        "total_reward": 36.46000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3615951640951641
+      },
+      {
+        "run": 168,
+        "seed": 3823494909,
+        "success": true,
+        "steps": 162,
+        "total_reward": 30.59000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47061056998556994
+      },
+      {
+        "run": 169,
+        "seed": 3823494910,
+        "success": true,
+        "steps": 222,
+        "total_reward": 38.680000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3701875510030675
+      },
+      {
+        "run": 170,
+        "seed": 3823494911,
+        "success": true,
+        "steps": 220,
+        "total_reward": 35.71000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38350863080274844
+      },
+      {
+        "run": 171,
+        "seed": 3823494912,
+        "success": true,
+        "steps": 159,
+        "total_reward": 36.195000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5094378170848759
+      },
+      {
+        "run": 172,
+        "seed": 3823494913,
+        "success": true,
+        "steps": 185,
+        "total_reward": 45.58500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.506496310706837
+      },
+      {
+        "run": 173,
+        "seed": 3823494914,
+        "success": true,
+        "steps": 252,
+        "total_reward": 32.720000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3404712987568369
+      },
+      {
+        "run": 174,
+        "seed": 3823494915,
+        "success": true,
+        "steps": 160,
+        "total_reward": 32.31000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5408742013001648
+      },
+      {
+        "run": 175,
+        "seed": 3823494916,
+        "success": true,
+        "steps": 300,
+        "total_reward": 40.290000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30201402408309425
+      },
+      {
+        "run": 176,
+        "seed": 3823494917,
+        "success": true,
+        "steps": 137,
+        "total_reward": 31.245000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5483183483183482
+      },
+      {
+        "run": 177,
+        "seed": 3823494918,
+        "success": true,
+        "steps": 151,
+        "total_reward": 30.19500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5286069917877698
+      },
+      {
+        "run": 178,
+        "seed": 3823494919,
+        "success": true,
+        "steps": 294,
+        "total_reward": 44.73999999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34890565278055863
+      },
+      {
+        "run": 179,
+        "seed": 3823494920,
+        "success": true,
+        "steps": 207,
+        "total_reward": 34.77500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44617624350092794
+      },
+      {
+        "run": 180,
+        "seed": 3823494921,
+        "success": true,
+        "steps": 242,
+        "total_reward": 40.210000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38900624317262517
+      },
+      {
+        "run": 181,
+        "seed": 3823494922,
+        "success": true,
+        "steps": 192,
+        "total_reward": 36.720000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48536941089139596
+      },
+      {
+        "run": 182,
+        "seed": 3823494923,
+        "success": true,
+        "steps": 245,
+        "total_reward": 38.615000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.439338956063094
+      },
+      {
+        "run": 183,
+        "seed": 3823494924,
+        "success": true,
+        "steps": 245,
+        "total_reward": 44.26500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49322590735897187
+      },
+      {
+        "run": 184,
+        "seed": 3823494925,
+        "success": true,
+        "steps": 214,
+        "total_reward": 42.62000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45638492846531326
+      },
+      {
+        "run": 185,
+        "seed": 3823494926,
+        "success": true,
+        "steps": 229,
+        "total_reward": 38.155000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.396131993006993
+      },
+      {
+        "run": 186,
+        "seed": 3823494927,
+        "success": true,
+        "steps": 164,
+        "total_reward": 33.24000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44310037280289
+      },
+      {
+        "run": 187,
+        "seed": 3823494928,
+        "success": true,
+        "steps": 220,
+        "total_reward": 31.4800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3743191406490639
+      },
+      {
+        "run": 188,
+        "seed": 3823494929,
+        "success": true,
+        "steps": 179,
+        "total_reward": 35.785000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.561007326007326
+      },
+      {
+        "run": 189,
+        "seed": 3823494930,
+        "success": true,
+        "steps": 199,
+        "total_reward": 40.015000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47949134199134197
+      },
+      {
+        "run": 190,
+        "seed": 3823494931,
+        "success": true,
+        "steps": 192,
+        "total_reward": 26.350000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44575963718820866
+      },
+      {
+        "run": 191,
+        "seed": 3823494932,
+        "success": true,
+        "steps": 188,
+        "total_reward": 31.35000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3920753320753321
+      },
+      {
+        "run": 192,
+        "seed": 3823494933,
+        "success": true,
+        "steps": 196,
+        "total_reward": 35.57000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3989451832830911
+      },
+      {
+        "run": 193,
+        "seed": 3823494934,
+        "success": true,
+        "steps": 246,
+        "total_reward": 35.80000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3192078285181733
+      },
+      {
+        "run": 194,
+        "seed": 3823494935,
+        "success": true,
+        "steps": 216,
+        "total_reward": 36.54000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4860894057633188
+      },
+      {
+        "run": 195,
+        "seed": 3823494936,
+        "success": true,
+        "steps": 232,
+        "total_reward": 38.53000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4195873232458598
+      },
+      {
+        "run": 196,
+        "seed": 3823494937,
+        "success": true,
+        "steps": 187,
+        "total_reward": 32.32500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4193812279338595
+      },
+      {
+        "run": 197,
+        "seed": 3823494938,
+        "success": true,
+        "steps": 226,
+        "total_reward": 33.02000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3844340854924379
+      },
+      {
+        "run": 198,
+        "seed": 3823494939,
+        "success": true,
+        "steps": 170,
+        "total_reward": 31.06000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43386293642125284
+      },
+      {
+        "run": 199,
+        "seed": 3823494940,
+        "success": true,
+        "steps": 183,
+        "total_reward": 40.86500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4508958432871476
+      },
+      {
+        "run": 200,
+        "seed": 3823494941,
+        "success": true,
+        "steps": 211,
+        "total_reward": 40.935000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5183561634376852
+      }
+    ],
+    "avg_chemotaxis_index": 0.4033055862576482,
+    "avg_time_in_attractant": 0.701652793128824,
+    "avg_approach_frequency": 0.4210948735499182,
+    "avg_path_efficiency": 0.045519981765098506,
+    "post_convergence_chemotaxis_index": 0.41442468403949934,
+    "post_convergence_time_in_attractant": 0.7072123420197497,
+    "post_convergence_approach_frequency": 0.4255861045631672,
+    "post_convergence_path_efficiency": 0.04701842557881611,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_093727.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_093727.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_093727",
+  "timestamp": "2025-12-29T09:48:03.244535+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_093727",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.925,
+    "avg_steps": 240.495,
+    "avg_reward": 33.913225000000104,
+    "avg_foods_collected": 9.465,
+    "avg_distance_efficiency": 0.367917970429223,
+    "completed_all_food": 185,
+    "starved": 14,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 21,
+    "runs_to_convergence": 20,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 230.89444444444445,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.3901473101328095,
+    "composite_benchmark_score": 0.7970441930398429,
+    "learning_speed": 0.885,
+    "learning_speed_episodes": 23,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 48887489,
+        "success": false,
+        "steps": 200,
+        "total_reward": -7.969999999999994,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 48887490,
+        "success": false,
+        "steps": 240,
+        "total_reward": -3.480000000000002,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.10126582278481013
+      },
+      {
+        "run": 3,
+        "seed": 48887491,
+        "success": false,
+        "steps": 200,
+        "total_reward": -5.6099999999999985,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 48887492,
+        "success": false,
+        "steps": 240,
+        "total_reward": -4.519999999999994,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.030612244897959183
+      },
+      {
+        "run": 5,
+        "seed": 48887493,
+        "success": false,
+        "steps": 238,
+        "total_reward": -1.2400000000000038,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.21052631578947367
+      },
+      {
+        "run": 6,
+        "seed": 48887494,
+        "success": false,
+        "steps": 271,
+        "total_reward": -1.3550000000000182,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.15915273999222695
+      },
+      {
+        "run": 7,
+        "seed": 48887495,
+        "success": false,
+        "steps": 240,
+        "total_reward": -3.3399999999999954,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.04591836734693878
+      },
+      {
+        "run": 8,
+        "seed": 48887496,
+        "success": false,
+        "steps": 500,
+        "total_reward": 34.70000000000006,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.16556249620308885
+      },
+      {
+        "run": 9,
+        "seed": 48887497,
+        "success": false,
+        "steps": 257,
+        "total_reward": 2.9049999999999496,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.19582542694497154
+      },
+      {
+        "run": 10,
+        "seed": 48887498,
+        "success": false,
+        "steps": 240,
+        "total_reward": -3.1700000000000026,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.17073170731707318
+      },
+      {
+        "run": 11,
+        "seed": 48887499,
+        "success": false,
+        "steps": 440,
+        "total_reward": 10.770000000000145,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.16179230496810287
+      },
+      {
+        "run": 12,
+        "seed": 48887500,
+        "success": false,
+        "steps": 280,
+        "total_reward": 2.3299999999999805,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.09060049722700325
+      },
+      {
+        "run": 13,
+        "seed": 48887501,
+        "success": false,
+        "steps": 445,
+        "total_reward": 18.885000000000282,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.21087933258338393
+      },
+      {
+        "run": 14,
+        "seed": 48887502,
+        "success": true,
+        "steps": 390,
+        "total_reward": 36.96000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24315342352469557
+      },
+      {
+        "run": 15,
+        "seed": 48887503,
+        "success": false,
+        "steps": 310,
+        "total_reward": 8.090000000000039,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.228696196332372
+      },
+      {
+        "run": 16,
+        "seed": 48887504,
+        "success": true,
+        "steps": 368,
+        "total_reward": 38.84000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3010346889206953
+      },
+      {
+        "run": 17,
+        "seed": 48887505,
+        "success": true,
+        "steps": 341,
+        "total_reward": 35.11500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29094466448987316
+      },
+      {
+        "run": 18,
+        "seed": 48887506,
+        "success": true,
+        "steps": 375,
+        "total_reward": 40.35500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29477706044108454
+      },
+      {
+        "run": 19,
+        "seed": 48887507,
+        "success": true,
+        "steps": 468,
+        "total_reward": 34.40000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2675844651699161
+      },
+      {
+        "run": 20,
+        "seed": 48887508,
+        "success": false,
+        "steps": 495,
+        "total_reward": 21.285000000000345,
+        "termination_reason": "starved",
+        "foods_collected": 8,
+        "distance_efficiency": 0.18802050700522877
+      },
+      {
+        "run": 21,
+        "seed": 48887509,
+        "success": true,
+        "steps": 382,
+        "total_reward": 36.38000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20682313236299305
+      },
+      {
+        "run": 22,
+        "seed": 48887510,
+        "success": true,
+        "steps": 305,
+        "total_reward": 36.24500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2794531144402633
+      },
+      {
+        "run": 23,
+        "seed": 48887511,
+        "success": true,
+        "steps": 243,
+        "total_reward": 36.42500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36705710265844643
+      },
+      {
+        "run": 24,
+        "seed": 48887512,
+        "success": true,
+        "steps": 348,
+        "total_reward": 38.98999999999997,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26827385872082277
+      },
+      {
+        "run": 25,
+        "seed": 48887513,
+        "success": true,
+        "steps": 324,
+        "total_reward": 39.31000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2859758645472931
+      },
+      {
+        "run": 26,
+        "seed": 48887514,
+        "success": true,
+        "steps": 272,
+        "total_reward": 41.66000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2945884734897985
+      },
+      {
+        "run": 27,
+        "seed": 48887515,
+        "success": true,
+        "steps": 202,
+        "total_reward": 29.140000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3443107891919437
+      },
+      {
+        "run": 28,
+        "seed": 48887516,
+        "success": true,
+        "steps": 319,
+        "total_reward": 39.325000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33272658590366144
+      },
+      {
+        "run": 29,
+        "seed": 48887517,
+        "success": true,
+        "steps": 257,
+        "total_reward": 34.38500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40869920189142156
+      },
+      {
+        "run": 30,
+        "seed": 48887518,
+        "success": true,
+        "steps": 255,
+        "total_reward": 34.81500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3382888976348729
+      },
+      {
+        "run": 31,
+        "seed": 48887519,
+        "success": true,
+        "steps": 199,
+        "total_reward": 27.355000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42043831168831164
+      },
+      {
+        "run": 32,
+        "seed": 48887520,
+        "success": true,
+        "steps": 189,
+        "total_reward": 31.46500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3993666511574481
+      },
+      {
+        "run": 33,
+        "seed": 48887521,
+        "success": true,
+        "steps": 291,
+        "total_reward": 42.674999999999976,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3593606691976257
+      },
+      {
+        "run": 34,
+        "seed": 48887522,
+        "success": true,
+        "steps": 291,
+        "total_reward": 38.21500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2729472561090126
+      },
+      {
+        "run": 35,
+        "seed": 48887523,
+        "success": true,
+        "steps": 248,
+        "total_reward": 45.420000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4019664975547329
+      },
+      {
+        "run": 36,
+        "seed": 48887524,
+        "success": true,
+        "steps": 212,
+        "total_reward": 31.32000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41539830912814785
+      },
+      {
+        "run": 37,
+        "seed": 48887525,
+        "success": true,
+        "steps": 204,
+        "total_reward": 33.98000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.426975886686413
+      },
+      {
+        "run": 38,
+        "seed": 48887526,
+        "success": true,
+        "steps": 253,
+        "total_reward": 43.7250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39128564418038103
+      },
+      {
+        "run": 39,
+        "seed": 48887527,
+        "success": true,
+        "steps": 248,
+        "total_reward": 31.280000000000147,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3586454106696867
+      },
+      {
+        "run": 40,
+        "seed": 48887528,
+        "success": true,
+        "steps": 209,
+        "total_reward": 34.08500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3933972669842235
+      },
+      {
+        "run": 41,
+        "seed": 48887529,
+        "success": true,
+        "steps": 309,
+        "total_reward": 39.18500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3473245107097397
+      },
+      {
+        "run": 42,
+        "seed": 48887530,
+        "success": true,
+        "steps": 177,
+        "total_reward": 37.54500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46703490953490956
+      },
+      {
+        "run": 43,
+        "seed": 48887531,
+        "success": true,
+        "steps": 228,
+        "total_reward": 38.6300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3931537971028384
+      },
+      {
+        "run": 44,
+        "seed": 48887532,
+        "success": true,
+        "steps": 255,
+        "total_reward": 38.28500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35353269583695546
+      },
+      {
+        "run": 45,
+        "seed": 48887533,
+        "success": true,
+        "steps": 187,
+        "total_reward": 36.76500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46029366332592137
+      },
+      {
+        "run": 46,
+        "seed": 48887534,
+        "success": true,
+        "steps": 243,
+        "total_reward": 43.6450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4283053379352791
+      },
+      {
+        "run": 47,
+        "seed": 48887535,
+        "success": true,
+        "steps": 195,
+        "total_reward": 31.465000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41536659749732757
+      },
+      {
+        "run": 48,
+        "seed": 48887536,
+        "success": true,
+        "steps": 278,
+        "total_reward": 34.020000000000195,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3263791763791764
+      },
+      {
+        "run": 49,
+        "seed": 48887537,
+        "success": true,
+        "steps": 232,
+        "total_reward": 34.68000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35297930531569355
+      },
+      {
+        "run": 50,
+        "seed": 48887538,
+        "success": true,
+        "steps": 244,
+        "total_reward": 37.990000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38630628591220234
+      },
+      {
+        "run": 51,
+        "seed": 48887539,
+        "success": true,
+        "steps": 252,
+        "total_reward": 36.260000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4092966677921187
+      },
+      {
+        "run": 52,
+        "seed": 48887540,
+        "success": true,
+        "steps": 251,
+        "total_reward": 41.58500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4123019650837817
+      },
+      {
+        "run": 53,
+        "seed": 48887541,
+        "success": true,
+        "steps": 241,
+        "total_reward": 31.295000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3058655000394131
+      },
+      {
+        "run": 54,
+        "seed": 48887542,
+        "success": true,
+        "steps": 188,
+        "total_reward": 38.90000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4620177643707056
+      },
+      {
+        "run": 55,
+        "seed": 48887543,
+        "success": true,
+        "steps": 241,
+        "total_reward": 36.53500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38571967319449707
+      },
+      {
+        "run": 56,
+        "seed": 48887544,
+        "success": true,
+        "steps": 207,
+        "total_reward": 32.9750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4568238778765094
+      },
+      {
+        "run": 57,
+        "seed": 48887545,
+        "success": true,
+        "steps": 223,
+        "total_reward": 35.57500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38727654560034425
+      },
+      {
+        "run": 58,
+        "seed": 48887546,
+        "success": true,
+        "steps": 320,
+        "total_reward": 31.84000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31881040038767483
+      },
+      {
+        "run": 59,
+        "seed": 48887547,
+        "success": true,
+        "steps": 209,
+        "total_reward": 34.42500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4430885780885781
+      },
+      {
+        "run": 60,
+        "seed": 48887548,
+        "success": true,
+        "steps": 224,
+        "total_reward": 37.900000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46836483578938826
+      },
+      {
+        "run": 61,
+        "seed": 48887549,
+        "success": true,
+        "steps": 253,
+        "total_reward": 38.51500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31376145873362427
+      },
+      {
+        "run": 62,
+        "seed": 48887550,
+        "success": true,
+        "steps": 268,
+        "total_reward": 42.520000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3490637254901961
+      },
+      {
+        "run": 63,
+        "seed": 48887551,
+        "success": true,
+        "steps": 224,
+        "total_reward": 33.85000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40707995951417003
+      },
+      {
+        "run": 64,
+        "seed": 48887552,
+        "success": true,
+        "steps": 308,
+        "total_reward": 42.78000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32576515963711083
+      },
+      {
+        "run": 65,
+        "seed": 48887553,
+        "success": true,
+        "steps": 179,
+        "total_reward": 37.36500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47132070372008456
+      },
+      {
+        "run": 66,
+        "seed": 48887554,
+        "success": true,
+        "steps": 255,
+        "total_reward": 32.46500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3070124039689257
+      },
+      {
+        "run": 67,
+        "seed": 48887555,
+        "success": true,
+        "steps": 220,
+        "total_reward": 37.85000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4081322011322011
+      },
+      {
+        "run": 68,
+        "seed": 48887556,
+        "success": true,
+        "steps": 185,
+        "total_reward": 34.3150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40371790490211545
+      },
+      {
+        "run": 69,
+        "seed": 48887557,
+        "success": true,
+        "steps": 263,
+        "total_reward": 39.985000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3396053507895613
+      },
+      {
+        "run": 70,
+        "seed": 48887558,
+        "success": true,
+        "steps": 241,
+        "total_reward": 43.89500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4049652622281933
+      },
+      {
+        "run": 71,
+        "seed": 48887559,
+        "success": true,
+        "steps": 259,
+        "total_reward": 30.74500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3141555762245417
+      },
+      {
+        "run": 72,
+        "seed": 48887560,
+        "success": true,
+        "steps": 214,
+        "total_reward": 33.640000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38419429649465947
+      },
+      {
+        "run": 73,
+        "seed": 48887561,
+        "success": true,
+        "steps": 234,
+        "total_reward": 37.730000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35816450497381525
+      },
+      {
+        "run": 74,
+        "seed": 48887562,
+        "success": true,
+        "steps": 260,
+        "total_reward": 37.94000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3257300144201319
+      },
+      {
+        "run": 75,
+        "seed": 48887563,
+        "success": true,
+        "steps": 198,
+        "total_reward": 29.880000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.365833724239297
+      },
+      {
+        "run": 76,
+        "seed": 48887564,
+        "success": true,
+        "steps": 232,
+        "total_reward": 39.860000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4562606186617038
+      },
+      {
+        "run": 77,
+        "seed": 48887565,
+        "success": true,
+        "steps": 253,
+        "total_reward": 39.06500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40969295530522276
+      },
+      {
+        "run": 78,
+        "seed": 48887566,
+        "success": true,
+        "steps": 190,
+        "total_reward": 25.080000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4013566404078738
+      },
+      {
+        "run": 79,
+        "seed": 48887567,
+        "success": true,
+        "steps": 255,
+        "total_reward": 41.87500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3412742589961203
+      },
+      {
+        "run": 80,
+        "seed": 48887568,
+        "success": true,
+        "steps": 247,
+        "total_reward": 42.67500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39545262145262144
+      },
+      {
+        "run": 81,
+        "seed": 48887569,
+        "success": true,
+        "steps": 221,
+        "total_reward": 41.18500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5512287581699347
+      },
+      {
+        "run": 82,
+        "seed": 48887570,
+        "success": true,
+        "steps": 196,
+        "total_reward": 34.33000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3850729147013977
+      },
+      {
+        "run": 83,
+        "seed": 48887571,
+        "success": true,
+        "steps": 226,
+        "total_reward": 35.3400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40882130084257745
+      },
+      {
+        "run": 84,
+        "seed": 48887572,
+        "success": true,
+        "steps": 239,
+        "total_reward": 35.21500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33245353565907104
+      },
+      {
+        "run": 85,
+        "seed": 48887573,
+        "success": true,
+        "steps": 210,
+        "total_reward": 40.8600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4075213531004481
+      },
+      {
+        "run": 86,
+        "seed": 48887574,
+        "success": true,
+        "steps": 230,
+        "total_reward": 33.01000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3498826484957992
+      },
+      {
+        "run": 87,
+        "seed": 48887575,
+        "success": true,
+        "steps": 193,
+        "total_reward": 35.02500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38945533149894207
+      },
+      {
+        "run": 88,
+        "seed": 48887576,
+        "success": true,
+        "steps": 271,
+        "total_reward": 35.9350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3125193157546796
+      },
+      {
+        "run": 89,
+        "seed": 48887577,
+        "success": true,
+        "steps": 261,
+        "total_reward": 37.335000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3267330899050824
+      },
+      {
+        "run": 90,
+        "seed": 48887578,
+        "success": true,
+        "steps": 215,
+        "total_reward": 33.6550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43698601077858046
+      },
+      {
+        "run": 91,
+        "seed": 48887579,
+        "success": true,
+        "steps": 204,
+        "total_reward": 36.580000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49574749163879595
+      },
+      {
+        "run": 92,
+        "seed": 48887580,
+        "success": true,
+        "steps": 236,
+        "total_reward": 40.630000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42987470557543805
+      },
+      {
+        "run": 93,
+        "seed": 48887581,
+        "success": true,
+        "steps": 198,
+        "total_reward": 35.820000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4247972739820566
+      },
+      {
+        "run": 94,
+        "seed": 48887582,
+        "success": true,
+        "steps": 169,
+        "total_reward": 38.605000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5132760757760757
+      },
+      {
+        "run": 95,
+        "seed": 48887583,
+        "success": true,
+        "steps": 289,
+        "total_reward": 33.30500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30266455841052614
+      },
+      {
+        "run": 96,
+        "seed": 48887584,
+        "success": true,
+        "steps": 203,
+        "total_reward": 32.70500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4319702507486807
+      },
+      {
+        "run": 97,
+        "seed": 48887585,
+        "success": true,
+        "steps": 187,
+        "total_reward": 37.975000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4560720086491643
+      },
+      {
+        "run": 98,
+        "seed": 48887586,
+        "success": true,
+        "steps": 314,
+        "total_reward": 43.540000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34643445185848243
+      },
+      {
+        "run": 99,
+        "seed": 48887587,
+        "success": true,
+        "steps": 196,
+        "total_reward": 37.130000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4139376456876457
+      },
+      {
+        "run": 100,
+        "seed": 48887588,
+        "success": true,
+        "steps": 230,
+        "total_reward": 35.06000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32201725012120563
+      },
+      {
+        "run": 101,
+        "seed": 48887589,
+        "success": true,
+        "steps": 153,
+        "total_reward": 34.9150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4953960819595495
+      },
+      {
+        "run": 102,
+        "seed": 48887590,
+        "success": true,
+        "steps": 291,
+        "total_reward": 36.99500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27504923111827123
+      },
+      {
+        "run": 103,
+        "seed": 48887591,
+        "success": true,
+        "steps": 149,
+        "total_reward": 28.38500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.447798055058117
+      },
+      {
+        "run": 104,
+        "seed": 48887592,
+        "success": true,
+        "steps": 198,
+        "total_reward": 33.860000000000184,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4996046001928355
+      },
+      {
+        "run": 105,
+        "seed": 48887593,
+        "success": true,
+        "steps": 214,
+        "total_reward": 39.99000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43639073458840894
+      },
+      {
+        "run": 106,
+        "seed": 48887594,
+        "success": true,
+        "steps": 252,
+        "total_reward": 41.0,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40933742512743876
+      },
+      {
+        "run": 107,
+        "seed": 48887595,
+        "success": true,
+        "steps": 180,
+        "total_reward": 32.5600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42708568929820806
+      },
+      {
+        "run": 108,
+        "seed": 48887596,
+        "success": true,
+        "steps": 225,
+        "total_reward": 39.3150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38910853868480405
+      },
+      {
+        "run": 109,
+        "seed": 48887597,
+        "success": true,
+        "steps": 253,
+        "total_reward": 33.55500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3110819686575172
+      },
+      {
+        "run": 110,
+        "seed": 48887598,
+        "success": true,
+        "steps": 211,
+        "total_reward": 36.00500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45014820548102286
+      },
+      {
+        "run": 111,
+        "seed": 48887599,
+        "success": true,
+        "steps": 232,
+        "total_reward": 36.62000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.416538684439293
+      },
+      {
+        "run": 112,
+        "seed": 48887600,
+        "success": true,
+        "steps": 241,
+        "total_reward": 39.45500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3792768351359682
+      },
+      {
+        "run": 113,
+        "seed": 48887601,
+        "success": true,
+        "steps": 264,
+        "total_reward": 42.58000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39130244755244753
+      },
+      {
+        "run": 114,
+        "seed": 48887602,
+        "success": true,
+        "steps": 209,
+        "total_reward": 33.42500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45567827076548006
+      },
+      {
+        "run": 115,
+        "seed": 48887603,
+        "success": true,
+        "steps": 254,
+        "total_reward": 40.35000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38144004974299506
+      },
+      {
+        "run": 116,
+        "seed": 48887604,
+        "success": true,
+        "steps": 185,
+        "total_reward": 34.50500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40434692934692934
+      },
+      {
+        "run": 117,
+        "seed": 48887605,
+        "success": true,
+        "steps": 216,
+        "total_reward": 39.81000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3908392616043713
+      },
+      {
+        "run": 118,
+        "seed": 48887606,
+        "success": true,
+        "steps": 157,
+        "total_reward": 37.55500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5758594223811615
+      },
+      {
+        "run": 119,
+        "seed": 48887607,
+        "success": true,
+        "steps": 216,
+        "total_reward": 26.500000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2901464320666097
+      },
+      {
+        "run": 120,
+        "seed": 48887608,
+        "success": true,
+        "steps": 181,
+        "total_reward": 33.60500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4200291375291375
+      },
+      {
+        "run": 121,
+        "seed": 48887609,
+        "success": true,
+        "steps": 211,
+        "total_reward": 41.115000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47359943565206725
+      },
+      {
+        "run": 122,
+        "seed": 48887610,
+        "success": true,
+        "steps": 283,
+        "total_reward": 41.37500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3304950703708468
+      },
+      {
+        "run": 123,
+        "seed": 48887611,
+        "success": true,
+        "steps": 245,
+        "total_reward": 40.77500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39743684801224577
+      },
+      {
+        "run": 124,
+        "seed": 48887612,
+        "success": true,
+        "steps": 264,
+        "total_reward": 34.650000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3134299513186312
+      },
+      {
+        "run": 125,
+        "seed": 48887613,
+        "success": true,
+        "steps": 195,
+        "total_reward": 41.295000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4681481459657503
+      },
+      {
+        "run": 126,
+        "seed": 48887614,
+        "success": true,
+        "steps": 188,
+        "total_reward": 32.20000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4203837386018237
+      },
+      {
+        "run": 127,
+        "seed": 48887615,
+        "success": true,
+        "steps": 191,
+        "total_reward": 37.97500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4854334554334554
+      },
+      {
+        "run": 128,
+        "seed": 48887616,
+        "success": true,
+        "steps": 215,
+        "total_reward": 33.76500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3720398217766639
+      },
+      {
+        "run": 129,
+        "seed": 48887617,
+        "success": true,
+        "steps": 228,
+        "total_reward": 37.7500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3487477337477337
+      },
+      {
+        "run": 130,
+        "seed": 48887618,
+        "success": true,
+        "steps": 182,
+        "total_reward": 35.140000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48020678246484694
+      },
+      {
+        "run": 131,
+        "seed": 48887619,
+        "success": true,
+        "steps": 246,
+        "total_reward": 32.22000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3256236383096637
+      },
+      {
+        "run": 132,
+        "seed": 48887620,
+        "success": true,
+        "steps": 265,
+        "total_reward": 34.285000000000196,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3336544300785787
+      },
+      {
+        "run": 133,
+        "seed": 48887621,
+        "success": true,
+        "steps": 238,
+        "total_reward": 35.05000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39112145159812506
+      },
+      {
+        "run": 134,
+        "seed": 48887622,
+        "success": true,
+        "steps": 181,
+        "total_reward": 32.57500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41645360436664786
+      },
+      {
+        "run": 135,
+        "seed": 48887623,
+        "success": true,
+        "steps": 222,
+        "total_reward": 41.24000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40265549319368577
+      },
+      {
+        "run": 136,
+        "seed": 48887624,
+        "success": true,
+        "steps": 218,
+        "total_reward": 35.450000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40933021505745204
+      },
+      {
+        "run": 137,
+        "seed": 48887625,
+        "success": true,
+        "steps": 241,
+        "total_reward": 35.57500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4105940710894271
+      },
+      {
+        "run": 138,
+        "seed": 48887626,
+        "success": true,
+        "steps": 214,
+        "total_reward": 33.36000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3980233869519103
+      },
+      {
+        "run": 139,
+        "seed": 48887627,
+        "success": true,
+        "steps": 240,
+        "total_reward": 33.000000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3780761096256881
+      },
+      {
+        "run": 140,
+        "seed": 48887628,
+        "success": true,
+        "steps": 223,
+        "total_reward": 31.625000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45120835686053073
+      },
+      {
+        "run": 141,
+        "seed": 48887629,
+        "success": true,
+        "steps": 256,
+        "total_reward": 30.740000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3329589798301766
+      },
+      {
+        "run": 142,
+        "seed": 48887630,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.6450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44788733019328386
+      },
+      {
+        "run": 143,
+        "seed": 48887631,
+        "success": true,
+        "steps": 236,
+        "total_reward": 35.17000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36152759740259743
+      },
+      {
+        "run": 144,
+        "seed": 48887632,
+        "success": true,
+        "steps": 161,
+        "total_reward": 45.60500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5733101366972335
+      },
+      {
+        "run": 145,
+        "seed": 48887633,
+        "success": true,
+        "steps": 224,
+        "total_reward": 34.970000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38055128399322113
+      },
+      {
+        "run": 146,
+        "seed": 48887634,
+        "success": true,
+        "steps": 224,
+        "total_reward": 34.98000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33396985504757903
+      },
+      {
+        "run": 147,
+        "seed": 48887635,
+        "success": true,
+        "steps": 217,
+        "total_reward": 39.805000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4166089354402048
+      },
+      {
+        "run": 148,
+        "seed": 48887636,
+        "success": true,
+        "steps": 216,
+        "total_reward": 33.910000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3908198653198653
+      },
+      {
+        "run": 149,
+        "seed": 48887637,
+        "success": true,
+        "steps": 226,
+        "total_reward": 41.180000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5075923542947716
+      },
+      {
+        "run": 150,
+        "seed": 48887638,
+        "success": true,
+        "steps": 218,
+        "total_reward": 36.35000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38331922978981803
+      },
+      {
+        "run": 151,
+        "seed": 48887639,
+        "success": true,
+        "steps": 201,
+        "total_reward": 35.58500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43823953823953826
+      },
+      {
+        "run": 152,
+        "seed": 48887640,
+        "success": true,
+        "steps": 297,
+        "total_reward": 38.00500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3944416452883164
+      },
+      {
+        "run": 153,
+        "seed": 48887641,
+        "success": true,
+        "steps": 232,
+        "total_reward": 41.5000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4512068068334053
+      },
+      {
+        "run": 154,
+        "seed": 48887642,
+        "success": true,
+        "steps": 199,
+        "total_reward": 30.9650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3587710884262608
+      },
+      {
+        "run": 155,
+        "seed": 48887643,
+        "success": true,
+        "steps": 232,
+        "total_reward": 37.38000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3575220424810028
+      },
+      {
+        "run": 156,
+        "seed": 48887644,
+        "success": true,
+        "steps": 257,
+        "total_reward": 36.36500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3686685335302772
+      },
+      {
+        "run": 157,
+        "seed": 48887645,
+        "success": true,
+        "steps": 209,
+        "total_reward": 35.59500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3595120135394735
+      },
+      {
+        "run": 158,
+        "seed": 48887646,
+        "success": true,
+        "steps": 179,
+        "total_reward": 33.975000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47308404239438717
+      },
+      {
+        "run": 159,
+        "seed": 48887647,
+        "success": true,
+        "steps": 154,
+        "total_reward": 33.94000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5154239465384977
+      },
+      {
+        "run": 160,
+        "seed": 48887648,
+        "success": true,
+        "steps": 229,
+        "total_reward": 35.07500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3532822438939659
+      },
+      {
+        "run": 161,
+        "seed": 48887649,
+        "success": true,
+        "steps": 250,
+        "total_reward": 35.38000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.329791161629268
+      },
+      {
+        "run": 162,
+        "seed": 48887650,
+        "success": true,
+        "steps": 230,
+        "total_reward": 27.470000000000127,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34105494505494505
+      },
+      {
+        "run": 163,
+        "seed": 48887651,
+        "success": true,
+        "steps": 246,
+        "total_reward": 41.870000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4806709613341775
+      },
+      {
+        "run": 164,
+        "seed": 48887652,
+        "success": true,
+        "steps": 219,
+        "total_reward": 34.425000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36979903030406125
+      },
+      {
+        "run": 165,
+        "seed": 48887653,
+        "success": true,
+        "steps": 200,
+        "total_reward": 37.11000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42883406700511967
+      },
+      {
+        "run": 166,
+        "seed": 48887654,
+        "success": true,
+        "steps": 274,
+        "total_reward": 39.7100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3266141582063188
+      },
+      {
+        "run": 167,
+        "seed": 48887655,
+        "success": true,
+        "steps": 223,
+        "total_reward": 31.035000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4201592582655671
+      },
+      {
+        "run": 168,
+        "seed": 48887656,
+        "success": true,
+        "steps": 323,
+        "total_reward": 36.77500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2621981428738937
+      },
+      {
+        "run": 169,
+        "seed": 48887657,
+        "success": true,
+        "steps": 196,
+        "total_reward": 37.69000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4327648353911983
+      },
+      {
+        "run": 170,
+        "seed": 48887658,
+        "success": true,
+        "steps": 251,
+        "total_reward": 33.555000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31740990309284434
+      },
+      {
+        "run": 171,
+        "seed": 48887659,
+        "success": true,
+        "steps": 172,
+        "total_reward": 34.26000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.502038386674273
+      },
+      {
+        "run": 172,
+        "seed": 48887660,
+        "success": true,
+        "steps": 282,
+        "total_reward": 34.23000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34374706152723394
+      },
+      {
+        "run": 173,
+        "seed": 48887661,
+        "success": true,
+        "steps": 175,
+        "total_reward": 33.65500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5037639553429027
+      },
+      {
+        "run": 174,
+        "seed": 48887662,
+        "success": true,
+        "steps": 233,
+        "total_reward": 36.3950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34254270799557945
+      },
+      {
+        "run": 175,
+        "seed": 48887663,
+        "success": true,
+        "steps": 260,
+        "total_reward": 42.75000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3838800295230536
+      },
+      {
+        "run": 176,
+        "seed": 48887664,
+        "success": true,
+        "steps": 251,
+        "total_reward": 32.73500000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34903829909927475
+      },
+      {
+        "run": 177,
+        "seed": 48887665,
+        "success": true,
+        "steps": 177,
+        "total_reward": 35.90500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48462886962886964
+      },
+      {
+        "run": 178,
+        "seed": 48887666,
+        "success": true,
+        "steps": 171,
+        "total_reward": 33.30500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48232691346634377
+      },
+      {
+        "run": 179,
+        "seed": 48887667,
+        "success": true,
+        "steps": 204,
+        "total_reward": 36.9000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4206477889156711
+      },
+      {
+        "run": 180,
+        "seed": 48887668,
+        "success": true,
+        "steps": 278,
+        "total_reward": 42.66000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3595577444867506
+      },
+      {
+        "run": 181,
+        "seed": 48887669,
+        "success": true,
+        "steps": 229,
+        "total_reward": 34.8550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31498112889417235
+      },
+      {
+        "run": 182,
+        "seed": 48887670,
+        "success": true,
+        "steps": 272,
+        "total_reward": 42.50000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3750635629018652
+      },
+      {
+        "run": 183,
+        "seed": 48887671,
+        "success": true,
+        "steps": 232,
+        "total_reward": 37.280000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3332491898308157
+      },
+      {
+        "run": 184,
+        "seed": 48887672,
+        "success": true,
+        "steps": 266,
+        "total_reward": 39.40000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3201305459472016
+      },
+      {
+        "run": 185,
+        "seed": 48887673,
+        "success": true,
+        "steps": 273,
+        "total_reward": 28.935000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27465981033680525
+      },
+      {
+        "run": 186,
+        "seed": 48887674,
+        "success": true,
+        "steps": 212,
+        "total_reward": 39.9300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4228336156597027
+      },
+      {
+        "run": 187,
+        "seed": 48887675,
+        "success": true,
+        "steps": 200,
+        "total_reward": 34.25000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3995260879471406
+      },
+      {
+        "run": 188,
+        "seed": 48887676,
+        "success": true,
+        "steps": 204,
+        "total_reward": 38.38000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5328022983457765
+      },
+      {
+        "run": 189,
+        "seed": 48887677,
+        "success": true,
+        "steps": 203,
+        "total_reward": 33.5150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39618221579463
+      },
+      {
+        "run": 190,
+        "seed": 48887678,
+        "success": true,
+        "steps": 198,
+        "total_reward": 34.94000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3855877487471415
+      },
+      {
+        "run": 191,
+        "seed": 48887679,
+        "success": true,
+        "steps": 184,
+        "total_reward": 31.12000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3809626312144015
+      },
+      {
+        "run": 192,
+        "seed": 48887680,
+        "success": true,
+        "steps": 215,
+        "total_reward": 26.455000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38936594880867326
+      },
+      {
+        "run": 193,
+        "seed": 48887681,
+        "success": true,
+        "steps": 233,
+        "total_reward": 34.25500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.378965914496605
+      },
+      {
+        "run": 194,
+        "seed": 48887682,
+        "success": true,
+        "steps": 245,
+        "total_reward": 38.345000000000184,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3875562833757421
+      },
+      {
+        "run": 195,
+        "seed": 48887683,
+        "success": true,
+        "steps": 227,
+        "total_reward": 32.86500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3997144979203803
+      },
+      {
+        "run": 196,
+        "seed": 48887684,
+        "success": true,
+        "steps": 203,
+        "total_reward": 32.51500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36884383199920284
+      },
+      {
+        "run": 197,
+        "seed": 48887685,
+        "success": true,
+        "steps": 206,
+        "total_reward": 38.13000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4080897207367796
+      },
+      {
+        "run": 198,
+        "seed": 48887686,
+        "success": true,
+        "steps": 237,
+        "total_reward": 37.345000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35438307306728356
+      },
+      {
+        "run": 199,
+        "seed": 48887687,
+        "success": true,
+        "steps": 341,
+        "total_reward": 36.14500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22873832581004291
+      },
+      {
+        "run": 200,
+        "seed": 48887688,
+        "success": true,
+        "steps": 238,
+        "total_reward": 38.61000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3753676372564704
+      }
+    ],
+    "avg_chemotaxis_index": 0.37285923689464723,
+    "avg_time_in_attractant": 0.6864296184473235,
+    "avg_approach_frequency": 0.40609814327613813,
+    "avg_path_efficiency": 0.0361892459003633,
+    "post_convergence_chemotaxis_index": 0.3965116824399076,
+    "post_convergence_time_in_attractant": 0.6982558412199538,
+    "post_convergence_approach_frequency": 0.4103502578382324,
+    "post_convergence_path_efficiency": 0.037689822536280025,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_093730.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_093730.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_093730",
+  "timestamp": "2025-12-29T09:48:41.430605+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_093730",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.93,
+    "avg_steps": 255.705,
+    "avg_reward": 34.00272500000011,
+    "avg_foods_collected": 9.505,
+    "avg_distance_efficiency": 0.34790731942626557,
+    "completed_all_food": 186,
+    "starved": 13,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 16,
+    "runs_to_convergence": 15,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 250.6054054054054,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.36623876899617425,
+    "composite_benchmark_score": 0.7948716306988524,
+    "learning_speed": 0.885,
+    "learning_speed_episodes": 23,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 765322463,
+        "success": false,
+        "steps": 320,
+        "total_reward": 2.079999999999945,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.096265589569161
+      },
+      {
+        "run": 2,
+        "seed": 765322464,
+        "success": false,
+        "steps": 200,
+        "total_reward": -3.679999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 765322465,
+        "success": false,
+        "steps": 200,
+        "total_reward": -6.849999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 765322466,
+        "success": false,
+        "steps": 280,
+        "total_reward": 4.949999999999909,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.12077341624562768
+      },
+      {
+        "run": 5,
+        "seed": 765322467,
+        "success": false,
+        "steps": 240,
+        "total_reward": -0.490000000000018,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.20454545454545456
+      },
+      {
+        "run": 6,
+        "seed": 765322468,
+        "success": false,
+        "steps": 240,
+        "total_reward": -2.639999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.040229885057471264
+      },
+      {
+        "run": 7,
+        "seed": 765322469,
+        "success": false,
+        "steps": 280,
+        "total_reward": 7.530000000000001,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.1350806451612903
+      },
+      {
+        "run": 8,
+        "seed": 765322470,
+        "success": false,
+        "steps": 240,
+        "total_reward": -1.4700000000000077,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.058823529411764705
+      },
+      {
+        "run": 9,
+        "seed": 765322471,
+        "success": false,
+        "steps": 280,
+        "total_reward": 5.3399999999999235,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.11019736842105263
+      },
+      {
+        "run": 10,
+        "seed": 765322472,
+        "success": false,
+        "steps": 500,
+        "total_reward": 31.16000000000012,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.1557180004411314
+      },
+      {
+        "run": 11,
+        "seed": 765322473,
+        "success": false,
+        "steps": 480,
+        "total_reward": 17.270000000000138,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.16348131394953627
+      },
+      {
+        "run": 12,
+        "seed": 765322474,
+        "success": true,
+        "steps": 405,
+        "total_reward": 36.625000000000206,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2549798425004727
+      },
+      {
+        "run": 13,
+        "seed": 765322475,
+        "success": false,
+        "steps": 316,
+        "total_reward": 6.129999999999988,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.1380356796587163
+      },
+      {
+        "run": 14,
+        "seed": 765322476,
+        "success": false,
+        "steps": 478,
+        "total_reward": 27.720000000000113,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.18535080931677067
+      },
+      {
+        "run": 15,
+        "seed": 765322477,
+        "success": false,
+        "steps": 320,
+        "total_reward": 14.150000000000162,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.1638100866824271
+      },
+      {
+        "run": 16,
+        "seed": 765322478,
+        "success": true,
+        "steps": 439,
+        "total_reward": 37.48500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.19910892351681825
+      },
+      {
+        "run": 17,
+        "seed": 765322479,
+        "success": true,
+        "steps": 328,
+        "total_reward": 37.38000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31134741396411875
+      },
+      {
+        "run": 18,
+        "seed": 765322480,
+        "success": true,
+        "steps": 339,
+        "total_reward": 35.40500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2823571761155646
+      },
+      {
+        "run": 19,
+        "seed": 765322481,
+        "success": true,
+        "steps": 397,
+        "total_reward": 37.13500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24815281105791884
+      },
+      {
+        "run": 20,
+        "seed": 765322482,
+        "success": true,
+        "steps": 297,
+        "total_reward": 33.16500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2973140109759828
+      },
+      {
+        "run": 21,
+        "seed": 765322483,
+        "success": true,
+        "steps": 424,
+        "total_reward": 46.95000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27149195415555855
+      },
+      {
+        "run": 22,
+        "seed": 765322484,
+        "success": true,
+        "steps": 275,
+        "total_reward": 35.30500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3036679519335471
+      },
+      {
+        "run": 23,
+        "seed": 765322485,
+        "success": true,
+        "steps": 241,
+        "total_reward": 33.08500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3014068369989423
+      },
+      {
+        "run": 24,
+        "seed": 765322486,
+        "success": true,
+        "steps": 265,
+        "total_reward": 36.055000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3124719954967633
+      },
+      {
+        "run": 25,
+        "seed": 765322487,
+        "success": true,
+        "steps": 341,
+        "total_reward": 41.68500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26358560374945833
+      },
+      {
+        "run": 26,
+        "seed": 765322488,
+        "success": true,
+        "steps": 323,
+        "total_reward": 37.17500000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3345376576793211
+      },
+      {
+        "run": 27,
+        "seed": 765322489,
+        "success": true,
+        "steps": 228,
+        "total_reward": 32.03000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42792334371281743
+      },
+      {
+        "run": 28,
+        "seed": 765322490,
+        "success": true,
+        "steps": 223,
+        "total_reward": 34.77500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3773681376181376
+      },
+      {
+        "run": 29,
+        "seed": 765322491,
+        "success": true,
+        "steps": 298,
+        "total_reward": 28.120000000000182,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28392102812636905
+      },
+      {
+        "run": 30,
+        "seed": 765322492,
+        "success": true,
+        "steps": 220,
+        "total_reward": 35.73000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3635403347942047
+      },
+      {
+        "run": 31,
+        "seed": 765322493,
+        "success": true,
+        "steps": 273,
+        "total_reward": 28.525000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3153269426337462
+      },
+      {
+        "run": 32,
+        "seed": 765322494,
+        "success": true,
+        "steps": 237,
+        "total_reward": 37.43500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37322903735610696
+      },
+      {
+        "run": 33,
+        "seed": 765322495,
+        "success": true,
+        "steps": 258,
+        "total_reward": 33.92000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31991722076448814
+      },
+      {
+        "run": 34,
+        "seed": 765322496,
+        "success": true,
+        "steps": 296,
+        "total_reward": 29.060000000000123,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31557934330248855
+      },
+      {
+        "run": 35,
+        "seed": 765322497,
+        "success": true,
+        "steps": 284,
+        "total_reward": 41.27000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3308833679989646
+      },
+      {
+        "run": 36,
+        "seed": 765322498,
+        "success": true,
+        "steps": 434,
+        "total_reward": 42.12999999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20300006828583497
+      },
+      {
+        "run": 37,
+        "seed": 765322499,
+        "success": true,
+        "steps": 349,
+        "total_reward": 34.84500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2765224055092743
+      },
+      {
+        "run": 38,
+        "seed": 765322500,
+        "success": true,
+        "steps": 277,
+        "total_reward": 40.3950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33134957447367447
+      },
+      {
+        "run": 39,
+        "seed": 765322501,
+        "success": true,
+        "steps": 264,
+        "total_reward": 39.41000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4021583731881974
+      },
+      {
+        "run": 40,
+        "seed": 765322502,
+        "success": true,
+        "steps": 197,
+        "total_reward": 28.575000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3845544733044733
+      },
+      {
+        "run": 41,
+        "seed": 765322503,
+        "success": true,
+        "steps": 270,
+        "total_reward": 41.82000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35802334141717085
+      },
+      {
+        "run": 42,
+        "seed": 765322504,
+        "success": true,
+        "steps": 272,
+        "total_reward": 31.55000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3319890603174425
+      },
+      {
+        "run": 43,
+        "seed": 765322505,
+        "success": true,
+        "steps": 216,
+        "total_reward": 37.33000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37374463371877165
+      },
+      {
+        "run": 44,
+        "seed": 765322506,
+        "success": true,
+        "steps": 264,
+        "total_reward": 29.180000000000206,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3066669681784131
+      },
+      {
+        "run": 45,
+        "seed": 765322507,
+        "success": true,
+        "steps": 262,
+        "total_reward": 37.61000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4000462772367803
+      },
+      {
+        "run": 46,
+        "seed": 765322508,
+        "success": true,
+        "steps": 220,
+        "total_reward": 36.530000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37552481631429
+      },
+      {
+        "run": 47,
+        "seed": 765322509,
+        "success": true,
+        "steps": 238,
+        "total_reward": 33.65000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3771042119701091
+      },
+      {
+        "run": 48,
+        "seed": 765322510,
+        "success": true,
+        "steps": 224,
+        "total_reward": 30.880000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34005291005291005
+      },
+      {
+        "run": 49,
+        "seed": 765322511,
+        "success": true,
+        "steps": 314,
+        "total_reward": 36.0200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2712003857656032
+      },
+      {
+        "run": 50,
+        "seed": 765322512,
+        "success": true,
+        "steps": 266,
+        "total_reward": 36.69000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33877585102413477
+      },
+      {
+        "run": 51,
+        "seed": 765322513,
+        "success": true,
+        "steps": 212,
+        "total_reward": 32.85000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4094429199111862
+      },
+      {
+        "run": 52,
+        "seed": 765322514,
+        "success": true,
+        "steps": 269,
+        "total_reward": 40.43500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4107733868597713
+      },
+      {
+        "run": 53,
+        "seed": 765322515,
+        "success": true,
+        "steps": 284,
+        "total_reward": 37.20000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27289748820604365
+      },
+      {
+        "run": 54,
+        "seed": 765322516,
+        "success": true,
+        "steps": 203,
+        "total_reward": 44.36500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4651732754331498
+      },
+      {
+        "run": 55,
+        "seed": 765322517,
+        "success": true,
+        "steps": 292,
+        "total_reward": 48.8800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4290243895988409
+      },
+      {
+        "run": 56,
+        "seed": 765322518,
+        "success": true,
+        "steps": 297,
+        "total_reward": 33.7350000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32505571011258766
+      },
+      {
+        "run": 57,
+        "seed": 765322519,
+        "success": true,
+        "steps": 186,
+        "total_reward": 34.100000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43584900284900285
+      },
+      {
+        "run": 58,
+        "seed": 765322520,
+        "success": true,
+        "steps": 211,
+        "total_reward": 40.4850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43221080419297736
+      },
+      {
+        "run": 59,
+        "seed": 765322521,
+        "success": true,
+        "steps": 237,
+        "total_reward": 37.96500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3307238419578845
+      },
+      {
+        "run": 60,
+        "seed": 765322522,
+        "success": true,
+        "steps": 193,
+        "total_reward": 30.905000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3626496782203304
+      },
+      {
+        "run": 61,
+        "seed": 765322523,
+        "success": true,
+        "steps": 233,
+        "total_reward": 33.96500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36603145220792277
+      },
+      {
+        "run": 62,
+        "seed": 765322524,
+        "success": true,
+        "steps": 272,
+        "total_reward": 37.20000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30938074003291394
+      },
+      {
+        "run": 63,
+        "seed": 765322525,
+        "success": true,
+        "steps": 216,
+        "total_reward": 38.280000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4455123308064485
+      },
+      {
+        "run": 64,
+        "seed": 765322526,
+        "success": true,
+        "steps": 203,
+        "total_reward": 42.09500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5231398231398232
+      },
+      {
+        "run": 65,
+        "seed": 765322527,
+        "success": true,
+        "steps": 245,
+        "total_reward": 34.625000000000185,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3685762411347518
+      },
+      {
+        "run": 66,
+        "seed": 765322528,
+        "success": true,
+        "steps": 207,
+        "total_reward": 33.575000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35254379029133487
+      },
+      {
+        "run": 67,
+        "seed": 765322529,
+        "success": true,
+        "steps": 199,
+        "total_reward": 34.54500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3895262145262145
+      },
+      {
+        "run": 68,
+        "seed": 765322530,
+        "success": true,
+        "steps": 181,
+        "total_reward": 35.355000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46944911297852476
+      },
+      {
+        "run": 69,
+        "seed": 765322531,
+        "success": true,
+        "steps": 261,
+        "total_reward": 34.87500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3260446797199317
+      },
+      {
+        "run": 70,
+        "seed": 765322532,
+        "success": true,
+        "steps": 305,
+        "total_reward": 34.535000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28309495048768507
+      },
+      {
+        "run": 71,
+        "seed": 765322533,
+        "success": true,
+        "steps": 244,
+        "total_reward": 36.08000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3112276101565806
+      },
+      {
+        "run": 72,
+        "seed": 765322534,
+        "success": true,
+        "steps": 243,
+        "total_reward": 35.64500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37847158847158846
+      },
+      {
+        "run": 73,
+        "seed": 765322535,
+        "success": true,
+        "steps": 287,
+        "total_reward": 34.155000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29157808267051966
+      },
+      {
+        "run": 74,
+        "seed": 765322536,
+        "success": true,
+        "steps": 219,
+        "total_reward": 29.16500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33310610685610686
+      },
+      {
+        "run": 75,
+        "seed": 765322537,
+        "success": true,
+        "steps": 279,
+        "total_reward": 36.8050000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30269607520801
+      },
+      {
+        "run": 76,
+        "seed": 765322538,
+        "success": true,
+        "steps": 287,
+        "total_reward": 43.295000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39274939874939874
+      },
+      {
+        "run": 77,
+        "seed": 765322539,
+        "success": true,
+        "steps": 275,
+        "total_reward": 36.40500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2899653931339978
+      },
+      {
+        "run": 78,
+        "seed": 765322540,
+        "success": true,
+        "steps": 182,
+        "total_reward": 37.15000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42914990238519646
+      },
+      {
+        "run": 79,
+        "seed": 765322541,
+        "success": true,
+        "steps": 269,
+        "total_reward": 25.775000000000098,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25032318445970236
+      },
+      {
+        "run": 80,
+        "seed": 765322542,
+        "success": true,
+        "steps": 216,
+        "total_reward": 43.550000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46582732487502937
+      },
+      {
+        "run": 81,
+        "seed": 765322543,
+        "success": true,
+        "steps": 176,
+        "total_reward": 34.350000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41382535764888706
+      },
+      {
+        "run": 82,
+        "seed": 765322544,
+        "success": true,
+        "steps": 184,
+        "total_reward": 33.920000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4507600250260097
+      },
+      {
+        "run": 83,
+        "seed": 765322545,
+        "success": true,
+        "steps": 239,
+        "total_reward": 42.26500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4056115264663651
+      },
+      {
+        "run": 84,
+        "seed": 765322546,
+        "success": true,
+        "steps": 228,
+        "total_reward": 31.370000000000108,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34915116866418694
+      },
+      {
+        "run": 85,
+        "seed": 765322547,
+        "success": true,
+        "steps": 301,
+        "total_reward": 46.65500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30815577940577943
+      },
+      {
+        "run": 86,
+        "seed": 765322548,
+        "success": true,
+        "steps": 135,
+        "total_reward": 28.00500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4971488957902001
+      },
+      {
+        "run": 87,
+        "seed": 765322549,
+        "success": true,
+        "steps": 242,
+        "total_reward": 34.180000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3084944858009374
+      },
+      {
+        "run": 88,
+        "seed": 765322550,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.265000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4456060606060606
+      },
+      {
+        "run": 89,
+        "seed": 765322551,
+        "success": true,
+        "steps": 212,
+        "total_reward": 39.9400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4476278656376108
+      },
+      {
+        "run": 90,
+        "seed": 765322552,
+        "success": true,
+        "steps": 302,
+        "total_reward": 38.56000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.274731831467765
+      },
+      {
+        "run": 91,
+        "seed": 765322553,
+        "success": true,
+        "steps": 275,
+        "total_reward": 35.35500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2969348059297597
+      },
+      {
+        "run": 92,
+        "seed": 765322554,
+        "success": true,
+        "steps": 182,
+        "total_reward": 33.89000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45092133925645184
+      },
+      {
+        "run": 93,
+        "seed": 765322555,
+        "success": true,
+        "steps": 260,
+        "total_reward": 41.75000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4374871401961185
+      },
+      {
+        "run": 94,
+        "seed": 765322556,
+        "success": true,
+        "steps": 186,
+        "total_reward": 29.610000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4115464141122036
+      },
+      {
+        "run": 95,
+        "seed": 765322557,
+        "success": true,
+        "steps": 209,
+        "total_reward": 39.2350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4374732068697586
+      },
+      {
+        "run": 96,
+        "seed": 765322558,
+        "success": true,
+        "steps": 327,
+        "total_reward": 35.06500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28244827846572035
+      },
+      {
+        "run": 97,
+        "seed": 765322559,
+        "success": true,
+        "steps": 266,
+        "total_reward": 31.720000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30339389877814926
+      },
+      {
+        "run": 98,
+        "seed": 765322560,
+        "success": true,
+        "steps": 224,
+        "total_reward": 38.28000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4143298959105411
+      },
+      {
+        "run": 99,
+        "seed": 765322561,
+        "success": true,
+        "steps": 248,
+        "total_reward": 34.50000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3541288217736118
+      },
+      {
+        "run": 100,
+        "seed": 765322562,
+        "success": true,
+        "steps": 220,
+        "total_reward": 38.37000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4006043858503813
+      },
+      {
+        "run": 101,
+        "seed": 765322563,
+        "success": true,
+        "steps": 210,
+        "total_reward": 30.190000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3801475283028991
+      },
+      {
+        "run": 102,
+        "seed": 765322564,
+        "success": true,
+        "steps": 275,
+        "total_reward": 36.34500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2916001070378951
+      },
+      {
+        "run": 103,
+        "seed": 765322565,
+        "success": true,
+        "steps": 170,
+        "total_reward": 27.59000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4449045072574484
+      },
+      {
+        "run": 104,
+        "seed": 765322566,
+        "success": true,
+        "steps": 286,
+        "total_reward": 39.410000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.345342458585243
+      },
+      {
+        "run": 105,
+        "seed": 765322567,
+        "success": true,
+        "steps": 236,
+        "total_reward": 36.23000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37746544391281234
+      },
+      {
+        "run": 106,
+        "seed": 765322568,
+        "success": true,
+        "steps": 235,
+        "total_reward": 42.85500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45277387015926907
+      },
+      {
+        "run": 107,
+        "seed": 765322569,
+        "success": true,
+        "steps": 365,
+        "total_reward": 33.745000000000196,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3235312588936129
+      },
+      {
+        "run": 108,
+        "seed": 765322570,
+        "success": true,
+        "steps": 279,
+        "total_reward": 33.45500000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.321785978039848
+      },
+      {
+        "run": 109,
+        "seed": 765322571,
+        "success": true,
+        "steps": 168,
+        "total_reward": 31.880000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4289140992770757
+      },
+      {
+        "run": 110,
+        "seed": 765322572,
+        "success": true,
+        "steps": 255,
+        "total_reward": 40.465000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3385892538833715
+      },
+      {
+        "run": 111,
+        "seed": 765322573,
+        "success": true,
+        "steps": 253,
+        "total_reward": 38.095000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37486362083636116
+      },
+      {
+        "run": 112,
+        "seed": 765322574,
+        "success": true,
+        "steps": 317,
+        "total_reward": 45.25499999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4125157881334352
+      },
+      {
+        "run": 113,
+        "seed": 765322575,
+        "success": true,
+        "steps": 333,
+        "total_reward": 40.16500000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29363353857517693
+      },
+      {
+        "run": 114,
+        "seed": 765322576,
+        "success": true,
+        "steps": 291,
+        "total_reward": 36.645000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28982847938705325
+      },
+      {
+        "run": 115,
+        "seed": 765322577,
+        "success": true,
+        "steps": 258,
+        "total_reward": 39.01000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32775144625144625
+      },
+      {
+        "run": 116,
+        "seed": 765322578,
+        "success": true,
+        "steps": 338,
+        "total_reward": 31.93000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22287697895620076
+      },
+      {
+        "run": 117,
+        "seed": 765322579,
+        "success": true,
+        "steps": 214,
+        "total_reward": 42.12000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4417650002327422
+      },
+      {
+        "run": 118,
+        "seed": 765322580,
+        "success": true,
+        "steps": 254,
+        "total_reward": 41.20000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36606599248704513
+      },
+      {
+        "run": 119,
+        "seed": 765322581,
+        "success": true,
+        "steps": 225,
+        "total_reward": 43.78500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4439726070047956
+      },
+      {
+        "run": 120,
+        "seed": 765322582,
+        "success": true,
+        "steps": 315,
+        "total_reward": 32.19500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28900520212816894
+      },
+      {
+        "run": 121,
+        "seed": 765322583,
+        "success": true,
+        "steps": 257,
+        "total_reward": 32.99500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3448336099361504
+      },
+      {
+        "run": 122,
+        "seed": 765322584,
+        "success": true,
+        "steps": 230,
+        "total_reward": 28.640000000000143,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3448080419111536
+      },
+      {
+        "run": 123,
+        "seed": 765322585,
+        "success": true,
+        "steps": 257,
+        "total_reward": 36.385000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3140249879157202
+      },
+      {
+        "run": 124,
+        "seed": 765322586,
+        "success": true,
+        "steps": 252,
+        "total_reward": 38.08000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31885634846824107
+      },
+      {
+        "run": 125,
+        "seed": 765322587,
+        "success": true,
+        "steps": 185,
+        "total_reward": 34.305000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46141946289005115
+      },
+      {
+        "run": 126,
+        "seed": 765322588,
+        "success": true,
+        "steps": 281,
+        "total_reward": 36.98500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3150382982650425
+      },
+      {
+        "run": 127,
+        "seed": 765322589,
+        "success": true,
+        "steps": 258,
+        "total_reward": 37.23000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3473010267180118
+      },
+      {
+        "run": 128,
+        "seed": 765322590,
+        "success": true,
+        "steps": 245,
+        "total_reward": 44.24500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40999290392147536
+      },
+      {
+        "run": 129,
+        "seed": 765322591,
+        "success": true,
+        "steps": 279,
+        "total_reward": 32.7650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3288987670036057
+      },
+      {
+        "run": 130,
+        "seed": 765322592,
+        "success": true,
+        "steps": 272,
+        "total_reward": 36.450000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33565967427100396
+      },
+      {
+        "run": 131,
+        "seed": 765322593,
+        "success": true,
+        "steps": 187,
+        "total_reward": 35.06500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4370898794300329
+      },
+      {
+        "run": 132,
+        "seed": 765322594,
+        "success": true,
+        "steps": 207,
+        "total_reward": 36.13500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4074383183865942
+      },
+      {
+        "run": 133,
+        "seed": 765322595,
+        "success": true,
+        "steps": 195,
+        "total_reward": 34.56500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4051036894140342
+      },
+      {
+        "run": 134,
+        "seed": 765322596,
+        "success": true,
+        "steps": 309,
+        "total_reward": 32.85500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3057415625098691
+      },
+      {
+        "run": 135,
+        "seed": 765322597,
+        "success": true,
+        "steps": 226,
+        "total_reward": 29.9800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34239575701020714
+      },
+      {
+        "run": 136,
+        "seed": 765322598,
+        "success": true,
+        "steps": 292,
+        "total_reward": 35.15000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30134769255724225
+      },
+      {
+        "run": 137,
+        "seed": 765322599,
+        "success": true,
+        "steps": 231,
+        "total_reward": 32.565000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40876961100365355
+      },
+      {
+        "run": 138,
+        "seed": 765322600,
+        "success": true,
+        "steps": 186,
+        "total_reward": 38.88000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.513744837856091
+      },
+      {
+        "run": 139,
+        "seed": 765322601,
+        "success": true,
+        "steps": 302,
+        "total_reward": 37.680000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3106320020924971
+      },
+      {
+        "run": 140,
+        "seed": 765322602,
+        "success": true,
+        "steps": 291,
+        "total_reward": 35.46500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3006159420289855
+      },
+      {
+        "run": 141,
+        "seed": 765322603,
+        "success": true,
+        "steps": 197,
+        "total_reward": 31.23500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38782093723270195
+      },
+      {
+        "run": 142,
+        "seed": 765322604,
+        "success": true,
+        "steps": 168,
+        "total_reward": 36.66000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5188931253719583
+      },
+      {
+        "run": 143,
+        "seed": 765322605,
+        "success": true,
+        "steps": 235,
+        "total_reward": 34.34500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3893659286001129
+      },
+      {
+        "run": 144,
+        "seed": 765322606,
+        "success": true,
+        "steps": 235,
+        "total_reward": 35.0350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39612529927027407
+      },
+      {
+        "run": 145,
+        "seed": 765322607,
+        "success": true,
+        "steps": 204,
+        "total_reward": 39.68000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4660058781345846
+      },
+      {
+        "run": 146,
+        "seed": 765322608,
+        "success": true,
+        "steps": 208,
+        "total_reward": 37.630000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40761061161061163
+      },
+      {
+        "run": 147,
+        "seed": 765322609,
+        "success": true,
+        "steps": 146,
+        "total_reward": 34.260000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5701031746031746
+      },
+      {
+        "run": 148,
+        "seed": 765322610,
+        "success": true,
+        "steps": 163,
+        "total_reward": 40.935000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5839285714285715
+      },
+      {
+        "run": 149,
+        "seed": 765322611,
+        "success": true,
+        "steps": 267,
+        "total_reward": 33.555000000000184,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2930546741073057
+      },
+      {
+        "run": 150,
+        "seed": 765322612,
+        "success": true,
+        "steps": 224,
+        "total_reward": 36.04000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45020467836257305
+      },
+      {
+        "run": 151,
+        "seed": 765322613,
+        "success": true,
+        "steps": 150,
+        "total_reward": 33.330000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5157937922643805
+      },
+      {
+        "run": 152,
+        "seed": 765322614,
+        "success": true,
+        "steps": 207,
+        "total_reward": 41.91500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4362329314123706
+      },
+      {
+        "run": 153,
+        "seed": 765322615,
+        "success": true,
+        "steps": 205,
+        "total_reward": 33.05500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4264102564102564
+      },
+      {
+        "run": 154,
+        "seed": 765322616,
+        "success": true,
+        "steps": 207,
+        "total_reward": 36.52500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.502425442640119
+      },
+      {
+        "run": 155,
+        "seed": 765322617,
+        "success": true,
+        "steps": 173,
+        "total_reward": 34.54500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4205318945760122
+      },
+      {
+        "run": 156,
+        "seed": 765322618,
+        "success": true,
+        "steps": 261,
+        "total_reward": 39.45500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3649967640437751
+      },
+      {
+        "run": 157,
+        "seed": 765322619,
+        "success": true,
+        "steps": 266,
+        "total_reward": 34.22000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2912213457041043
+      },
+      {
+        "run": 158,
+        "seed": 765322620,
+        "success": true,
+        "steps": 214,
+        "total_reward": 30.46000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3523245124051576
+      },
+      {
+        "run": 159,
+        "seed": 765322621,
+        "success": true,
+        "steps": 274,
+        "total_reward": 41.63000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3516581764541259
+      },
+      {
+        "run": 160,
+        "seed": 765322622,
+        "success": true,
+        "steps": 256,
+        "total_reward": 37.85000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3909912641562562
+      },
+      {
+        "run": 161,
+        "seed": 765322623,
+        "success": true,
+        "steps": 229,
+        "total_reward": 37.615000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4005801276421212
+      },
+      {
+        "run": 162,
+        "seed": 765322624,
+        "success": true,
+        "steps": 302,
+        "total_reward": 32.970000000000205,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31143883358844426
+      },
+      {
+        "run": 163,
+        "seed": 765322625,
+        "success": true,
+        "steps": 170,
+        "total_reward": 31.090000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39899930529240873
+      },
+      {
+        "run": 164,
+        "seed": 765322626,
+        "success": true,
+        "steps": 229,
+        "total_reward": 27.645000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29423458485958487
+      },
+      {
+        "run": 165,
+        "seed": 765322627,
+        "success": true,
+        "steps": 280,
+        "total_reward": 39.24000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3563020618350806
+      },
+      {
+        "run": 166,
+        "seed": 765322628,
+        "success": true,
+        "steps": 282,
+        "total_reward": 35.30000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2995555412329606
+      },
+      {
+        "run": 167,
+        "seed": 765322629,
+        "success": true,
+        "steps": 209,
+        "total_reward": 28.605000000000192,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37995554213355687
+      },
+      {
+        "run": 168,
+        "seed": 765322630,
+        "success": true,
+        "steps": 251,
+        "total_reward": 35.20500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39296807132988754
+      },
+      {
+        "run": 169,
+        "seed": 765322631,
+        "success": true,
+        "steps": 188,
+        "total_reward": 36.430000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47784498207885306
+      },
+      {
+        "run": 170,
+        "seed": 765322632,
+        "success": true,
+        "steps": 275,
+        "total_reward": 37.015000000000036,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3455512259306261
+      },
+      {
+        "run": 171,
+        "seed": 765322633,
+        "success": true,
+        "steps": 318,
+        "total_reward": 37.0800000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29864536268791586
+      },
+      {
+        "run": 172,
+        "seed": 765322634,
+        "success": true,
+        "steps": 291,
+        "total_reward": 29.0650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2749831329661051
+      },
+      {
+        "run": 173,
+        "seed": 765322635,
+        "success": true,
+        "steps": 190,
+        "total_reward": 36.70000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48842150336315093
+      },
+      {
+        "run": 174,
+        "seed": 765322636,
+        "success": true,
+        "steps": 218,
+        "total_reward": 40.36000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43943388276697526
+      },
+      {
+        "run": 175,
+        "seed": 765322637,
+        "success": true,
+        "steps": 183,
+        "total_reward": 35.48500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49363792055897315
+      },
+      {
+        "run": 176,
+        "seed": 765322638,
+        "success": true,
+        "steps": 220,
+        "total_reward": 34.04000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37469339714071564
+      },
+      {
+        "run": 177,
+        "seed": 765322639,
+        "success": true,
+        "steps": 233,
+        "total_reward": 35.60500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4275972393619452
+      },
+      {
+        "run": 178,
+        "seed": 765322640,
+        "success": true,
+        "steps": 302,
+        "total_reward": 33.700000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34235264211679306
+      },
+      {
+        "run": 179,
+        "seed": 765322641,
+        "success": true,
+        "steps": 257,
+        "total_reward": 30.185000000000123,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31124628974396773
+      },
+      {
+        "run": 180,
+        "seed": 765322642,
+        "success": true,
+        "steps": 209,
+        "total_reward": 34.88500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4324033468286788
+      },
+      {
+        "run": 181,
+        "seed": 765322643,
+        "success": true,
+        "steps": 287,
+        "total_reward": 37.115000000000215,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44356290574112356
+      },
+      {
+        "run": 182,
+        "seed": 765322644,
+        "success": true,
+        "steps": 262,
+        "total_reward": 31.950000000000127,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31820956720193067
+      },
+      {
+        "run": 183,
+        "seed": 765322645,
+        "success": true,
+        "steps": 254,
+        "total_reward": 34.96000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37998405103668265
+      },
+      {
+        "run": 184,
+        "seed": 765322646,
+        "success": true,
+        "steps": 233,
+        "total_reward": 36.09500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3724395881895882
+      },
+      {
+        "run": 185,
+        "seed": 765322647,
+        "success": true,
+        "steps": 219,
+        "total_reward": 34.135000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33927594133476485
+      },
+      {
+        "run": 186,
+        "seed": 765322648,
+        "success": true,
+        "steps": 196,
+        "total_reward": 40.580000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4321635620126999
+      },
+      {
+        "run": 187,
+        "seed": 765322649,
+        "success": true,
+        "steps": 224,
+        "total_reward": 37.090000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34340647370059135
+      },
+      {
+        "run": 188,
+        "seed": 765322650,
+        "success": true,
+        "steps": 386,
+        "total_reward": 45.03000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3100533608398879
+      },
+      {
+        "run": 189,
+        "seed": 765322651,
+        "success": true,
+        "steps": 273,
+        "total_reward": 38.01500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3732237573355994
+      },
+      {
+        "run": 190,
+        "seed": 765322652,
+        "success": true,
+        "steps": 233,
+        "total_reward": 35.215000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3697052318951296
+      },
+      {
+        "run": 191,
+        "seed": 765322653,
+        "success": true,
+        "steps": 342,
+        "total_reward": 40.87000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3057329765216704
+      },
+      {
+        "run": 192,
+        "seed": 765322654,
+        "success": true,
+        "steps": 173,
+        "total_reward": 36.885000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4684591203929065
+      },
+      {
+        "run": 193,
+        "seed": 765322655,
+        "success": true,
+        "steps": 294,
+        "total_reward": 39.79000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3299234343872502
+      },
+      {
+        "run": 194,
+        "seed": 765322656,
+        "success": true,
+        "steps": 271,
+        "total_reward": 36.825000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3469691279583025
+      },
+      {
+        "run": 195,
+        "seed": 765322657,
+        "success": true,
+        "steps": 243,
+        "total_reward": 39.85500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37138585293632315
+      },
+      {
+        "run": 196,
+        "seed": 765322658,
+        "success": true,
+        "steps": 227,
+        "total_reward": 30.135000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.374148580671537
+      },
+      {
+        "run": 197,
+        "seed": 765322659,
+        "success": true,
+        "steps": 216,
+        "total_reward": 33.520000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3559066721699879
+      },
+      {
+        "run": 198,
+        "seed": 765322660,
+        "success": true,
+        "steps": 269,
+        "total_reward": 26.835000000000118,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2647240572861691
+      },
+      {
+        "run": 199,
+        "seed": 765322661,
+        "success": true,
+        "steps": 269,
+        "total_reward": 33.42500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2814300553036251
+      },
+      {
+        "run": 200,
+        "seed": 765322662,
+        "success": true,
+        "steps": 291,
+        "total_reward": 44.245000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34945799619938445
+      }
+    ],
+    "avg_chemotaxis_index": 0.40090682895757757,
+    "avg_time_in_attractant": 0.7004534144787888,
+    "avg_approach_frequency": 0.4166228163063298,
+    "avg_path_efficiency": 0.05372433852116664,
+    "post_convergence_chemotaxis_index": 0.4116075278663233,
+    "post_convergence_time_in_attractant": 0.7058037639331617,
+    "post_convergence_approach_frequency": 0.4198886143438849,
+    "post_convergence_path_efficiency": 0.056875511865701216,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_095326.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_095326.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_095326",
+  "timestamp": "2025-12-29T10:03:06.123044+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_095326",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.95,
+    "avg_steps": 214.59,
+    "avg_reward": 34.93780000000011,
+    "avg_foods_collected": 9.715,
+    "avg_distance_efficiency": 0.41906941136655607,
+    "completed_all_food": 190,
+    "starved": 8,
+    "max_steps_reached": 2,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 10,
+    "runs_to_convergence": 9,
+    "post_convergence_success_rate": 0.9947643979057592,
+    "post_convergence_avg_steps": 207.67368421052632,
+    "post_convergence_avg_foods": 9.979057591623036,
+    "post_convergence_variance": 0.005208190564951618,
+    "post_convergence_distance_efficiency": 0.4296321176745165,
+    "composite_benchmark_score": 0.8151912991821829,
+    "learning_speed": 0.915,
+    "learning_speed_episodes": 17,
+    "stability": 0.9274523749889988,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 4255614831,
+        "success": false,
+        "steps": 240,
+        "total_reward": 0.23999999999994692,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.06363636363636363
+      },
+      {
+        "run": 2,
+        "seed": 4255614832,
+        "success": false,
+        "steps": 240,
+        "total_reward": -4.119999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.05
+      },
+      {
+        "run": 3,
+        "seed": 4255614833,
+        "success": false,
+        "steps": 352,
+        "total_reward": 9.260000000000105,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.2035036196052201
+      },
+      {
+        "run": 4,
+        "seed": 4255614834,
+        "success": false,
+        "steps": 279,
+        "total_reward": 6.894999999999914,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.18344645550527905
+      },
+      {
+        "run": 5,
+        "seed": 4255614835,
+        "success": false,
+        "steps": 400,
+        "total_reward": 10.360000000000174,
+        "termination_reason": "starved",
+        "foods_collected": 5,
+        "distance_efficiency": 0.2648053035058685
+      },
+      {
+        "run": 6,
+        "seed": 4255614836,
+        "success": false,
+        "steps": 355,
+        "total_reward": 7.65500000000004,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.1683360944734718
+      },
+      {
+        "run": 7,
+        "seed": 4255614837,
+        "success": false,
+        "steps": 320,
+        "total_reward": 5.679999999999893,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.12346813725490197
+      },
+      {
+        "run": 8,
+        "seed": 4255614838,
+        "success": false,
+        "steps": 500,
+        "total_reward": 33.57000000000005,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.17931428053397208
+      },
+      {
+        "run": 9,
+        "seed": 4255614839,
+        "success": false,
+        "steps": 500,
+        "total_reward": 28.750000000000366,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.23673242010076645
+      },
+      {
+        "run": 10,
+        "seed": 4255614840,
+        "success": true,
+        "steps": 428,
+        "total_reward": 37.17000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28139159326379637
+      },
+      {
+        "run": 11,
+        "seed": 4255614841,
+        "success": true,
+        "steps": 308,
+        "total_reward": 40.07000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3823888944216047
+      },
+      {
+        "run": 12,
+        "seed": 4255614842,
+        "success": true,
+        "steps": 372,
+        "total_reward": 48.17000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2760841697153242
+      },
+      {
+        "run": 13,
+        "seed": 4255614843,
+        "success": true,
+        "steps": 298,
+        "total_reward": 41.98000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4145079952524128
+      },
+      {
+        "run": 14,
+        "seed": 4255614844,
+        "success": true,
+        "steps": 272,
+        "total_reward": 37.9300000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.323826273011833
+      },
+      {
+        "run": 15,
+        "seed": 4255614845,
+        "success": true,
+        "steps": 260,
+        "total_reward": 33.35000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41308267126870113
+      },
+      {
+        "run": 16,
+        "seed": 4255614846,
+        "success": true,
+        "steps": 245,
+        "total_reward": 32.71500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3306610120124605
+      },
+      {
+        "run": 17,
+        "seed": 4255614847,
+        "success": true,
+        "steps": 332,
+        "total_reward": 43.52000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3109022634002302
+      },
+      {
+        "run": 18,
+        "seed": 4255614848,
+        "success": true,
+        "steps": 312,
+        "total_reward": 44.01000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33797595060602936
+      },
+      {
+        "run": 19,
+        "seed": 4255614849,
+        "success": true,
+        "steps": 288,
+        "total_reward": 34.65000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3254663925058662
+      },
+      {
+        "run": 20,
+        "seed": 4255614850,
+        "success": true,
+        "steps": 201,
+        "total_reward": 39.335000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4070571747093486
+      },
+      {
+        "run": 21,
+        "seed": 4255614851,
+        "success": true,
+        "steps": 196,
+        "total_reward": 32.97000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43436397001088445
+      },
+      {
+        "run": 22,
+        "seed": 4255614852,
+        "success": true,
+        "steps": 190,
+        "total_reward": 34.64000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40997667301572227
+      },
+      {
+        "run": 23,
+        "seed": 4255614853,
+        "success": true,
+        "steps": 229,
+        "total_reward": 35.445000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3368931698315999
+      },
+      {
+        "run": 24,
+        "seed": 4255614854,
+        "success": true,
+        "steps": 247,
+        "total_reward": 42.815000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36350841607060247
+      },
+      {
+        "run": 25,
+        "seed": 4255614855,
+        "success": true,
+        "steps": 180,
+        "total_reward": 36.06000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.478497335997336
+      },
+      {
+        "run": 26,
+        "seed": 4255614856,
+        "success": true,
+        "steps": 283,
+        "total_reward": 37.145000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36200681562841275
+      },
+      {
+        "run": 27,
+        "seed": 4255614857,
+        "success": true,
+        "steps": 186,
+        "total_reward": 29.700000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3668151465392845
+      },
+      {
+        "run": 28,
+        "seed": 4255614858,
+        "success": true,
+        "steps": 198,
+        "total_reward": 36.20000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42348065677013047
+      },
+      {
+        "run": 29,
+        "seed": 4255614859,
+        "success": true,
+        "steps": 240,
+        "total_reward": 39.16000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3811604223868375
+      },
+      {
+        "run": 30,
+        "seed": 4255614860,
+        "success": true,
+        "steps": 198,
+        "total_reward": 35.81000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44011597425131266
+      },
+      {
+        "run": 31,
+        "seed": 4255614861,
+        "success": true,
+        "steps": 263,
+        "total_reward": 33.88500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36762132007166765
+      },
+      {
+        "run": 32,
+        "seed": 4255614862,
+        "success": true,
+        "steps": 334,
+        "total_reward": 34.48000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32961817901004103
+      },
+      {
+        "run": 33,
+        "seed": 4255614863,
+        "success": true,
+        "steps": 224,
+        "total_reward": 39.37000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44166419787109445
+      },
+      {
+        "run": 34,
+        "seed": 4255614864,
+        "success": true,
+        "steps": 227,
+        "total_reward": 34.565000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4877151680624204
+      },
+      {
+        "run": 35,
+        "seed": 4255614865,
+        "success": true,
+        "steps": 173,
+        "total_reward": 25.03500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48631113039007773
+      },
+      {
+        "run": 36,
+        "seed": 4255614866,
+        "success": true,
+        "steps": 253,
+        "total_reward": 36.02500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.349071880759793
+      },
+      {
+        "run": 37,
+        "seed": 4255614867,
+        "success": true,
+        "steps": 227,
+        "total_reward": 33.43500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35017220651853914
+      },
+      {
+        "run": 38,
+        "seed": 4255614868,
+        "success": true,
+        "steps": 162,
+        "total_reward": 39.05000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5387698412698413
+      },
+      {
+        "run": 39,
+        "seed": 4255614869,
+        "success": true,
+        "steps": 243,
+        "total_reward": 35.145000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3403223969013443
+      },
+      {
+        "run": 40,
+        "seed": 4255614870,
+        "success": true,
+        "steps": 302,
+        "total_reward": 34.34000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3444895940832473
+      },
+      {
+        "run": 41,
+        "seed": 4255614871,
+        "success": true,
+        "steps": 211,
+        "total_reward": 44.125000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5070611577964519
+      },
+      {
+        "run": 42,
+        "seed": 4255614872,
+        "success": true,
+        "steps": 158,
+        "total_reward": 30.400000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.450446258771067
+      },
+      {
+        "run": 43,
+        "seed": 4255614873,
+        "success": true,
+        "steps": 176,
+        "total_reward": 35.49000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4997474747474747
+      },
+      {
+        "run": 44,
+        "seed": 4255614874,
+        "success": true,
+        "steps": 199,
+        "total_reward": 32.29500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43445468730688414
+      },
+      {
+        "run": 45,
+        "seed": 4255614875,
+        "success": true,
+        "steps": 197,
+        "total_reward": 41.535000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4528345357994314
+      },
+      {
+        "run": 46,
+        "seed": 4255614876,
+        "success": true,
+        "steps": 188,
+        "total_reward": 41.93000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4476083390293916
+      },
+      {
+        "run": 47,
+        "seed": 4255614877,
+        "success": true,
+        "steps": 170,
+        "total_reward": 39.510000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.541490675990676
+      },
+      {
+        "run": 48,
+        "seed": 4255614878,
+        "success": true,
+        "steps": 185,
+        "total_reward": 33.76500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43558940801200857
+      },
+      {
+        "run": 49,
+        "seed": 4255614879,
+        "success": true,
+        "steps": 184,
+        "total_reward": 33.540000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4220639796636002
+      },
+      {
+        "run": 50,
+        "seed": 4255614880,
+        "success": true,
+        "steps": 252,
+        "total_reward": 42.54000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3496833835984249
+      },
+      {
+        "run": 51,
+        "seed": 4255614881,
+        "success": true,
+        "steps": 207,
+        "total_reward": 38.065000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4706688048793312
+      },
+      {
+        "run": 52,
+        "seed": 4255614882,
+        "success": true,
+        "steps": 173,
+        "total_reward": 30.845000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.446003068568858
+      },
+      {
+        "run": 53,
+        "seed": 4255614883,
+        "success": true,
+        "steps": 283,
+        "total_reward": 41.53500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3118310879007473
+      },
+      {
+        "run": 54,
+        "seed": 4255614884,
+        "success": true,
+        "steps": 192,
+        "total_reward": 37.170000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5045128135575706
+      },
+      {
+        "run": 55,
+        "seed": 4255614885,
+        "success": true,
+        "steps": 224,
+        "total_reward": 32.79000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3679347503397393
+      },
+      {
+        "run": 56,
+        "seed": 4255614886,
+        "success": true,
+        "steps": 238,
+        "total_reward": 41.87000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41220335220335225
+      },
+      {
+        "run": 57,
+        "seed": 4255614887,
+        "success": true,
+        "steps": 215,
+        "total_reward": 37.76500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4291675774732041
+      },
+      {
+        "run": 58,
+        "seed": 4255614888,
+        "success": true,
+        "steps": 200,
+        "total_reward": 34.320000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4144945831491322
+      },
+      {
+        "run": 59,
+        "seed": 4255614889,
+        "success": true,
+        "steps": 194,
+        "total_reward": 35.670000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42598205338580897
+      },
+      {
+        "run": 60,
+        "seed": 4255614890,
+        "success": true,
+        "steps": 205,
+        "total_reward": 34.15500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3976915182518631
+      },
+      {
+        "run": 61,
+        "seed": 4255614891,
+        "success": true,
+        "steps": 192,
+        "total_reward": 37.690000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4396970448434795
+      },
+      {
+        "run": 62,
+        "seed": 4255614892,
+        "success": false,
+        "steps": 274,
+        "total_reward": 21.670000000000226,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.7105372405372404
+      },
+      {
+        "run": 63,
+        "seed": 4255614893,
+        "success": true,
+        "steps": 196,
+        "total_reward": 33.960000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.417874807185152
+      },
+      {
+        "run": 64,
+        "seed": 4255614894,
+        "success": true,
+        "steps": 209,
+        "total_reward": 36.485000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4468981745168509
+      },
+      {
+        "run": 65,
+        "seed": 4255614895,
+        "success": true,
+        "steps": 231,
+        "total_reward": 42.45500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.400204730920406
+      },
+      {
+        "run": 66,
+        "seed": 4255614896,
+        "success": true,
+        "steps": 210,
+        "total_reward": 30.790000000000177,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3711435492611963
+      },
+      {
+        "run": 67,
+        "seed": 4255614897,
+        "success": true,
+        "steps": 188,
+        "total_reward": 40.83000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49574167273021263
+      },
+      {
+        "run": 68,
+        "seed": 4255614898,
+        "success": true,
+        "steps": 226,
+        "total_reward": 33.79000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38448911378688266
+      },
+      {
+        "run": 69,
+        "seed": 4255614899,
+        "success": true,
+        "steps": 206,
+        "total_reward": 25.270000000000103,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37247741389045735
+      },
+      {
+        "run": 70,
+        "seed": 4255614900,
+        "success": true,
+        "steps": 229,
+        "total_reward": 40.025000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4172606962929543
+      },
+      {
+        "run": 71,
+        "seed": 4255614901,
+        "success": true,
+        "steps": 223,
+        "total_reward": 41.855000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.429980704399309
+      },
+      {
+        "run": 72,
+        "seed": 4255614902,
+        "success": true,
+        "steps": 174,
+        "total_reward": 38.740000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5059468524251807
+      },
+      {
+        "run": 73,
+        "seed": 4255614903,
+        "success": true,
+        "steps": 240,
+        "total_reward": 29.830000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3051034361176349
+      },
+      {
+        "run": 74,
+        "seed": 4255614904,
+        "success": true,
+        "steps": 229,
+        "total_reward": 35.34500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35586221770432297
+      },
+      {
+        "run": 75,
+        "seed": 4255614905,
+        "success": true,
+        "steps": 194,
+        "total_reward": 40.82000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4406277682697793
+      },
+      {
+        "run": 76,
+        "seed": 4255614906,
+        "success": true,
+        "steps": 208,
+        "total_reward": 31.7700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39681561732473564
+      },
+      {
+        "run": 77,
+        "seed": 4255614907,
+        "success": true,
+        "steps": 174,
+        "total_reward": 27.63000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39028950216450214
+      },
+      {
+        "run": 78,
+        "seed": 4255614908,
+        "success": true,
+        "steps": 194,
+        "total_reward": 37.35000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41758273889852837
+      },
+      {
+        "run": 79,
+        "seed": 4255614909,
+        "success": true,
+        "steps": 189,
+        "total_reward": 35.39500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4666240527341096
+      },
+      {
+        "run": 80,
+        "seed": 4255614910,
+        "success": true,
+        "steps": 191,
+        "total_reward": 32.765000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46652126902265945
+      },
+      {
+        "run": 81,
+        "seed": 4255614911,
+        "success": true,
+        "steps": 180,
+        "total_reward": 31.29000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4208880997051729
+      },
+      {
+        "run": 82,
+        "seed": 4255614912,
+        "success": true,
+        "steps": 202,
+        "total_reward": 34.2700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4069900687547746
+      },
+      {
+        "run": 83,
+        "seed": 4255614913,
+        "success": true,
+        "steps": 206,
+        "total_reward": 36.49000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4130900405900406
+      },
+      {
+        "run": 84,
+        "seed": 4255614914,
+        "success": true,
+        "steps": 218,
+        "total_reward": 34.630000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4313498784477897
+      },
+      {
+        "run": 85,
+        "seed": 4255614915,
+        "success": true,
+        "steps": 177,
+        "total_reward": 32.1750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38713810513810515
+      },
+      {
+        "run": 86,
+        "seed": 4255614916,
+        "success": true,
+        "steps": 220,
+        "total_reward": 33.63000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34283117490022097
+      },
+      {
+        "run": 87,
+        "seed": 4255614917,
+        "success": true,
+        "steps": 176,
+        "total_reward": 40.70000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5343127111788992
+      },
+      {
+        "run": 88,
+        "seed": 4255614918,
+        "success": true,
+        "steps": 170,
+        "total_reward": 36.86000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5045053568199348
+      },
+      {
+        "run": 89,
+        "seed": 4255614919,
+        "success": true,
+        "steps": 212,
+        "total_reward": 38.770000000000024,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43165450588837684
+      },
+      {
+        "run": 90,
+        "seed": 4255614920,
+        "success": true,
+        "steps": 155,
+        "total_reward": 38.00500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5058369898075781
+      },
+      {
+        "run": 91,
+        "seed": 4255614921,
+        "success": true,
+        "steps": 167,
+        "total_reward": 36.66500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.522947460628906
+      },
+      {
+        "run": 92,
+        "seed": 4255614922,
+        "success": true,
+        "steps": 177,
+        "total_reward": 37.04500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5027838827838828
+      },
+      {
+        "run": 93,
+        "seed": 4255614923,
+        "success": true,
+        "steps": 156,
+        "total_reward": 34.2100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5198798750269338
+      },
+      {
+        "run": 94,
+        "seed": 4255614924,
+        "success": true,
+        "steps": 214,
+        "total_reward": 34.91000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.448971027479092
+      },
+      {
+        "run": 95,
+        "seed": 4255614925,
+        "success": true,
+        "steps": 208,
+        "total_reward": 31.340000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35640417378320605
+      },
+      {
+        "run": 96,
+        "seed": 4255614926,
+        "success": true,
+        "steps": 192,
+        "total_reward": 32.38000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48882365687285595
+      },
+      {
+        "run": 97,
+        "seed": 4255614927,
+        "success": true,
+        "steps": 246,
+        "total_reward": 36.910000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3748603423998161
+      },
+      {
+        "run": 98,
+        "seed": 4255614928,
+        "success": true,
+        "steps": 284,
+        "total_reward": 34.47000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2477556422717743
+      },
+      {
+        "run": 99,
+        "seed": 4255614929,
+        "success": true,
+        "steps": 189,
+        "total_reward": 35.055000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4114577784586859
+      },
+      {
+        "run": 100,
+        "seed": 4255614930,
+        "success": true,
+        "steps": 187,
+        "total_reward": 38.71500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5089225888163338
+      },
+      {
+        "run": 101,
+        "seed": 4255614931,
+        "success": true,
+        "steps": 195,
+        "total_reward": 32.8350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.406106523550409
+      },
+      {
+        "run": 102,
+        "seed": 4255614932,
+        "success": true,
+        "steps": 222,
+        "total_reward": 43.420000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5067448614187745
+      },
+      {
+        "run": 103,
+        "seed": 4255614933,
+        "success": true,
+        "steps": 208,
+        "total_reward": 34.40000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3748915526624505
+      },
+      {
+        "run": 104,
+        "seed": 4255614934,
+        "success": true,
+        "steps": 198,
+        "total_reward": 33.40000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4540194357408224
+      },
+      {
+        "run": 105,
+        "seed": 4255614935,
+        "success": true,
+        "steps": 165,
+        "total_reward": 33.12500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5098083942201589
+      },
+      {
+        "run": 106,
+        "seed": 4255614936,
+        "success": true,
+        "steps": 209,
+        "total_reward": 42.775000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4678461426487742
+      },
+      {
+        "run": 107,
+        "seed": 4255614937,
+        "success": true,
+        "steps": 211,
+        "total_reward": 36.625000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4446555336648216
+      },
+      {
+        "run": 108,
+        "seed": 4255614938,
+        "success": true,
+        "steps": 204,
+        "total_reward": 38.11000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5178528884672149
+      },
+      {
+        "run": 109,
+        "seed": 4255614939,
+        "success": true,
+        "steps": 213,
+        "total_reward": 30.135000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37211971936109867
+      },
+      {
+        "run": 110,
+        "seed": 4255614940,
+        "success": true,
+        "steps": 278,
+        "total_reward": 40.20000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3681732365123208
+      },
+      {
+        "run": 111,
+        "seed": 4255614941,
+        "success": true,
+        "steps": 201,
+        "total_reward": 33.2850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44912955090637147
+      },
+      {
+        "run": 112,
+        "seed": 4255614942,
+        "success": true,
+        "steps": 183,
+        "total_reward": 41.725000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5203688141923436
+      },
+      {
+        "run": 113,
+        "seed": 4255614943,
+        "success": true,
+        "steps": 211,
+        "total_reward": 37.52500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3985712871006989
+      },
+      {
+        "run": 114,
+        "seed": 4255614944,
+        "success": true,
+        "steps": 206,
+        "total_reward": 34.55000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35636380303562964
+      },
+      {
+        "run": 115,
+        "seed": 4255614945,
+        "success": true,
+        "steps": 146,
+        "total_reward": 29.120000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5415764187503318
+      },
+      {
+        "run": 116,
+        "seed": 4255614946,
+        "success": true,
+        "steps": 160,
+        "total_reward": 36.49000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4891107503607504
+      },
+      {
+        "run": 117,
+        "seed": 4255614947,
+        "success": true,
+        "steps": 192,
+        "total_reward": 31.110000000000113,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4513251702874344
+      },
+      {
+        "run": 118,
+        "seed": 4255614948,
+        "success": true,
+        "steps": 267,
+        "total_reward": 41.485000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34765754713123137
+      },
+      {
+        "run": 119,
+        "seed": 4255614949,
+        "success": true,
+        "steps": 201,
+        "total_reward": 41.16500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4769719230724835
+      },
+      {
+        "run": 120,
+        "seed": 4255614950,
+        "success": true,
+        "steps": 183,
+        "total_reward": 32.78500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4272920847268673
+      },
+      {
+        "run": 121,
+        "seed": 4255614951,
+        "success": true,
+        "steps": 164,
+        "total_reward": 31.530000000000133,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5376143790849672
+      },
+      {
+        "run": 122,
+        "seed": 4255614952,
+        "success": true,
+        "steps": 147,
+        "total_reward": 33.64500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5025998184821714
+      },
+      {
+        "run": 123,
+        "seed": 4255614953,
+        "success": true,
+        "steps": 244,
+        "total_reward": 35.31000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4059528902470079
+      },
+      {
+        "run": 124,
+        "seed": 4255614954,
+        "success": true,
+        "steps": 218,
+        "total_reward": 39.53000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44460855768636093
+      },
+      {
+        "run": 125,
+        "seed": 4255614955,
+        "success": true,
+        "steps": 209,
+        "total_reward": 34.45500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4875922117098588
+      },
+      {
+        "run": 126,
+        "seed": 4255614956,
+        "success": true,
+        "steps": 218,
+        "total_reward": 42.21000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43857408177888724
+      },
+      {
+        "run": 127,
+        "seed": 4255614957,
+        "success": true,
+        "steps": 204,
+        "total_reward": 35.190000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.441483238983239
+      },
+      {
+        "run": 128,
+        "seed": 4255614958,
+        "success": true,
+        "steps": 173,
+        "total_reward": 20.565000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3770882560212246
+      },
+      {
+        "run": 129,
+        "seed": 4255614959,
+        "success": true,
+        "steps": 148,
+        "total_reward": 38.11000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6073800112930547
+      },
+      {
+        "run": 130,
+        "seed": 4255614960,
+        "success": true,
+        "steps": 199,
+        "total_reward": 40.195000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5062746675246675
+      },
+      {
+        "run": 131,
+        "seed": 4255614961,
+        "success": true,
+        "steps": 239,
+        "total_reward": 37.255000000000166,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3467747843554295
+      },
+      {
+        "run": 132,
+        "seed": 4255614962,
+        "success": true,
+        "steps": 174,
+        "total_reward": 39.34000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5066850867141115
+      },
+      {
+        "run": 133,
+        "seed": 4255614963,
+        "success": true,
+        "steps": 196,
+        "total_reward": 36.9200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41230695818726737
+      },
+      {
+        "run": 134,
+        "seed": 4255614964,
+        "success": true,
+        "steps": 183,
+        "total_reward": 40.71500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5648482564468007
+      },
+      {
+        "run": 135,
+        "seed": 4255614965,
+        "success": true,
+        "steps": 212,
+        "total_reward": 39.52000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5059543472188432
+      },
+      {
+        "run": 136,
+        "seed": 4255614966,
+        "success": true,
+        "steps": 135,
+        "total_reward": 33.62500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5519474136974136
+      },
+      {
+        "run": 137,
+        "seed": 4255614967,
+        "success": true,
+        "steps": 252,
+        "total_reward": 42.68000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3991491447244923
+      },
+      {
+        "run": 138,
+        "seed": 4255614968,
+        "success": true,
+        "steps": 211,
+        "total_reward": 35.31500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4205988092018119
+      },
+      {
+        "run": 139,
+        "seed": 4255614969,
+        "success": true,
+        "steps": 177,
+        "total_reward": 37.42500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48318737972642645
+      },
+      {
+        "run": 140,
+        "seed": 4255614970,
+        "success": true,
+        "steps": 183,
+        "total_reward": 34.305000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4616341991341991
+      },
+      {
+        "run": 141,
+        "seed": 4255614971,
+        "success": true,
+        "steps": 167,
+        "total_reward": 30.63500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4211937327378504
+      },
+      {
+        "run": 142,
+        "seed": 4255614972,
+        "success": true,
+        "steps": 172,
+        "total_reward": 33.92000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49956230860642625
+      },
+      {
+        "run": 143,
+        "seed": 4255614973,
+        "success": true,
+        "steps": 219,
+        "total_reward": 45.19500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4429579849974587
+      },
+      {
+        "run": 144,
+        "seed": 4255614974,
+        "success": true,
+        "steps": 185,
+        "total_reward": 30.245000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4099040451957909
+      },
+      {
+        "run": 145,
+        "seed": 4255614975,
+        "success": true,
+        "steps": 235,
+        "total_reward": 37.46500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3745585269288456
+      },
+      {
+        "run": 146,
+        "seed": 4255614976,
+        "success": true,
+        "steps": 224,
+        "total_reward": 45.31000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41261880190672756
+      },
+      {
+        "run": 147,
+        "seed": 4255614977,
+        "success": true,
+        "steps": 244,
+        "total_reward": 33.57000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34846286636300317
+      },
+      {
+        "run": 148,
+        "seed": 4255614978,
+        "success": true,
+        "steps": 151,
+        "total_reward": 34.60500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4818868149394465
+      },
+      {
+        "run": 149,
+        "seed": 4255614979,
+        "success": true,
+        "steps": 217,
+        "total_reward": 35.92500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4122581850553987
+      },
+      {
+        "run": 150,
+        "seed": 4255614980,
+        "success": true,
+        "steps": 179,
+        "total_reward": 37.94500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44499087392394027
+      },
+      {
+        "run": 151,
+        "seed": 4255614981,
+        "success": true,
+        "steps": 251,
+        "total_reward": 43.08500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41520086155079144
+      },
+      {
+        "run": 152,
+        "seed": 4255614982,
+        "success": true,
+        "steps": 196,
+        "total_reward": 37.25000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.428727937194829
+      },
+      {
+        "run": 153,
+        "seed": 4255614983,
+        "success": true,
+        "steps": 199,
+        "total_reward": 36.23500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4479851124485271
+      },
+      {
+        "run": 154,
+        "seed": 4255614984,
+        "success": true,
+        "steps": 176,
+        "total_reward": 38.90000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.485578529657477
+      },
+      {
+        "run": 155,
+        "seed": 4255614985,
+        "success": true,
+        "steps": 165,
+        "total_reward": 31.15500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43632417955979863
+      },
+      {
+        "run": 156,
+        "seed": 4255614986,
+        "success": true,
+        "steps": 212,
+        "total_reward": 38.89000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4040365157069963
+      },
+      {
+        "run": 157,
+        "seed": 4255614987,
+        "success": true,
+        "steps": 201,
+        "total_reward": 37.9350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42468128197539967
+      },
+      {
+        "run": 158,
+        "seed": 4255614988,
+        "success": true,
+        "steps": 222,
+        "total_reward": 30.670000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3585724996251312
+      },
+      {
+        "run": 159,
+        "seed": 4255614989,
+        "success": true,
+        "steps": 182,
+        "total_reward": 31.410000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42092087309478615
+      },
+      {
+        "run": 160,
+        "seed": 4255614990,
+        "success": true,
+        "steps": 212,
+        "total_reward": 35.36000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4015353833841229
+      },
+      {
+        "run": 161,
+        "seed": 4255614991,
+        "success": true,
+        "steps": 166,
+        "total_reward": 37.500000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5174747474747475
+      },
+      {
+        "run": 162,
+        "seed": 4255614992,
+        "success": true,
+        "steps": 283,
+        "total_reward": 33.805000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.313198696997813
+      },
+      {
+        "run": 163,
+        "seed": 4255614993,
+        "success": true,
+        "steps": 179,
+        "total_reward": 30.545000000000112,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3793727106227106
+      },
+      {
+        "run": 164,
+        "seed": 4255614994,
+        "success": true,
+        "steps": 213,
+        "total_reward": 37.685000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3709590230061032
+      },
+      {
+        "run": 165,
+        "seed": 4255614995,
+        "success": true,
+        "steps": 234,
+        "total_reward": 38.64000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4388509245894645
+      },
+      {
+        "run": 166,
+        "seed": 4255614996,
+        "success": true,
+        "steps": 234,
+        "total_reward": 39.310000000000166,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40832417582417585
+      },
+      {
+        "run": 167,
+        "seed": 4255614997,
+        "success": true,
+        "steps": 220,
+        "total_reward": 35.07000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37018613682850854
+      },
+      {
+        "run": 168,
+        "seed": 4255614998,
+        "success": true,
+        "steps": 219,
+        "total_reward": 31.55500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3055421742186448
+      },
+      {
+        "run": 169,
+        "seed": 4255614999,
+        "success": true,
+        "steps": 189,
+        "total_reward": 32.865000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4523760127706997
+      },
+      {
+        "run": 170,
+        "seed": 4255615000,
+        "success": true,
+        "steps": 219,
+        "total_reward": 31.485000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35157257878997006
+      },
+      {
+        "run": 171,
+        "seed": 4255615001,
+        "success": true,
+        "steps": 178,
+        "total_reward": 39.550000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5153380345145051
+      },
+      {
+        "run": 172,
+        "seed": 4255615002,
+        "success": true,
+        "steps": 199,
+        "total_reward": 33.76500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40492982456140353
+      },
+      {
+        "run": 173,
+        "seed": 4255615003,
+        "success": true,
+        "steps": 192,
+        "total_reward": 35.930000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4275738900083529
+      },
+      {
+        "run": 174,
+        "seed": 4255615004,
+        "success": true,
+        "steps": 164,
+        "total_reward": 34.79000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5019381925264279
+      },
+      {
+        "run": 175,
+        "seed": 4255615005,
+        "success": true,
+        "steps": 138,
+        "total_reward": 36.120000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5760198761811666
+      },
+      {
+        "run": 176,
+        "seed": 4255615006,
+        "success": true,
+        "steps": 211,
+        "total_reward": 40.475000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4698133456809178
+      },
+      {
+        "run": 177,
+        "seed": 4255615007,
+        "success": true,
+        "steps": 180,
+        "total_reward": 34.05000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4496532324184094
+      },
+      {
+        "run": 178,
+        "seed": 4255615008,
+        "success": true,
+        "steps": 175,
+        "total_reward": 40.21500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5405194176866004
+      },
+      {
+        "run": 179,
+        "seed": 4255615009,
+        "success": true,
+        "steps": 224,
+        "total_reward": 37.88000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.445432678998044
+      },
+      {
+        "run": 180,
+        "seed": 4255615010,
+        "success": true,
+        "steps": 181,
+        "total_reward": 34.37500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47775651304572325
+      },
+      {
+        "run": 181,
+        "seed": 4255615011,
+        "success": true,
+        "steps": 174,
+        "total_reward": 33.730000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4758089353205185
+      },
+      {
+        "run": 182,
+        "seed": 4255615012,
+        "success": true,
+        "steps": 187,
+        "total_reward": 32.105000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4106190958164643
+      },
+      {
+        "run": 183,
+        "seed": 4255615013,
+        "success": true,
+        "steps": 196,
+        "total_reward": 33.10000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3868758942288354
+      },
+      {
+        "run": 184,
+        "seed": 4255615014,
+        "success": true,
+        "steps": 213,
+        "total_reward": 41.08500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41017373529130746
+      },
+      {
+        "run": 185,
+        "seed": 4255615015,
+        "success": true,
+        "steps": 151,
+        "total_reward": 35.85500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5458617160392009
+      },
+      {
+        "run": 186,
+        "seed": 4255615016,
+        "success": true,
+        "steps": 184,
+        "total_reward": 31.360000000000138,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41443422169228616
+      },
+      {
+        "run": 187,
+        "seed": 4255615017,
+        "success": true,
+        "steps": 217,
+        "total_reward": 40.29500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38025724058077
+      },
+      {
+        "run": 188,
+        "seed": 4255615018,
+        "success": true,
+        "steps": 173,
+        "total_reward": 38.675000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45410100539071463
+      },
+      {
+        "run": 189,
+        "seed": 4255615019,
+        "success": true,
+        "steps": 195,
+        "total_reward": 40.635000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4712316842831717
+      },
+      {
+        "run": 190,
+        "seed": 4255615020,
+        "success": true,
+        "steps": 201,
+        "total_reward": 33.76500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43379020979020977
+      },
+      {
+        "run": 191,
+        "seed": 4255615021,
+        "success": true,
+        "steps": 155,
+        "total_reward": 34.4650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5741052631578947
+      },
+      {
+        "run": 192,
+        "seed": 4255615022,
+        "success": true,
+        "steps": 163,
+        "total_reward": 35.2350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48854716820274097
+      },
+      {
+        "run": 193,
+        "seed": 4255615023,
+        "success": true,
+        "steps": 212,
+        "total_reward": 33.2600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3576987829177969
+      },
+      {
+        "run": 194,
+        "seed": 4255615024,
+        "success": true,
+        "steps": 154,
+        "total_reward": 29.930000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5124645469473055
+      },
+      {
+        "run": 195,
+        "seed": 4255615025,
+        "success": true,
+        "steps": 178,
+        "total_reward": 35.460000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4286080586080586
+      },
+      {
+        "run": 196,
+        "seed": 4255615026,
+        "success": true,
+        "steps": 203,
+        "total_reward": 36.18500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43780704711183016
+      },
+      {
+        "run": 197,
+        "seed": 4255615027,
+        "success": true,
+        "steps": 194,
+        "total_reward": 43.0100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48413217671785447
+      },
+      {
+        "run": 198,
+        "seed": 4255615028,
+        "success": true,
+        "steps": 205,
+        "total_reward": 35.785000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40501983808018294
+      },
+      {
+        "run": 199,
+        "seed": 4255615029,
+        "success": true,
+        "steps": 183,
+        "total_reward": 37.005000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44525727304864426
+      },
+      {
+        "run": 200,
+        "seed": 4255615030,
+        "success": true,
+        "steps": 213,
+        "total_reward": 34.43500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4017457150324245
+      }
+    ],
+    "avg_chemotaxis_index": 0.3846341816137267,
+    "avg_time_in_attractant": 0.6923170908068633,
+    "avg_approach_frequency": 0.41819150914646736,
+    "avg_path_efficiency": 0.04149919356539372,
+    "post_convergence_chemotaxis_index": 0.3914273946456184,
+    "post_convergence_time_in_attractant": 0.6957136973228092,
+    "post_convergence_approach_frequency": 0.42049997313086107,
+    "post_convergence_path_efficiency": 0.04288697244283293,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_095329.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_095329.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_095329",
+  "timestamp": "2025-12-29T10:02:32.504360+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_095329",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.97,
+    "avg_steps": 199.53,
+    "avg_reward": 35.2030500000001,
+    "avg_foods_collected": 9.82,
+    "avg_distance_efficiency": 0.441488235496052,
+    "completed_all_food": 194,
+    "starved": 5,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 7,
+    "runs_to_convergence": 6,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 194.6701030927835,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.4511647116204974,
+    "composite_benchmark_score": 0.8293494134861493,
+    "learning_speed": 0.9299999999999999,
+    "learning_speed_episodes": 14,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3429436109,
+        "success": false,
+        "steps": 200,
+        "total_reward": -8.369999999999994,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 3429436110,
+        "success": false,
+        "steps": 360,
+        "total_reward": 5.0899999999999,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.1306926473221317
+      },
+      {
+        "run": 3,
+        "seed": 3429436111,
+        "success": false,
+        "steps": 280,
+        "total_reward": -1.5900000000000283,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.10484637313905606
+      },
+      {
+        "run": 4,
+        "seed": 3429436112,
+        "success": false,
+        "steps": 360,
+        "total_reward": 11.410000000000153,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.22004549718881825
+      },
+      {
+        "run": 5,
+        "seed": 3429436113,
+        "success": false,
+        "steps": 440,
+        "total_reward": 20.210000000000267,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.12679278961557652
+      },
+      {
+        "run": 6,
+        "seed": 3429436114,
+        "success": false,
+        "steps": 500,
+        "total_reward": 34.45000000000013,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.18931573756831838
+      },
+      {
+        "run": 7,
+        "seed": 3429436115,
+        "success": true,
+        "steps": 444,
+        "total_reward": 45.84,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23687567378625074
+      },
+      {
+        "run": 8,
+        "seed": 3429436116,
+        "success": true,
+        "steps": 382,
+        "total_reward": 38.35000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34368303199169814
+      },
+      {
+        "run": 9,
+        "seed": 3429436117,
+        "success": true,
+        "steps": 312,
+        "total_reward": 40.90000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2758858618136569
+      },
+      {
+        "run": 10,
+        "seed": 3429436118,
+        "success": true,
+        "steps": 257,
+        "total_reward": 38.34500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3753849212184274
+      },
+      {
+        "run": 11,
+        "seed": 3429436119,
+        "success": true,
+        "steps": 197,
+        "total_reward": 32.0650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41902863227991105
+      },
+      {
+        "run": 12,
+        "seed": 3429436120,
+        "success": true,
+        "steps": 194,
+        "total_reward": 32.69000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47206904206904204
+      },
+      {
+        "run": 13,
+        "seed": 3429436121,
+        "success": true,
+        "steps": 236,
+        "total_reward": 38.52000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.445221599703496
+      },
+      {
+        "run": 14,
+        "seed": 3429436122,
+        "success": true,
+        "steps": 251,
+        "total_reward": 36.225000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39960538456401007
+      },
+      {
+        "run": 15,
+        "seed": 3429436123,
+        "success": true,
+        "steps": 246,
+        "total_reward": 45.02000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4253183001710875
+      },
+      {
+        "run": 16,
+        "seed": 3429436124,
+        "success": true,
+        "steps": 255,
+        "total_reward": 38.225000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4085206606259238
+      },
+      {
+        "run": 17,
+        "seed": 3429436125,
+        "success": true,
+        "steps": 213,
+        "total_reward": 28.165000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40062059522734794
+      },
+      {
+        "run": 18,
+        "seed": 3429436126,
+        "success": true,
+        "steps": 181,
+        "total_reward": 35.07500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.512191306500517
+      },
+      {
+        "run": 19,
+        "seed": 3429436127,
+        "success": true,
+        "steps": 268,
+        "total_reward": 36.49000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3462474081576764
+      },
+      {
+        "run": 20,
+        "seed": 3429436128,
+        "success": true,
+        "steps": 249,
+        "total_reward": 34.59500000000024,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3649609732874096
+      },
+      {
+        "run": 21,
+        "seed": 3429436129,
+        "success": true,
+        "steps": 225,
+        "total_reward": 39.00500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42355487157309935
+      },
+      {
+        "run": 22,
+        "seed": 3429436130,
+        "success": true,
+        "steps": 200,
+        "total_reward": 37.59000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3983770469296785
+      },
+      {
+        "run": 23,
+        "seed": 3429436131,
+        "success": true,
+        "steps": 263,
+        "total_reward": 39.81500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40398700206480526
+      },
+      {
+        "run": 24,
+        "seed": 3429436132,
+        "success": true,
+        "steps": 209,
+        "total_reward": 28.555000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3562085137085137
+      },
+      {
+        "run": 25,
+        "seed": 3429436133,
+        "success": true,
+        "steps": 162,
+        "total_reward": 27.040000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40489983600277724
+      },
+      {
+        "run": 26,
+        "seed": 3429436134,
+        "success": true,
+        "steps": 234,
+        "total_reward": 34.36000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4187240836925269
+      },
+      {
+        "run": 27,
+        "seed": 3429436135,
+        "success": true,
+        "steps": 216,
+        "total_reward": 34.160000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4231789721396514
+      },
+      {
+        "run": 28,
+        "seed": 3429436136,
+        "success": true,
+        "steps": 198,
+        "total_reward": 38.44000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4183105725081896
+      },
+      {
+        "run": 29,
+        "seed": 3429436137,
+        "success": true,
+        "steps": 185,
+        "total_reward": 35.735000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4411290790027369
+      },
+      {
+        "run": 30,
+        "seed": 3429436138,
+        "success": true,
+        "steps": 217,
+        "total_reward": 44.30500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4311681945505475
+      },
+      {
+        "run": 31,
+        "seed": 3429436139,
+        "success": true,
+        "steps": 220,
+        "total_reward": 41.85000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4497125097125097
+      },
+      {
+        "run": 32,
+        "seed": 3429436140,
+        "success": true,
+        "steps": 205,
+        "total_reward": 27.775000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3520903361344538
+      },
+      {
+        "run": 33,
+        "seed": 3429436141,
+        "success": true,
+        "steps": 160,
+        "total_reward": 33.2100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48908002669844775
+      },
+      {
+        "run": 34,
+        "seed": 3429436142,
+        "success": true,
+        "steps": 177,
+        "total_reward": 30.575000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5425842032363771
+      },
+      {
+        "run": 35,
+        "seed": 3429436143,
+        "success": true,
+        "steps": 204,
+        "total_reward": 35.69000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47451101557846964
+      },
+      {
+        "run": 36,
+        "seed": 3429436144,
+        "success": true,
+        "steps": 223,
+        "total_reward": 35.98500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.477685931352598
+      },
+      {
+        "run": 37,
+        "seed": 3429436145,
+        "success": true,
+        "steps": 202,
+        "total_reward": 38.11,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42016992172363016
+      },
+      {
+        "run": 38,
+        "seed": 3429436146,
+        "success": true,
+        "steps": 182,
+        "total_reward": 28.52000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3965714285714286
+      },
+      {
+        "run": 39,
+        "seed": 3429436147,
+        "success": true,
+        "steps": 248,
+        "total_reward": 33.440000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33242952449849
+      },
+      {
+        "run": 40,
+        "seed": 3429436148,
+        "success": true,
+        "steps": 196,
+        "total_reward": 36.470000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40572618139551775
+      },
+      {
+        "run": 41,
+        "seed": 3429436149,
+        "success": true,
+        "steps": 223,
+        "total_reward": 34.41500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33536881451049366
+      },
+      {
+        "run": 42,
+        "seed": 3429436150,
+        "success": true,
+        "steps": 185,
+        "total_reward": 37.89500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5109191247349142
+      },
+      {
+        "run": 43,
+        "seed": 3429436151,
+        "success": true,
+        "steps": 146,
+        "total_reward": 31.42000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46747623291740936
+      },
+      {
+        "run": 44,
+        "seed": 3429436152,
+        "success": true,
+        "steps": 149,
+        "total_reward": 37.70500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5622228648544438
+      },
+      {
+        "run": 45,
+        "seed": 3429436153,
+        "success": true,
+        "steps": 198,
+        "total_reward": 39.24000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46384249084249085
+      },
+      {
+        "run": 46,
+        "seed": 3429436154,
+        "success": true,
+        "steps": 211,
+        "total_reward": 39.0550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4214547724081193
+      },
+      {
+        "run": 47,
+        "seed": 3429436155,
+        "success": true,
+        "steps": 181,
+        "total_reward": 32.70500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4513937271878448
+      },
+      {
+        "run": 48,
+        "seed": 3429436156,
+        "success": true,
+        "steps": 208,
+        "total_reward": 46.44000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4735754604872252
+      },
+      {
+        "run": 49,
+        "seed": 3429436157,
+        "success": true,
+        "steps": 198,
+        "total_reward": 34.42000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4703100031060557
+      },
+      {
+        "run": 50,
+        "seed": 3429436158,
+        "success": true,
+        "steps": 186,
+        "total_reward": 34.680000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.423407282741738
+      },
+      {
+        "run": 51,
+        "seed": 3429436159,
+        "success": true,
+        "steps": 212,
+        "total_reward": 37.670000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4750263771316403
+      },
+      {
+        "run": 52,
+        "seed": 3429436160,
+        "success": true,
+        "steps": 180,
+        "total_reward": 38.97000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5585324748616184
+      },
+      {
+        "run": 53,
+        "seed": 3429436161,
+        "success": true,
+        "steps": 178,
+        "total_reward": 33.32000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4056723319792037
+      },
+      {
+        "run": 54,
+        "seed": 3429436162,
+        "success": true,
+        "steps": 181,
+        "total_reward": 33.72500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5062775217613927
+      },
+      {
+        "run": 55,
+        "seed": 3429436163,
+        "success": true,
+        "steps": 148,
+        "total_reward": 37.54000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5682367305896718
+      },
+      {
+        "run": 56,
+        "seed": 3429436164,
+        "success": true,
+        "steps": 201,
+        "total_reward": 37.475000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41516211398564334
+      },
+      {
+        "run": 57,
+        "seed": 3429436165,
+        "success": true,
+        "steps": 214,
+        "total_reward": 38.610000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44396692488797757
+      },
+      {
+        "run": 58,
+        "seed": 3429436166,
+        "success": true,
+        "steps": 177,
+        "total_reward": 33.925000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5272219085262564
+      },
+      {
+        "run": 59,
+        "seed": 3429436167,
+        "success": true,
+        "steps": 204,
+        "total_reward": 44.43000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49906499547304434
+      },
+      {
+        "run": 60,
+        "seed": 3429436168,
+        "success": true,
+        "steps": 194,
+        "total_reward": 40.41000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5117878028404343
+      },
+      {
+        "run": 61,
+        "seed": 3429436169,
+        "success": true,
+        "steps": 194,
+        "total_reward": 31.870000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38995070598772424
+      },
+      {
+        "run": 62,
+        "seed": 3429436170,
+        "success": true,
+        "steps": 273,
+        "total_reward": 38.945000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37300324675324675
+      },
+      {
+        "run": 63,
+        "seed": 3429436171,
+        "success": true,
+        "steps": 178,
+        "total_reward": 31.990000000000148,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4056045425163072
+      },
+      {
+        "run": 64,
+        "seed": 3429436172,
+        "success": true,
+        "steps": 166,
+        "total_reward": 37.82000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5445274725274725
+      },
+      {
+        "run": 65,
+        "seed": 3429436173,
+        "success": true,
+        "steps": 178,
+        "total_reward": 31.15000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4618627105583627
+      },
+      {
+        "run": 66,
+        "seed": 3429436174,
+        "success": true,
+        "steps": 184,
+        "total_reward": 30.130000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3685959692481432
+      },
+      {
+        "run": 67,
+        "seed": 3429436175,
+        "success": true,
+        "steps": 174,
+        "total_reward": 38.510000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4847709016130069
+      },
+      {
+        "run": 68,
+        "seed": 3429436176,
+        "success": true,
+        "steps": 193,
+        "total_reward": 38.87500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49778536648999727
+      },
+      {
+        "run": 69,
+        "seed": 3429436177,
+        "success": true,
+        "steps": 139,
+        "total_reward": 35.3750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5848311546840959
+      },
+      {
+        "run": 70,
+        "seed": 3429436178,
+        "success": true,
+        "steps": 228,
+        "total_reward": 35.16000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3980720879873422
+      },
+      {
+        "run": 71,
+        "seed": 3429436179,
+        "success": true,
+        "steps": 188,
+        "total_reward": 37.59000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4458206087312974
+      },
+      {
+        "run": 72,
+        "seed": 3429436180,
+        "success": true,
+        "steps": 169,
+        "total_reward": 34.18500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45552223742441134
+      },
+      {
+        "run": 73,
+        "seed": 3429436181,
+        "success": true,
+        "steps": 190,
+        "total_reward": 31.430000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4735513595682176
+      },
+      {
+        "run": 74,
+        "seed": 3429436182,
+        "success": true,
+        "steps": 176,
+        "total_reward": 38.63000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4908303706097824
+      },
+      {
+        "run": 75,
+        "seed": 3429436183,
+        "success": true,
+        "steps": 171,
+        "total_reward": 30.485000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4523240164228536
+      },
+      {
+        "run": 76,
+        "seed": 3429436184,
+        "success": true,
+        "steps": 176,
+        "total_reward": 32.28000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3940591194122896
+      },
+      {
+        "run": 77,
+        "seed": 3429436185,
+        "success": true,
+        "steps": 247,
+        "total_reward": 34.53500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36085938033750087
+      },
+      {
+        "run": 78,
+        "seed": 3429436186,
+        "success": true,
+        "steps": 176,
+        "total_reward": 34.560000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45017469848991587
+      },
+      {
+        "run": 79,
+        "seed": 3429436187,
+        "success": true,
+        "steps": 169,
+        "total_reward": 39.13500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5324586717548259
+      },
+      {
+        "run": 80,
+        "seed": 3429436188,
+        "success": true,
+        "steps": 151,
+        "total_reward": 41.4050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5889896309400953
+      },
+      {
+        "run": 81,
+        "seed": 3429436189,
+        "success": true,
+        "steps": 225,
+        "total_reward": 29.685000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3162139172883854
+      },
+      {
+        "run": 82,
+        "seed": 3429436190,
+        "success": true,
+        "steps": 164,
+        "total_reward": 35.41000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46322438483429196
+      },
+      {
+        "run": 83,
+        "seed": 3429436191,
+        "success": true,
+        "steps": 235,
+        "total_reward": 36.08500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4191771372961884
+      },
+      {
+        "run": 84,
+        "seed": 3429436192,
+        "success": true,
+        "steps": 195,
+        "total_reward": 31.835000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37895873734109026
+      },
+      {
+        "run": 85,
+        "seed": 3429436193,
+        "success": true,
+        "steps": 196,
+        "total_reward": 30.9300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3849496336996337
+      },
+      {
+        "run": 86,
+        "seed": 3429436194,
+        "success": true,
+        "steps": 173,
+        "total_reward": 36.53500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45215986790986795
+      },
+      {
+        "run": 87,
+        "seed": 3429436195,
+        "success": true,
+        "steps": 191,
+        "total_reward": 40.275000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49148137994200614
+      },
+      {
+        "run": 88,
+        "seed": 3429436196,
+        "success": true,
+        "steps": 139,
+        "total_reward": 33.405000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48221124286341677
+      },
+      {
+        "run": 89,
+        "seed": 3429436197,
+        "success": true,
+        "steps": 144,
+        "total_reward": 27.220000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4414772727272728
+      },
+      {
+        "run": 90,
+        "seed": 3429436198,
+        "success": true,
+        "steps": 160,
+        "total_reward": 32.840000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5345978087357397
+      },
+      {
+        "run": 91,
+        "seed": 3429436199,
+        "success": true,
+        "steps": 209,
+        "total_reward": 36.61500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4250477941806964
+      },
+      {
+        "run": 92,
+        "seed": 3429436200,
+        "success": true,
+        "steps": 170,
+        "total_reward": 34.7000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46560290586606373
+      },
+      {
+        "run": 93,
+        "seed": 3429436201,
+        "success": true,
+        "steps": 171,
+        "total_reward": 30.975000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4470743514797223
+      },
+      {
+        "run": 94,
+        "seed": 3429436202,
+        "success": true,
+        "steps": 211,
+        "total_reward": 37.80500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3896464256990573
+      },
+      {
+        "run": 95,
+        "seed": 3429436203,
+        "success": true,
+        "steps": 174,
+        "total_reward": 33.44000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4332594856124268
+      },
+      {
+        "run": 96,
+        "seed": 3429436204,
+        "success": true,
+        "steps": 187,
+        "total_reward": 39.21500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4627375975473802
+      },
+      {
+        "run": 97,
+        "seed": 3429436205,
+        "success": true,
+        "steps": 163,
+        "total_reward": 31.765000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44750854700854703
+      },
+      {
+        "run": 98,
+        "seed": 3429436206,
+        "success": true,
+        "steps": 185,
+        "total_reward": 38.495000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4762813589385598
+      },
+      {
+        "run": 99,
+        "seed": 3429436207,
+        "success": true,
+        "steps": 219,
+        "total_reward": 37.03500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43067253967001456
+      },
+      {
+        "run": 100,
+        "seed": 3429436208,
+        "success": true,
+        "steps": 176,
+        "total_reward": 32.41000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43512210012210006
+      },
+      {
+        "run": 101,
+        "seed": 3429436209,
+        "success": true,
+        "steps": 210,
+        "total_reward": 36.600000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.510606435749687
+      },
+      {
+        "run": 102,
+        "seed": 3429436210,
+        "success": true,
+        "steps": 190,
+        "total_reward": 31.210000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43944405057308283
+      },
+      {
+        "run": 103,
+        "seed": 3429436211,
+        "success": true,
+        "steps": 159,
+        "total_reward": 30.255000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4078907203907204
+      },
+      {
+        "run": 104,
+        "seed": 3429436212,
+        "success": true,
+        "steps": 187,
+        "total_reward": 33.20500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42155852199330457
+      },
+      {
+        "run": 105,
+        "seed": 3429436213,
+        "success": true,
+        "steps": 208,
+        "total_reward": 34.12000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4592916951469583
+      },
+      {
+        "run": 106,
+        "seed": 3429436214,
+        "success": true,
+        "steps": 232,
+        "total_reward": 42.25000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4179828051561264
+      },
+      {
+        "run": 107,
+        "seed": 3429436215,
+        "success": true,
+        "steps": 199,
+        "total_reward": 39.32500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40989150684197123
+      },
+      {
+        "run": 108,
+        "seed": 3429436216,
+        "success": true,
+        "steps": 148,
+        "total_reward": 34.2600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5612129281537176
+      },
+      {
+        "run": 109,
+        "seed": 3429436217,
+        "success": true,
+        "steps": 171,
+        "total_reward": 31.595000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4282719108377003
+      },
+      {
+        "run": 110,
+        "seed": 3429436218,
+        "success": true,
+        "steps": 164,
+        "total_reward": 38.13000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5591675814469932
+      },
+      {
+        "run": 111,
+        "seed": 3429436219,
+        "success": true,
+        "steps": 188,
+        "total_reward": 29.000000000000128,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36189208713357324
+      },
+      {
+        "run": 112,
+        "seed": 3429436220,
+        "success": true,
+        "steps": 260,
+        "total_reward": 38.780000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.429262973152362
+      },
+      {
+        "run": 113,
+        "seed": 3429436221,
+        "success": true,
+        "steps": 198,
+        "total_reward": 34.460000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40898503883886195
+      },
+      {
+        "run": 114,
+        "seed": 3429436222,
+        "success": true,
+        "steps": 228,
+        "total_reward": 42.700000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43291558202954894
+      },
+      {
+        "run": 115,
+        "seed": 3429436223,
+        "success": true,
+        "steps": 166,
+        "total_reward": 36.720000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5448611111111111
+      },
+      {
+        "run": 116,
+        "seed": 3429436224,
+        "success": true,
+        "steps": 197,
+        "total_reward": 33.645000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4211507693876649
+      },
+      {
+        "run": 117,
+        "seed": 3429436225,
+        "success": true,
+        "steps": 170,
+        "total_reward": 27.800000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46730023025754736
+      },
+      {
+        "run": 118,
+        "seed": 3429436226,
+        "success": true,
+        "steps": 167,
+        "total_reward": 40.45500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5623780091746844
+      },
+      {
+        "run": 119,
+        "seed": 3429436227,
+        "success": true,
+        "steps": 179,
+        "total_reward": 36.205000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4843956043956045
+      },
+      {
+        "run": 120,
+        "seed": 3429436228,
+        "success": true,
+        "steps": 198,
+        "total_reward": 34.22000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42975211315728556
+      },
+      {
+        "run": 121,
+        "seed": 3429436229,
+        "success": true,
+        "steps": 177,
+        "total_reward": 35.4550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47376826682089834
+      },
+      {
+        "run": 122,
+        "seed": 3429436230,
+        "success": true,
+        "steps": 210,
+        "total_reward": 41.34000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43506189260799577
+      },
+      {
+        "run": 123,
+        "seed": 3429436231,
+        "success": true,
+        "steps": 192,
+        "total_reward": 31.050000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4329842149594471
+      },
+      {
+        "run": 124,
+        "seed": 3429436232,
+        "success": true,
+        "steps": 182,
+        "total_reward": 37.26000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4284944789028273
+      },
+      {
+        "run": 125,
+        "seed": 3429436233,
+        "success": true,
+        "steps": 205,
+        "total_reward": 41.30500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4708475054357407
+      },
+      {
+        "run": 126,
+        "seed": 3429436234,
+        "success": true,
+        "steps": 181,
+        "total_reward": 33.1350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4330367585630744
+      },
+      {
+        "run": 127,
+        "seed": 3429436235,
+        "success": true,
+        "steps": 179,
+        "total_reward": 44.53500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5697786729399633
+      },
+      {
+        "run": 128,
+        "seed": 3429436236,
+        "success": true,
+        "steps": 120,
+        "total_reward": 28.400000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5189028944911298
+      },
+      {
+        "run": 129,
+        "seed": 3429436237,
+        "success": true,
+        "steps": 184,
+        "total_reward": 33.73000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41365131520737924
+      },
+      {
+        "run": 130,
+        "seed": 3429436238,
+        "success": true,
+        "steps": 177,
+        "total_reward": 37.645000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4897825371509582
+      },
+      {
+        "run": 131,
+        "seed": 3429436239,
+        "success": true,
+        "steps": 207,
+        "total_reward": 36.6550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4750435388366423
+      },
+      {
+        "run": 132,
+        "seed": 3429436240,
+        "success": true,
+        "steps": 184,
+        "total_reward": 38.64000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5034326181065312
+      },
+      {
+        "run": 133,
+        "seed": 3429436241,
+        "success": true,
+        "steps": 183,
+        "total_reward": 32.42500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4516907325131009
+      },
+      {
+        "run": 134,
+        "seed": 3429436242,
+        "success": true,
+        "steps": 260,
+        "total_reward": 37.760000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37437290779396043
+      },
+      {
+        "run": 135,
+        "seed": 3429436243,
+        "success": true,
+        "steps": 212,
+        "total_reward": 35.7800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.457910158610623
+      },
+      {
+        "run": 136,
+        "seed": 3429436244,
+        "success": true,
+        "steps": 193,
+        "total_reward": 34.855000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4512007441657323
+      },
+      {
+        "run": 137,
+        "seed": 3429436245,
+        "success": true,
+        "steps": 232,
+        "total_reward": 44.8500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4977202285151363
+      },
+      {
+        "run": 138,
+        "seed": 3429436246,
+        "success": true,
+        "steps": 170,
+        "total_reward": 31.44000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44868007809184274
+      },
+      {
+        "run": 139,
+        "seed": 3429436247,
+        "success": true,
+        "steps": 162,
+        "total_reward": 37.89000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5851587786881904
+      },
+      {
+        "run": 140,
+        "seed": 3429436248,
+        "success": true,
+        "steps": 228,
+        "total_reward": 41.79000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4179328777582592
+      },
+      {
+        "run": 141,
+        "seed": 3429436249,
+        "success": true,
+        "steps": 225,
+        "total_reward": 37.035000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4172888189046725
+      },
+      {
+        "run": 142,
+        "seed": 3429436250,
+        "success": true,
+        "steps": 199,
+        "total_reward": 35.98500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4459545491920795
+      },
+      {
+        "run": 143,
+        "seed": 3429436251,
+        "success": true,
+        "steps": 177,
+        "total_reward": 34.7950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4826864801864802
+      },
+      {
+        "run": 144,
+        "seed": 3429436252,
+        "success": true,
+        "steps": 175,
+        "total_reward": 36.2850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4400862068965517
+      },
+      {
+        "run": 145,
+        "seed": 3429436253,
+        "success": true,
+        "steps": 170,
+        "total_reward": 40.20000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4881866430782839
+      },
+      {
+        "run": 146,
+        "seed": 3429436254,
+        "success": true,
+        "steps": 207,
+        "total_reward": 41.12500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38823123009887717
+      },
+      {
+        "run": 147,
+        "seed": 3429436255,
+        "success": true,
+        "steps": 216,
+        "total_reward": 31.990000000000148,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3851870343794235
+      },
+      {
+        "run": 148,
+        "seed": 3429436256,
+        "success": true,
+        "steps": 194,
+        "total_reward": 41.13000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4611606938812821
+      },
+      {
+        "run": 149,
+        "seed": 3429436257,
+        "success": true,
+        "steps": 193,
+        "total_reward": 31.93500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3782729700067161
+      },
+      {
+        "run": 150,
+        "seed": 3429436258,
+        "success": true,
+        "steps": 239,
+        "total_reward": 33.04500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37760446773758133
+      },
+      {
+        "run": 151,
+        "seed": 3429436259,
+        "success": true,
+        "steps": 183,
+        "total_reward": 42.9450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4881766917293233
+      },
+      {
+        "run": 152,
+        "seed": 3429436260,
+        "success": true,
+        "steps": 169,
+        "total_reward": 33.81500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4408562654310736
+      },
+      {
+        "run": 153,
+        "seed": 3429436261,
+        "success": true,
+        "steps": 193,
+        "total_reward": 37.28500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4750819041066719
+      },
+      {
+        "run": 154,
+        "seed": 3429436262,
+        "success": true,
+        "steps": 153,
+        "total_reward": 36.465000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5315542300836419
+      },
+      {
+        "run": 155,
+        "seed": 3429436263,
+        "success": true,
+        "steps": 146,
+        "total_reward": 30.08000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4993171878001599
+      },
+      {
+        "run": 156,
+        "seed": 3429436264,
+        "success": true,
+        "steps": 150,
+        "total_reward": 36.43000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5565159671246628
+      },
+      {
+        "run": 157,
+        "seed": 3429436265,
+        "success": true,
+        "steps": 201,
+        "total_reward": 44.075000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47910035948460994
+      },
+      {
+        "run": 158,
+        "seed": 3429436266,
+        "success": true,
+        "steps": 136,
+        "total_reward": 31.250000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5331292398729133
+      },
+      {
+        "run": 159,
+        "seed": 3429436267,
+        "success": true,
+        "steps": 208,
+        "total_reward": 31.01000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39746317662687536
+      },
+      {
+        "run": 160,
+        "seed": 3429436268,
+        "success": true,
+        "steps": 177,
+        "total_reward": 31.295000000000122,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4223810850984764
+      },
+      {
+        "run": 161,
+        "seed": 3429436269,
+        "success": true,
+        "steps": 183,
+        "total_reward": 34.295000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39829509087403825
+      },
+      {
+        "run": 162,
+        "seed": 3429436270,
+        "success": true,
+        "steps": 184,
+        "total_reward": 45.91000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5198400673400674
+      },
+      {
+        "run": 163,
+        "seed": 3429436271,
+        "success": true,
+        "steps": 177,
+        "total_reward": 31.295000000000098,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4293642497853024
+      },
+      {
+        "run": 164,
+        "seed": 3429436272,
+        "success": true,
+        "steps": 188,
+        "total_reward": 33.65000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4067204719122878
+      },
+      {
+        "run": 165,
+        "seed": 3429436273,
+        "success": true,
+        "steps": 194,
+        "total_reward": 41.33000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45125289087058207
+      },
+      {
+        "run": 166,
+        "seed": 3429436274,
+        "success": true,
+        "steps": 135,
+        "total_reward": 34.58500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5210574229691877
+      },
+      {
+        "run": 167,
+        "seed": 3429436275,
+        "success": true,
+        "steps": 205,
+        "total_reward": 31.355000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38998280807777375
+      },
+      {
+        "run": 168,
+        "seed": 3429436276,
+        "success": true,
+        "steps": 222,
+        "total_reward": 37.730000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3844835911215222
+      },
+      {
+        "run": 169,
+        "seed": 3429436277,
+        "success": true,
+        "steps": 172,
+        "total_reward": 37.370000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4945143139108656
+      },
+      {
+        "run": 170,
+        "seed": 3429436278,
+        "success": true,
+        "steps": 153,
+        "total_reward": 37.39500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.568146436896437
+      },
+      {
+        "run": 171,
+        "seed": 3429436279,
+        "success": true,
+        "steps": 182,
+        "total_reward": 33.840000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4660057826167189
+      },
+      {
+        "run": 172,
+        "seed": 3429436280,
+        "success": true,
+        "steps": 167,
+        "total_reward": 33.5450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4792533704685408
+      },
+      {
+        "run": 173,
+        "seed": 3429436281,
+        "success": true,
+        "steps": 190,
+        "total_reward": 29.660000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4162455157501597
+      },
+      {
+        "run": 174,
+        "seed": 3429436282,
+        "success": true,
+        "steps": 206,
+        "total_reward": 47.73000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48612210713687487
+      },
+      {
+        "run": 175,
+        "seed": 3429436283,
+        "success": true,
+        "steps": 148,
+        "total_reward": 29.740000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4729888446606713
+      },
+      {
+        "run": 176,
+        "seed": 3429436284,
+        "success": true,
+        "steps": 228,
+        "total_reward": 36.19000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3700976094561287
+      },
+      {
+        "run": 177,
+        "seed": 3429436285,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.38500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43755112703388566
+      },
+      {
+        "run": 178,
+        "seed": 3429436286,
+        "success": true,
+        "steps": 200,
+        "total_reward": 41.71000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47570584412909217
+      },
+      {
+        "run": 179,
+        "seed": 3429436287,
+        "success": true,
+        "steps": 189,
+        "total_reward": 39.39500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5187838278341711
+      },
+      {
+        "run": 180,
+        "seed": 3429436288,
+        "success": true,
+        "steps": 224,
+        "total_reward": 38.790000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3657670481985898
+      },
+      {
+        "run": 181,
+        "seed": 3429436289,
+        "success": true,
+        "steps": 207,
+        "total_reward": 38.5750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4593645783256094
+      },
+      {
+        "run": 182,
+        "seed": 3429436290,
+        "success": true,
+        "steps": 162,
+        "total_reward": 29.650000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44721514868573686
+      },
+      {
+        "run": 183,
+        "seed": 3429436291,
+        "success": true,
+        "steps": 162,
+        "total_reward": 36.67000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5363192908742445
+      },
+      {
+        "run": 184,
+        "seed": 3429436292,
+        "success": true,
+        "steps": 234,
+        "total_reward": 35.2500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4564109679152632
+      },
+      {
+        "run": 185,
+        "seed": 3429436293,
+        "success": true,
+        "steps": 165,
+        "total_reward": 39.205000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5860842687899748
+      },
+      {
+        "run": 186,
+        "seed": 3429436294,
+        "success": true,
+        "steps": 152,
+        "total_reward": 33.130000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.460012875633672
+      },
+      {
+        "run": 187,
+        "seed": 3429436295,
+        "success": true,
+        "steps": 165,
+        "total_reward": 37.425000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5731483063719905
+      },
+      {
+        "run": 188,
+        "seed": 3429436296,
+        "success": true,
+        "steps": 209,
+        "total_reward": 39.895000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4347211494972689
+      },
+      {
+        "run": 189,
+        "seed": 3429436297,
+        "success": true,
+        "steps": 163,
+        "total_reward": 33.36500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47240635032397044
+      },
+      {
+        "run": 190,
+        "seed": 3429436298,
+        "success": true,
+        "steps": 188,
+        "total_reward": 41.14000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48711306205871424
+      },
+      {
+        "run": 191,
+        "seed": 3429436299,
+        "success": true,
+        "steps": 151,
+        "total_reward": 35.845000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5565522875816994
+      },
+      {
+        "run": 192,
+        "seed": 3429436300,
+        "success": true,
+        "steps": 218,
+        "total_reward": 41.09000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40240985981906696
+      },
+      {
+        "run": 193,
+        "seed": 3429436301,
+        "success": true,
+        "steps": 162,
+        "total_reward": 30.170000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4640350877192982
+      },
+      {
+        "run": 194,
+        "seed": 3429436302,
+        "success": true,
+        "steps": 190,
+        "total_reward": 36.74000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49735458985458986
+      },
+      {
+        "run": 195,
+        "seed": 3429436303,
+        "success": true,
+        "steps": 165,
+        "total_reward": 28.565000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44412278244631187
+      },
+      {
+        "run": 196,
+        "seed": 3429436304,
+        "success": true,
+        "steps": 168,
+        "total_reward": 37.26000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5088135402609086
+      },
+      {
+        "run": 197,
+        "seed": 3429436305,
+        "success": true,
+        "steps": 180,
+        "total_reward": 38.3400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48503788694965166
+      },
+      {
+        "run": 198,
+        "seed": 3429436306,
+        "success": true,
+        "steps": 142,
+        "total_reward": 36.7400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47865578865578867
+      },
+      {
+        "run": 199,
+        "seed": 3429436307,
+        "success": true,
+        "steps": 241,
+        "total_reward": 41.93500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4409904982023626
+      },
+      {
+        "run": 200,
+        "seed": 3429436308,
+        "success": true,
+        "steps": 226,
+        "total_reward": 40.550000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39947789744131207
+      }
+    ],
+    "avg_chemotaxis_index": 0.39212406422348345,
+    "avg_time_in_attractant": 0.6960620321117418,
+    "avg_approach_frequency": 0.43211545411412766,
+    "avg_path_efficiency": 0.05226083761650203,
+    "post_convergence_chemotaxis_index": 0.40369163556128285,
+    "post_convergence_time_in_attractant": 0.7018458177806414,
+    "post_convergence_approach_frequency": 0.434160206592916,
+    "post_convergence_path_efficiency": 0.05349741487656132,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_095331.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_095331.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_095331",
+  "timestamp": "2025-12-29T10:04:09.251419+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_095331",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.98,
+    "avg_steps": 238.78,
+    "avg_reward": 35.68820000000011,
+    "avg_foods_collected": 9.885,
+    "avg_distance_efficiency": 0.38098877812598886,
+    "completed_all_food": 196,
+    "starved": 4,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 5,
+    "runs_to_convergence": 4,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 236.10204081632654,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.3860302928754351,
+    "composite_benchmark_score": 0.8118090878626306,
+    "learning_speed": 0.94,
+    "learning_speed_episodes": 12,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3896509289,
+        "success": false,
+        "steps": 280,
+        "total_reward": -3.150000000000035,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.11901064773735581
+      },
+      {
+        "run": 2,
+        "seed": 3896509290,
+        "success": false,
+        "steps": 320,
+        "total_reward": 1.679999999999966,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.08598995381274599
+      },
+      {
+        "run": 3,
+        "seed": 3896509291,
+        "success": false,
+        "steps": 440,
+        "total_reward": 22.7400000000001,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.21172882765488601
+      },
+      {
+        "run": 4,
+        "seed": 3896509292,
+        "success": false,
+        "steps": 440,
+        "total_reward": 13.100000000000126,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.11908879240750586
+      },
+      {
+        "run": 5,
+        "seed": 3896509293,
+        "success": true,
+        "steps": 475,
+        "total_reward": 44.35500000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2654504842689427
+      },
+      {
+        "run": 6,
+        "seed": 3896509294,
+        "success": true,
+        "steps": 461,
+        "total_reward": 27.135000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.17727515807450017
+      },
+      {
+        "run": 7,
+        "seed": 3896509295,
+        "success": true,
+        "steps": 433,
+        "total_reward": 38.955000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.245370244557983
+      },
+      {
+        "run": 8,
+        "seed": 3896509296,
+        "success": true,
+        "steps": 492,
+        "total_reward": 27.590000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.14626192962756962
+      },
+      {
+        "run": 9,
+        "seed": 3896509297,
+        "success": true,
+        "steps": 372,
+        "total_reward": 37.94000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3286717620407526
+      },
+      {
+        "run": 10,
+        "seed": 3896509298,
+        "success": true,
+        "steps": 373,
+        "total_reward": 40.45500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2521540171447162
+      },
+      {
+        "run": 11,
+        "seed": 3896509299,
+        "success": true,
+        "steps": 325,
+        "total_reward": 40.55500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3502272359044746
+      },
+      {
+        "run": 12,
+        "seed": 3896509300,
+        "success": true,
+        "steps": 430,
+        "total_reward": 34.66000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26145325336524494
+      },
+      {
+        "run": 13,
+        "seed": 3896509301,
+        "success": true,
+        "steps": 299,
+        "total_reward": 29.695000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24635838485838488
+      },
+      {
+        "run": 14,
+        "seed": 3896509302,
+        "success": true,
+        "steps": 248,
+        "total_reward": 38.950000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3612719021542551
+      },
+      {
+        "run": 15,
+        "seed": 3896509303,
+        "success": true,
+        "steps": 267,
+        "total_reward": 36.845000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34469520551527894
+      },
+      {
+        "run": 16,
+        "seed": 3896509304,
+        "success": true,
+        "steps": 232,
+        "total_reward": 32.18000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3812863663861849
+      },
+      {
+        "run": 17,
+        "seed": 3896509305,
+        "success": true,
+        "steps": 402,
+        "total_reward": 33.82000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.19943101494878832
+      },
+      {
+        "run": 18,
+        "seed": 3896509306,
+        "success": true,
+        "steps": 342,
+        "total_reward": 40.57000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28484095356698097
+      },
+      {
+        "run": 19,
+        "seed": 3896509307,
+        "success": true,
+        "steps": 288,
+        "total_reward": 31.75000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28942168243989713
+      },
+      {
+        "run": 20,
+        "seed": 3896509308,
+        "success": true,
+        "steps": 241,
+        "total_reward": 38.53500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41775718052605926
+      },
+      {
+        "run": 21,
+        "seed": 3896509309,
+        "success": true,
+        "steps": 254,
+        "total_reward": 36.04000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3236384506801929
+      },
+      {
+        "run": 22,
+        "seed": 3896509310,
+        "success": true,
+        "steps": 255,
+        "total_reward": 32.0350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29846721038940716
+      },
+      {
+        "run": 23,
+        "seed": 3896509311,
+        "success": true,
+        "steps": 277,
+        "total_reward": 37.60500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4320565866575099
+      },
+      {
+        "run": 24,
+        "seed": 3896509312,
+        "success": true,
+        "steps": 348,
+        "total_reward": 38.56000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2632888650328166
+      },
+      {
+        "run": 25,
+        "seed": 3896509313,
+        "success": true,
+        "steps": 335,
+        "total_reward": 34.815000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2712392014479301
+      },
+      {
+        "run": 26,
+        "seed": 3896509314,
+        "success": true,
+        "steps": 264,
+        "total_reward": 36.610000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31880234293147236
+      },
+      {
+        "run": 27,
+        "seed": 3896509315,
+        "success": true,
+        "steps": 295,
+        "total_reward": 43.6550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33437944408532644
+      },
+      {
+        "run": 28,
+        "seed": 3896509316,
+        "success": true,
+        "steps": 319,
+        "total_reward": 30.045000000000208,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21344824775962884
+      },
+      {
+        "run": 29,
+        "seed": 3896509317,
+        "success": true,
+        "steps": 211,
+        "total_reward": 39.585000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4145689205624749
+      },
+      {
+        "run": 30,
+        "seed": 3896509318,
+        "success": true,
+        "steps": 242,
+        "total_reward": 36.420000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3639319943072479
+      },
+      {
+        "run": 31,
+        "seed": 3896509319,
+        "success": true,
+        "steps": 299,
+        "total_reward": 34.88500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30002677671859257
+      },
+      {
+        "run": 32,
+        "seed": 3896509320,
+        "success": true,
+        "steps": 252,
+        "total_reward": 32.7400000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2727804429645871
+      },
+      {
+        "run": 33,
+        "seed": 3896509321,
+        "success": true,
+        "steps": 248,
+        "total_reward": 42.03000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36864321608903655
+      },
+      {
+        "run": 34,
+        "seed": 3896509322,
+        "success": true,
+        "steps": 208,
+        "total_reward": 37.15000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42316025641025645
+      },
+      {
+        "run": 35,
+        "seed": 3896509323,
+        "success": true,
+        "steps": 193,
+        "total_reward": 32.975000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39312957825341727
+      },
+      {
+        "run": 36,
+        "seed": 3896509324,
+        "success": true,
+        "steps": 252,
+        "total_reward": 37.49000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3508864938893543
+      },
+      {
+        "run": 37,
+        "seed": 3896509325,
+        "success": true,
+        "steps": 226,
+        "total_reward": 33.910000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39884522068345596
+      },
+      {
+        "run": 38,
+        "seed": 3896509326,
+        "success": true,
+        "steps": 264,
+        "total_reward": 35.2600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32621357798103573
+      },
+      {
+        "run": 39,
+        "seed": 3896509327,
+        "success": true,
+        "steps": 225,
+        "total_reward": 38.98500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4503152111046848
+      },
+      {
+        "run": 40,
+        "seed": 3896509328,
+        "success": true,
+        "steps": 182,
+        "total_reward": 33.680000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.412047397047397
+      },
+      {
+        "run": 41,
+        "seed": 3896509329,
+        "success": true,
+        "steps": 212,
+        "total_reward": 31.720000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3568730417180074
+      },
+      {
+        "run": 42,
+        "seed": 3896509330,
+        "success": true,
+        "steps": 192,
+        "total_reward": 33.65000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43153827511231163
+      },
+      {
+        "run": 43,
+        "seed": 3896509331,
+        "success": true,
+        "steps": 252,
+        "total_reward": 35.12000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33677216892504414
+      },
+      {
+        "run": 44,
+        "seed": 3896509332,
+        "success": true,
+        "steps": 185,
+        "total_reward": 34.2250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49039974323062563
+      },
+      {
+        "run": 45,
+        "seed": 3896509333,
+        "success": true,
+        "steps": 270,
+        "total_reward": 40.840000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3283576326809857
+      },
+      {
+        "run": 46,
+        "seed": 3896509334,
+        "success": true,
+        "steps": 239,
+        "total_reward": 34.93500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3459470679470679
+      },
+      {
+        "run": 47,
+        "seed": 3896509335,
+        "success": true,
+        "steps": 214,
+        "total_reward": 39.92000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46608054226475276
+      },
+      {
+        "run": 48,
+        "seed": 3896509336,
+        "success": true,
+        "steps": 245,
+        "total_reward": 43.705000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3964707633468879
+      },
+      {
+        "run": 49,
+        "seed": 3896509337,
+        "success": true,
+        "steps": 219,
+        "total_reward": 36.855000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4110286686885153
+      },
+      {
+        "run": 50,
+        "seed": 3896509338,
+        "success": true,
+        "steps": 234,
+        "total_reward": 37.900000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38200572792399057
+      },
+      {
+        "run": 51,
+        "seed": 3896509339,
+        "success": true,
+        "steps": 209,
+        "total_reward": 36.25500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41880212220729457
+      },
+      {
+        "run": 52,
+        "seed": 3896509340,
+        "success": true,
+        "steps": 218,
+        "total_reward": 33.00000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40748125872982854
+      },
+      {
+        "run": 53,
+        "seed": 3896509341,
+        "success": true,
+        "steps": 297,
+        "total_reward": 39.79500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28023691195845923
+      },
+      {
+        "run": 54,
+        "seed": 3896509342,
+        "success": true,
+        "steps": 228,
+        "total_reward": 40.940000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4814003584421541
+      },
+      {
+        "run": 55,
+        "seed": 3896509343,
+        "success": true,
+        "steps": 195,
+        "total_reward": 43.31500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43585858585858583
+      },
+      {
+        "run": 56,
+        "seed": 3896509344,
+        "success": true,
+        "steps": 287,
+        "total_reward": 37.25500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3180698634982523
+      },
+      {
+        "run": 57,
+        "seed": 3896509345,
+        "success": true,
+        "steps": 209,
+        "total_reward": 32.915000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3920915131200754
+      },
+      {
+        "run": 58,
+        "seed": 3896509346,
+        "success": true,
+        "steps": 273,
+        "total_reward": 45.11500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.357861809682836
+      },
+      {
+        "run": 59,
+        "seed": 3896509347,
+        "success": true,
+        "steps": 255,
+        "total_reward": 33.21500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3515298949715426
+      },
+      {
+        "run": 60,
+        "seed": 3896509348,
+        "success": true,
+        "steps": 246,
+        "total_reward": 33.13000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35017519128863667
+      },
+      {
+        "run": 61,
+        "seed": 3896509349,
+        "success": true,
+        "steps": 231,
+        "total_reward": 38.12500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38982442732442735
+      },
+      {
+        "run": 62,
+        "seed": 3896509350,
+        "success": true,
+        "steps": 251,
+        "total_reward": 38.445000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4166846508629691
+      },
+      {
+        "run": 63,
+        "seed": 3896509351,
+        "success": true,
+        "steps": 237,
+        "total_reward": 33.06500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28941874654215854
+      },
+      {
+        "run": 64,
+        "seed": 3896509352,
+        "success": true,
+        "steps": 231,
+        "total_reward": 43.3750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4423523983566808
+      },
+      {
+        "run": 65,
+        "seed": 3896509353,
+        "success": true,
+        "steps": 238,
+        "total_reward": 44.26000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3899774153192345
+      },
+      {
+        "run": 66,
+        "seed": 3896509354,
+        "success": true,
+        "steps": 263,
+        "total_reward": 42.29500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35747100122100123
+      },
+      {
+        "run": 67,
+        "seed": 3896509355,
+        "success": true,
+        "steps": 268,
+        "total_reward": 43.86000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39605469874978133
+      },
+      {
+        "run": 68,
+        "seed": 3896509356,
+        "success": true,
+        "steps": 277,
+        "total_reward": 32.92500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2786570912886702
+      },
+      {
+        "run": 69,
+        "seed": 3896509357,
+        "success": true,
+        "steps": 214,
+        "total_reward": 30.350000000000122,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3675361963202026
+      },
+      {
+        "run": 70,
+        "seed": 3896509358,
+        "success": true,
+        "steps": 255,
+        "total_reward": 40.965000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3465768575042622
+      },
+      {
+        "run": 71,
+        "seed": 3896509359,
+        "success": true,
+        "steps": 225,
+        "total_reward": 38.38500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3887796362564164
+      },
+      {
+        "run": 72,
+        "seed": 3896509360,
+        "success": true,
+        "steps": 209,
+        "total_reward": 35.64500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4137041397890294
+      },
+      {
+        "run": 73,
+        "seed": 3896509361,
+        "success": true,
+        "steps": 169,
+        "total_reward": 33.74500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5254201680672269
+      },
+      {
+        "run": 74,
+        "seed": 3896509362,
+        "success": true,
+        "steps": 171,
+        "total_reward": 32.27500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3841225604460899
+      },
+      {
+        "run": 75,
+        "seed": 3896509363,
+        "success": true,
+        "steps": 223,
+        "total_reward": 36.685000000000166,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3902889702889703
+      },
+      {
+        "run": 76,
+        "seed": 3896509364,
+        "success": true,
+        "steps": 227,
+        "total_reward": 27.805000000000128,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3327950857370095
+      },
+      {
+        "run": 77,
+        "seed": 3896509365,
+        "success": true,
+        "steps": 189,
+        "total_reward": 36.97500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49335740346609913
+      },
+      {
+        "run": 78,
+        "seed": 3896509366,
+        "success": true,
+        "steps": 242,
+        "total_reward": 36.920000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36073950620389394
+      },
+      {
+        "run": 79,
+        "seed": 3896509367,
+        "success": true,
+        "steps": 223,
+        "total_reward": 39.84500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42538946407689454
+      },
+      {
+        "run": 80,
+        "seed": 3896509368,
+        "success": true,
+        "steps": 163,
+        "total_reward": 30.515000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43401739829371405
+      },
+      {
+        "run": 81,
+        "seed": 3896509369,
+        "success": true,
+        "steps": 195,
+        "total_reward": 32.075000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3817321275216012
+      },
+      {
+        "run": 82,
+        "seed": 3896509370,
+        "success": true,
+        "steps": 269,
+        "total_reward": 32.92500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.345240182976787
+      },
+      {
+        "run": 83,
+        "seed": 3896509371,
+        "success": true,
+        "steps": 253,
+        "total_reward": 38.43500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32408826727880435
+      },
+      {
+        "run": 84,
+        "seed": 3896509372,
+        "success": true,
+        "steps": 275,
+        "total_reward": 35.04500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3794839656083141
+      },
+      {
+        "run": 85,
+        "seed": 3896509373,
+        "success": true,
+        "steps": 218,
+        "total_reward": 40.130000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4193211527035056
+      },
+      {
+        "run": 86,
+        "seed": 3896509374,
+        "success": true,
+        "steps": 219,
+        "total_reward": 40.63500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4426919602529359
+      },
+      {
+        "run": 87,
+        "seed": 3896509375,
+        "success": true,
+        "steps": 229,
+        "total_reward": 37.57500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3817756842848585
+      },
+      {
+        "run": 88,
+        "seed": 3896509376,
+        "success": true,
+        "steps": 248,
+        "total_reward": 31.300000000000107,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3171218543079301
+      },
+      {
+        "run": 89,
+        "seed": 3896509377,
+        "success": true,
+        "steps": 220,
+        "total_reward": 41.06000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4232632864211811
+      },
+      {
+        "run": 90,
+        "seed": 3896509378,
+        "success": true,
+        "steps": 213,
+        "total_reward": 43.875000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4189758497316637
+      },
+      {
+        "run": 91,
+        "seed": 3896509379,
+        "success": true,
+        "steps": 229,
+        "total_reward": 32.165000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42693364322520333
+      },
+      {
+        "run": 92,
+        "seed": 3896509380,
+        "success": true,
+        "steps": 214,
+        "total_reward": 30.510000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36274150370702096
+      },
+      {
+        "run": 93,
+        "seed": 3896509381,
+        "success": true,
+        "steps": 221,
+        "total_reward": 41.62500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4244240994643471
+      },
+      {
+        "run": 94,
+        "seed": 3896509382,
+        "success": true,
+        "steps": 238,
+        "total_reward": 35.78000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37008173525820587
+      },
+      {
+        "run": 95,
+        "seed": 3896509383,
+        "success": true,
+        "steps": 195,
+        "total_reward": 41.665000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5294691974691974
+      },
+      {
+        "run": 96,
+        "seed": 3896509384,
+        "success": true,
+        "steps": 203,
+        "total_reward": 32.91500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3959504822662717
+      },
+      {
+        "run": 97,
+        "seed": 3896509385,
+        "success": true,
+        "steps": 219,
+        "total_reward": 32.995000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40061794414735596
+      },
+      {
+        "run": 98,
+        "seed": 3896509386,
+        "success": true,
+        "steps": 219,
+        "total_reward": 33.14500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3613370324853701
+      },
+      {
+        "run": 99,
+        "seed": 3896509387,
+        "success": true,
+        "steps": 193,
+        "total_reward": 39.565000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5277347363638674
+      },
+      {
+        "run": 100,
+        "seed": 3896509388,
+        "success": true,
+        "steps": 198,
+        "total_reward": 37.430000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4189584533113945
+      },
+      {
+        "run": 101,
+        "seed": 3896509389,
+        "success": true,
+        "steps": 223,
+        "total_reward": 38.07500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39603555356415765
+      },
+      {
+        "run": 102,
+        "seed": 3896509390,
+        "success": true,
+        "steps": 226,
+        "total_reward": 36.50000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35222392481660214
+      },
+      {
+        "run": 103,
+        "seed": 3896509391,
+        "success": true,
+        "steps": 210,
+        "total_reward": 40.850000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3967104872251931
+      },
+      {
+        "run": 104,
+        "seed": 3896509392,
+        "success": true,
+        "steps": 207,
+        "total_reward": 32.9850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41377672014135697
+      },
+      {
+        "run": 105,
+        "seed": 3896509393,
+        "success": true,
+        "steps": 231,
+        "total_reward": 37.98500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3911238860565997
+      },
+      {
+        "run": 106,
+        "seed": 3896509394,
+        "success": true,
+        "steps": 210,
+        "total_reward": 42.610000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5065959586861226
+      },
+      {
+        "run": 107,
+        "seed": 3896509395,
+        "success": true,
+        "steps": 194,
+        "total_reward": 39.320000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4930772967373436
+      },
+      {
+        "run": 108,
+        "seed": 3896509396,
+        "success": true,
+        "steps": 219,
+        "total_reward": 36.485000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42641697678539786
+      },
+      {
+        "run": 109,
+        "seed": 3896509397,
+        "success": true,
+        "steps": 203,
+        "total_reward": 34.46500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.427796466397891
+      },
+      {
+        "run": 110,
+        "seed": 3896509398,
+        "success": true,
+        "steps": 196,
+        "total_reward": 27.400000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3293889721389721
+      },
+      {
+        "run": 111,
+        "seed": 3896509399,
+        "success": true,
+        "steps": 212,
+        "total_reward": 37.24000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4096192739741902
+      },
+      {
+        "run": 112,
+        "seed": 3896509400,
+        "success": true,
+        "steps": 207,
+        "total_reward": 33.12500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.392887851231841
+      },
+      {
+        "run": 113,
+        "seed": 3896509401,
+        "success": true,
+        "steps": 165,
+        "total_reward": 30.855000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4708781066134008
+      },
+      {
+        "run": 114,
+        "seed": 3896509402,
+        "success": true,
+        "steps": 205,
+        "total_reward": 29.80500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32888991443339266
+      },
+      {
+        "run": 115,
+        "seed": 3896509403,
+        "success": true,
+        "steps": 221,
+        "total_reward": 36.075000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3772686268039636
+      },
+      {
+        "run": 116,
+        "seed": 3896509404,
+        "success": true,
+        "steps": 205,
+        "total_reward": 35.085000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4409069972227867
+      },
+      {
+        "run": 117,
+        "seed": 3896509405,
+        "success": true,
+        "steps": 252,
+        "total_reward": 39.20000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36359836091840736
+      },
+      {
+        "run": 118,
+        "seed": 3896509406,
+        "success": true,
+        "steps": 236,
+        "total_reward": 29.020000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30292198950287186
+      },
+      {
+        "run": 119,
+        "seed": 3896509407,
+        "success": true,
+        "steps": 207,
+        "total_reward": 37.78500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4084989509337612
+      },
+      {
+        "run": 120,
+        "seed": 3896509408,
+        "success": true,
+        "steps": 279,
+        "total_reward": 37.05500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33083020445650757
+      },
+      {
+        "run": 121,
+        "seed": 3896509409,
+        "success": true,
+        "steps": 198,
+        "total_reward": 27.910000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3548642674461089
+      },
+      {
+        "run": 122,
+        "seed": 3896509410,
+        "success": true,
+        "steps": 221,
+        "total_reward": 40.54500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43093443090603334
+      },
+      {
+        "run": 123,
+        "seed": 3896509411,
+        "success": true,
+        "steps": 269,
+        "total_reward": 40.35500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3541092676386794
+      },
+      {
+        "run": 124,
+        "seed": 3896509412,
+        "success": true,
+        "steps": 222,
+        "total_reward": 38.19000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4001832211550882
+      },
+      {
+        "run": 125,
+        "seed": 3896509413,
+        "success": true,
+        "steps": 284,
+        "total_reward": 33.83000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30521082597538157
+      },
+      {
+        "run": 126,
+        "seed": 3896509414,
+        "success": true,
+        "steps": 294,
+        "total_reward": 31.180000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2326724312266108
+      },
+      {
+        "run": 127,
+        "seed": 3896509415,
+        "success": true,
+        "steps": 145,
+        "total_reward": 31.79500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.578869483007414
+      },
+      {
+        "run": 128,
+        "seed": 3896509416,
+        "success": true,
+        "steps": 200,
+        "total_reward": 34.12000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4859119784906891
+      },
+      {
+        "run": 129,
+        "seed": 3896509417,
+        "success": true,
+        "steps": 226,
+        "total_reward": 42.460000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4217870796713301
+      },
+      {
+        "run": 130,
+        "seed": 3896509418,
+        "success": true,
+        "steps": 192,
+        "total_reward": 31.700000000000113,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3761469102792632
+      },
+      {
+        "run": 131,
+        "seed": 3896509419,
+        "success": true,
+        "steps": 182,
+        "total_reward": 37.390000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5121911039152418
+      },
+      {
+        "run": 132,
+        "seed": 3896509420,
+        "success": true,
+        "steps": 215,
+        "total_reward": 33.17500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35924435776593877
+      },
+      {
+        "run": 133,
+        "seed": 3896509421,
+        "success": true,
+        "steps": 256,
+        "total_reward": 30.520000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3125429788975481
+      },
+      {
+        "run": 134,
+        "seed": 3896509422,
+        "success": true,
+        "steps": 178,
+        "total_reward": 37.0700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4838489240228371
+      },
+      {
+        "run": 135,
+        "seed": 3896509423,
+        "success": true,
+        "steps": 261,
+        "total_reward": 37.1150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32350837028468604
+      },
+      {
+        "run": 136,
+        "seed": 3896509424,
+        "success": true,
+        "steps": 203,
+        "total_reward": 41.19500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.418676288383692
+      },
+      {
+        "run": 137,
+        "seed": 3896509425,
+        "success": true,
+        "steps": 221,
+        "total_reward": 35.9650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4185147433851351
+      },
+      {
+        "run": 138,
+        "seed": 3896509426,
+        "success": true,
+        "steps": 245,
+        "total_reward": 43.34500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41747250459702323
+      },
+      {
+        "run": 139,
+        "seed": 3896509427,
+        "success": true,
+        "steps": 212,
+        "total_reward": 38.78000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44354700854700857
+      },
+      {
+        "run": 140,
+        "seed": 3896509428,
+        "success": true,
+        "steps": 190,
+        "total_reward": 33.1900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4126339658670486
+      },
+      {
+        "run": 141,
+        "seed": 3896509429,
+        "success": true,
+        "steps": 239,
+        "total_reward": 43.10499999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41540817369764743
+      },
+      {
+        "run": 142,
+        "seed": 3896509430,
+        "success": true,
+        "steps": 278,
+        "total_reward": 33.21000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30845978654148787
+      },
+      {
+        "run": 143,
+        "seed": 3896509431,
+        "success": true,
+        "steps": 205,
+        "total_reward": 36.2150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3788355916529291
+      },
+      {
+        "run": 144,
+        "seed": 3896509432,
+        "success": true,
+        "steps": 170,
+        "total_reward": 37.53000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5167261904761904
+      },
+      {
+        "run": 145,
+        "seed": 3896509433,
+        "success": true,
+        "steps": 189,
+        "total_reward": 35.5150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4321891546780495
+      },
+      {
+        "run": 146,
+        "seed": 3896509434,
+        "success": true,
+        "steps": 183,
+        "total_reward": 42.06500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5375475957023944
+      },
+      {
+        "run": 147,
+        "seed": 3896509435,
+        "success": true,
+        "steps": 221,
+        "total_reward": 34.11500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40947293449426486
+      },
+      {
+        "run": 148,
+        "seed": 3896509436,
+        "success": true,
+        "steps": 180,
+        "total_reward": 35.3400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42437870694836644
+      },
+      {
+        "run": 149,
+        "seed": 3896509437,
+        "success": true,
+        "steps": 208,
+        "total_reward": 28.240000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38376179376179376
+      },
+      {
+        "run": 150,
+        "seed": 3896509438,
+        "success": true,
+        "steps": 207,
+        "total_reward": 40.09500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46859989234182786
+      },
+      {
+        "run": 151,
+        "seed": 3896509439,
+        "success": true,
+        "steps": 282,
+        "total_reward": 40.55000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34832924087590694
+      },
+      {
+        "run": 152,
+        "seed": 3896509440,
+        "success": true,
+        "steps": 238,
+        "total_reward": 36.29000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40086955902241855
+      },
+      {
+        "run": 153,
+        "seed": 3896509441,
+        "success": true,
+        "steps": 174,
+        "total_reward": 27.430000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3869507101086048
+      },
+      {
+        "run": 154,
+        "seed": 3896509442,
+        "success": true,
+        "steps": 186,
+        "total_reward": 33.850000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37622756174789834
+      },
+      {
+        "run": 155,
+        "seed": 3896509443,
+        "success": true,
+        "steps": 254,
+        "total_reward": 30.440000000000108,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27211767535296943
+      },
+      {
+        "run": 156,
+        "seed": 3896509444,
+        "success": true,
+        "steps": 242,
+        "total_reward": 38.44000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37949020137891454
+      },
+      {
+        "run": 157,
+        "seed": 3896509445,
+        "success": true,
+        "steps": 195,
+        "total_reward": 33.2550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3700449584222404
+      },
+      {
+        "run": 158,
+        "seed": 3896509446,
+        "success": true,
+        "steps": 221,
+        "total_reward": 33.6350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34113650690394876
+      },
+      {
+        "run": 159,
+        "seed": 3896509447,
+        "success": true,
+        "steps": 287,
+        "total_reward": 36.16500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3387901529119017
+      },
+      {
+        "run": 160,
+        "seed": 3896509448,
+        "success": true,
+        "steps": 213,
+        "total_reward": 36.64500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4318930184539941
+      },
+      {
+        "run": 161,
+        "seed": 3896509449,
+        "success": true,
+        "steps": 201,
+        "total_reward": 41.755000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46287400250248545
+      },
+      {
+        "run": 162,
+        "seed": 3896509450,
+        "success": true,
+        "steps": 179,
+        "total_reward": 34.6150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45247153281015506
+      },
+      {
+        "run": 163,
+        "seed": 3896509451,
+        "success": true,
+        "steps": 233,
+        "total_reward": 41.56500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4394650605457494
+      },
+      {
+        "run": 164,
+        "seed": 3896509452,
+        "success": true,
+        "steps": 236,
+        "total_reward": 38.37000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3775185881370092
+      },
+      {
+        "run": 165,
+        "seed": 3896509453,
+        "success": true,
+        "steps": 197,
+        "total_reward": 37.80500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44407509631418546
+      },
+      {
+        "run": 166,
+        "seed": 3896509454,
+        "success": true,
+        "steps": 226,
+        "total_reward": 39.66000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46102424397837616
+      },
+      {
+        "run": 167,
+        "seed": 3896509455,
+        "success": true,
+        "steps": 213,
+        "total_reward": 36.3850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4018634488817415
+      },
+      {
+        "run": 168,
+        "seed": 3896509456,
+        "success": true,
+        "steps": 253,
+        "total_reward": 34.26500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38960042150831625
+      },
+      {
+        "run": 169,
+        "seed": 3896509457,
+        "success": true,
+        "steps": 248,
+        "total_reward": 38.85000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43070772139737656
+      },
+      {
+        "run": 170,
+        "seed": 3896509458,
+        "success": true,
+        "steps": 215,
+        "total_reward": 25.08500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4237771065363945
+      },
+      {
+        "run": 171,
+        "seed": 3896509459,
+        "success": true,
+        "steps": 234,
+        "total_reward": 41.530000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3972727272727273
+      },
+      {
+        "run": 172,
+        "seed": 3896509460,
+        "success": true,
+        "steps": 247,
+        "total_reward": 41.85500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3813671357881884
+      },
+      {
+        "run": 173,
+        "seed": 3896509461,
+        "success": true,
+        "steps": 209,
+        "total_reward": 34.96500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3667555054594528
+      },
+      {
+        "run": 174,
+        "seed": 3896509462,
+        "success": true,
+        "steps": 275,
+        "total_reward": 38.275000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3277932961565841
+      },
+      {
+        "run": 175,
+        "seed": 3896509463,
+        "success": true,
+        "steps": 208,
+        "total_reward": 34.14000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.422312834224599
+      },
+      {
+        "run": 176,
+        "seed": 3896509464,
+        "success": true,
+        "steps": 205,
+        "total_reward": 42.105000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4672043638829753
+      },
+      {
+        "run": 177,
+        "seed": 3896509465,
+        "success": true,
+        "steps": 251,
+        "total_reward": 30.105000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3665687090687091
+      },
+      {
+        "run": 178,
+        "seed": 3896509466,
+        "success": true,
+        "steps": 244,
+        "total_reward": 36.020000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3282352674548682
+      },
+      {
+        "run": 179,
+        "seed": 3896509467,
+        "success": true,
+        "steps": 191,
+        "total_reward": 37.29500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5399486914412288
+      },
+      {
+        "run": 180,
+        "seed": 3896509468,
+        "success": true,
+        "steps": 233,
+        "total_reward": 35.65500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3319848493959301
+      },
+      {
+        "run": 181,
+        "seed": 3896509469,
+        "success": true,
+        "steps": 233,
+        "total_reward": 40.61500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46673454825931604
+      },
+      {
+        "run": 182,
+        "seed": 3896509470,
+        "success": true,
+        "steps": 191,
+        "total_reward": 34.6550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4481032417195208
+      },
+      {
+        "run": 183,
+        "seed": 3896509471,
+        "success": true,
+        "steps": 271,
+        "total_reward": 33.99500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33705047399276367
+      },
+      {
+        "run": 184,
+        "seed": 3896509472,
+        "success": true,
+        "steps": 215,
+        "total_reward": 33.255000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34692143286933974
+      },
+      {
+        "run": 185,
+        "seed": 3896509473,
+        "success": true,
+        "steps": 178,
+        "total_reward": 33.0000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4715149187729833
+      },
+      {
+        "run": 186,
+        "seed": 3896509474,
+        "success": true,
+        "steps": 201,
+        "total_reward": 31.435000000000123,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4475340136054422
+      },
+      {
+        "run": 187,
+        "seed": 3896509475,
+        "success": true,
+        "steps": 181,
+        "total_reward": 32.88500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4217567461777988
+      },
+      {
+        "run": 188,
+        "seed": 3896509476,
+        "success": true,
+        "steps": 202,
+        "total_reward": 39.53000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46127444898696146
+      },
+      {
+        "run": 189,
+        "seed": 3896509477,
+        "success": true,
+        "steps": 204,
+        "total_reward": 34.980000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4262887743117922
+      },
+      {
+        "run": 190,
+        "seed": 3896509478,
+        "success": true,
+        "steps": 202,
+        "total_reward": 38.10000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4206326100212216
+      },
+      {
+        "run": 191,
+        "seed": 3896509479,
+        "success": true,
+        "steps": 235,
+        "total_reward": 39.89500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42066304835574614
+      },
+      {
+        "run": 192,
+        "seed": 3896509480,
+        "success": true,
+        "steps": 172,
+        "total_reward": 32.88000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5126641414141414
+      },
+      {
+        "run": 193,
+        "seed": 3896509481,
+        "success": true,
+        "steps": 209,
+        "total_reward": 41.665000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46562866804757874
+      },
+      {
+        "run": 194,
+        "seed": 3896509482,
+        "success": true,
+        "steps": 225,
+        "total_reward": 39.44500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45534916417566357
+      },
+      {
+        "run": 195,
+        "seed": 3896509483,
+        "success": true,
+        "steps": 263,
+        "total_reward": 37.985000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3518745143745144
+      },
+      {
+        "run": 196,
+        "seed": 3896509484,
+        "success": true,
+        "steps": 182,
+        "total_reward": 30.500000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36484477124183007
+      },
+      {
+        "run": 197,
+        "seed": 3896509485,
+        "success": true,
+        "steps": 262,
+        "total_reward": 38.64000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36248532612377005
+      },
+      {
+        "run": 198,
+        "seed": 3896509486,
+        "success": true,
+        "steps": 240,
+        "total_reward": 35.88000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3397706837929161
+      },
+      {
+        "run": 199,
+        "seed": 3896509487,
+        "success": true,
+        "steps": 180,
+        "total_reward": 31.15000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4286536092633654
+      },
+      {
+        "run": 200,
+        "seed": 3896509488,
+        "success": true,
+        "steps": 156,
+        "total_reward": 29.02000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4799372728720555
+      }
+    ],
+    "avg_chemotaxis_index": 0.39799117179209426,
+    "avg_time_in_attractant": 0.698995585896047,
+    "avg_approach_frequency": 0.3780174413619137,
+    "avg_path_efficiency": 0.036345622258459984,
+    "post_convergence_chemotaxis_index": 0.4017430485877869,
+    "post_convergence_time_in_attractant": 0.7008715242938935,
+    "post_convergence_approach_frequency": 0.37836296215213244,
+    "post_convergence_path_efficiency": 0.03698295550825641,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/20251229_095334.json
+++ b/artifacts/benchmarks/20251229_105138/20251229_095334.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_095334",
+  "timestamp": "2025-12-29T10:03:57.856322+00:00",
+  "config_file": "configs/examples/mlp_foraging_small.yml",
+  "config_hash": "11498a4a310cae9afafb6f8948432381b53ab0f59bf64e35c166b8088ac4213a",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_095334",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.96,
+    "avg_steps": 234.085,
+    "avg_reward": 35.0217250000001,
+    "avg_foods_collected": 9.725,
+    "avg_distance_efficiency": 0.38648559404771093,
+    "completed_all_food": 192,
+    "starved": 7,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 0,
+    "avg_predator_encounters": 0.0,
+    "avg_successful_evasions": 0.0,
+    "converged": true,
+    "convergence_run": 15,
+    "runs_to_convergence": 14,
+    "post_convergence_success_rate": 1.0,
+    "post_convergence_avg_steps": 227.33870967741936,
+    "post_convergence_avg_foods": 10.0,
+    "post_convergence_variance": 0.0,
+    "post_convergence_distance_efficiency": 0.4006602246570232,
+    "composite_benchmark_score": 0.8061980673971069,
+    "learning_speed": 0.92,
+    "learning_speed_episodes": 16,
+    "stability": 1.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 2065198659,
+        "success": false,
+        "steps": 280,
+        "total_reward": 2.6899999999999302,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.15390307066222714
+      },
+      {
+        "run": 2,
+        "seed": 2065198660,
+        "success": false,
+        "steps": 200,
+        "total_reward": -5.619999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 2065198661,
+        "success": false,
+        "steps": 200,
+        "total_reward": -7.299999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 2065198662,
+        "success": false,
+        "steps": 267,
+        "total_reward": 1.6449999999999498,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.19999999999999998
+      },
+      {
+        "run": 5,
+        "seed": 2065198663,
+        "success": false,
+        "steps": 240,
+        "total_reward": -1.2800000000000065,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.06796116504854369
+      },
+      {
+        "run": 6,
+        "seed": 2065198664,
+        "success": false,
+        "steps": 399,
+        "total_reward": 12.125000000000032,
+        "termination_reason": "starved",
+        "foods_collected": 5,
+        "distance_efficiency": 0.12034352470785108
+      },
+      {
+        "run": 7,
+        "seed": 2065198665,
+        "success": true,
+        "steps": 372,
+        "total_reward": 31.600000000000193,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2347962371346779
+      },
+      {
+        "run": 8,
+        "seed": 2065198666,
+        "success": false,
+        "steps": 440,
+        "total_reward": 17.18000000000013,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.15461052737789346
+      },
+      {
+        "run": 9,
+        "seed": 2065198667,
+        "success": true,
+        "steps": 279,
+        "total_reward": 26.785000000000032,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3130813234384663
+      },
+      {
+        "run": 10,
+        "seed": 2065198668,
+        "success": true,
+        "steps": 336,
+        "total_reward": 32.570000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3168173155485749
+      },
+      {
+        "run": 11,
+        "seed": 2065198669,
+        "success": true,
+        "steps": 247,
+        "total_reward": 36.80500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41681271289462113
+      },
+      {
+        "run": 12,
+        "seed": 2065198670,
+        "success": true,
+        "steps": 281,
+        "total_reward": 28.375000000000153,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3099902442908805
+      },
+      {
+        "run": 13,
+        "seed": 2065198671,
+        "success": true,
+        "steps": 491,
+        "total_reward": 40.43500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30061463178193193
+      },
+      {
+        "run": 14,
+        "seed": 2065198672,
+        "success": false,
+        "steps": 500,
+        "total_reward": 29.77000000000011,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.18538627045020906
+      },
+      {
+        "run": 15,
+        "seed": 2065198673,
+        "success": true,
+        "steps": 260,
+        "total_reward": 31.390000000000143,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.341184668989547
+      },
+      {
+        "run": 16,
+        "seed": 2065198674,
+        "success": true,
+        "steps": 390,
+        "total_reward": 37.050000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20703854014594017
+      },
+      {
+        "run": 17,
+        "seed": 2065198675,
+        "success": true,
+        "steps": 353,
+        "total_reward": 37.575000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25445764203117144
+      },
+      {
+        "run": 18,
+        "seed": 2065198676,
+        "success": true,
+        "steps": 293,
+        "total_reward": 47.9050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41545389904213437
+      },
+      {
+        "run": 19,
+        "seed": 2065198677,
+        "success": true,
+        "steps": 288,
+        "total_reward": 38.59000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.325219073377029
+      },
+      {
+        "run": 20,
+        "seed": 2065198678,
+        "success": true,
+        "steps": 301,
+        "total_reward": 37.69500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30053124836690503
+      },
+      {
+        "run": 21,
+        "seed": 2065198679,
+        "success": true,
+        "steps": 237,
+        "total_reward": 38.995000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48053572816072815
+      },
+      {
+        "run": 22,
+        "seed": 2065198680,
+        "success": true,
+        "steps": 224,
+        "total_reward": 30.020000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3311662022188338
+      },
+      {
+        "run": 23,
+        "seed": 2065198681,
+        "success": true,
+        "steps": 297,
+        "total_reward": 32.995000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3539497602938295
+      },
+      {
+        "run": 24,
+        "seed": 2065198682,
+        "success": true,
+        "steps": 226,
+        "total_reward": 26.13000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33654054491066376
+      },
+      {
+        "run": 25,
+        "seed": 2065198683,
+        "success": true,
+        "steps": 209,
+        "total_reward": 36.795000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4555602309349937
+      },
+      {
+        "run": 26,
+        "seed": 2065198684,
+        "success": true,
+        "steps": 241,
+        "total_reward": 44.04500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4297713593125957
+      },
+      {
+        "run": 27,
+        "seed": 2065198685,
+        "success": true,
+        "steps": 231,
+        "total_reward": 44.10500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3722667410673003
+      },
+      {
+        "run": 28,
+        "seed": 2065198686,
+        "success": true,
+        "steps": 230,
+        "total_reward": 39.21000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4463195155081565
+      },
+      {
+        "run": 29,
+        "seed": 2065198687,
+        "success": true,
+        "steps": 216,
+        "total_reward": 33.94000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33382986072475057
+      },
+      {
+        "run": 30,
+        "seed": 2065198688,
+        "success": true,
+        "steps": 242,
+        "total_reward": 44.390000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44100152343815935
+      },
+      {
+        "run": 31,
+        "seed": 2065198689,
+        "success": true,
+        "steps": 230,
+        "total_reward": 30.870000000000218,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.565066913013083
+      },
+      {
+        "run": 32,
+        "seed": 2065198690,
+        "success": true,
+        "steps": 223,
+        "total_reward": 29.955000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2903297315651858
+      },
+      {
+        "run": 33,
+        "seed": 2065198691,
+        "success": true,
+        "steps": 300,
+        "total_reward": 28.610000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35308802308802306
+      },
+      {
+        "run": 34,
+        "seed": 2065198692,
+        "success": true,
+        "steps": 245,
+        "total_reward": 38.79500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35325140872199695
+      },
+      {
+        "run": 35,
+        "seed": 2065198693,
+        "success": true,
+        "steps": 150,
+        "total_reward": 33.180000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5317183697234849
+      },
+      {
+        "run": 36,
+        "seed": 2065198694,
+        "success": true,
+        "steps": 260,
+        "total_reward": 34.56000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34918982853304886
+      },
+      {
+        "run": 37,
+        "seed": 2065198695,
+        "success": true,
+        "steps": 239,
+        "total_reward": 38.2550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4078067930466518
+      },
+      {
+        "run": 38,
+        "seed": 2065198696,
+        "success": true,
+        "steps": 199,
+        "total_reward": 28.13500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.345696823305519
+      },
+      {
+        "run": 39,
+        "seed": 2065198697,
+        "success": true,
+        "steps": 213,
+        "total_reward": 28.485000000000138,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3402411205352382
+      },
+      {
+        "run": 40,
+        "seed": 2065198698,
+        "success": true,
+        "steps": 255,
+        "total_reward": 37.15500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2922990897990898
+      },
+      {
+        "run": 41,
+        "seed": 2065198699,
+        "success": true,
+        "steps": 204,
+        "total_reward": 40.51000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.425837960889685
+      },
+      {
+        "run": 42,
+        "seed": 2065198700,
+        "success": true,
+        "steps": 241,
+        "total_reward": 27.895000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34844215614066953
+      },
+      {
+        "run": 43,
+        "seed": 2065198701,
+        "success": true,
+        "steps": 232,
+        "total_reward": 41.460000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41370963640986524
+      },
+      {
+        "run": 44,
+        "seed": 2065198702,
+        "success": true,
+        "steps": 250,
+        "total_reward": 39.210000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37608398500808193
+      },
+      {
+        "run": 45,
+        "seed": 2065198703,
+        "success": true,
+        "steps": 284,
+        "total_reward": 43.940000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3717308266785523
+      },
+      {
+        "run": 46,
+        "seed": 2065198704,
+        "success": true,
+        "steps": 255,
+        "total_reward": 36.465000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3824957737000131
+      },
+      {
+        "run": 47,
+        "seed": 2065198705,
+        "success": true,
+        "steps": 197,
+        "total_reward": 39.4950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42032478486425856
+      },
+      {
+        "run": 48,
+        "seed": 2065198706,
+        "success": true,
+        "steps": 251,
+        "total_reward": 37.235000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4017456427015251
+      },
+      {
+        "run": 49,
+        "seed": 2065198707,
+        "success": true,
+        "steps": 210,
+        "total_reward": 38.56000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4626255472895294
+      },
+      {
+        "run": 50,
+        "seed": 2065198708,
+        "success": true,
+        "steps": 261,
+        "total_reward": 36.84500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3361372836487253
+      },
+      {
+        "run": 51,
+        "seed": 2065198709,
+        "success": true,
+        "steps": 230,
+        "total_reward": 33.00000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3561321289649463
+      },
+      {
+        "run": 52,
+        "seed": 2065198710,
+        "success": true,
+        "steps": 225,
+        "total_reward": 41.33500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37909615959488085
+      },
+      {
+        "run": 53,
+        "seed": 2065198711,
+        "success": true,
+        "steps": 225,
+        "total_reward": 38.62500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4052985696735697
+      },
+      {
+        "run": 54,
+        "seed": 2065198712,
+        "success": true,
+        "steps": 201,
+        "total_reward": 36.55500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4000968001143317
+      },
+      {
+        "run": 55,
+        "seed": 2065198713,
+        "success": true,
+        "steps": 261,
+        "total_reward": 40.495000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.375531531072871
+      },
+      {
+        "run": 56,
+        "seed": 2065198714,
+        "success": true,
+        "steps": 215,
+        "total_reward": 34.14500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4264547397047397
+      },
+      {
+        "run": 57,
+        "seed": 2065198715,
+        "success": true,
+        "steps": 346,
+        "total_reward": 35.640000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3386237419869133
+      },
+      {
+        "run": 58,
+        "seed": 2065198716,
+        "success": true,
+        "steps": 176,
+        "total_reward": 30.180000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4445852743747481
+      },
+      {
+        "run": 59,
+        "seed": 2065198717,
+        "success": true,
+        "steps": 200,
+        "total_reward": 35.050000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41926496874772734
+      },
+      {
+        "run": 60,
+        "seed": 2065198718,
+        "success": true,
+        "steps": 187,
+        "total_reward": 29.425000000000168,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4184040795805502
+      },
+      {
+        "run": 61,
+        "seed": 2065198719,
+        "success": true,
+        "steps": 253,
+        "total_reward": 38.14500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.418632284132926
+      },
+      {
+        "run": 62,
+        "seed": 2065198720,
+        "success": true,
+        "steps": 231,
+        "total_reward": 37.19500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3736859717545294
+      },
+      {
+        "run": 63,
+        "seed": 2065198721,
+        "success": true,
+        "steps": 264,
+        "total_reward": 34.640000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30303904061062065
+      },
+      {
+        "run": 64,
+        "seed": 2065198722,
+        "success": true,
+        "steps": 212,
+        "total_reward": 30.540000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38679080276448696
+      },
+      {
+        "run": 65,
+        "seed": 2065198723,
+        "success": true,
+        "steps": 251,
+        "total_reward": 30.085000000000132,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3672934160782458
+      },
+      {
+        "run": 66,
+        "seed": 2065198724,
+        "success": true,
+        "steps": 219,
+        "total_reward": 39.26500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48654296738458225
+      },
+      {
+        "run": 67,
+        "seed": 2065198725,
+        "success": true,
+        "steps": 258,
+        "total_reward": 34.99000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32258365417543916
+      },
+      {
+        "run": 68,
+        "seed": 2065198726,
+        "success": true,
+        "steps": 281,
+        "total_reward": 41.865000000000194,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35733275023909694
+      },
+      {
+        "run": 69,
+        "seed": 2065198727,
+        "success": true,
+        "steps": 187,
+        "total_reward": 29.355000000000118,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46450980392156865
+      },
+      {
+        "run": 70,
+        "seed": 2065198728,
+        "success": true,
+        "steps": 183,
+        "total_reward": 36.255000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4329228243021347
+      },
+      {
+        "run": 71,
+        "seed": 2065198729,
+        "success": true,
+        "steps": 208,
+        "total_reward": 36.27000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4279174093879976
+      },
+      {
+        "run": 72,
+        "seed": 2065198730,
+        "success": true,
+        "steps": 193,
+        "total_reward": 37.11500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5485410632843969
+      },
+      {
+        "run": 73,
+        "seed": 2065198731,
+        "success": true,
+        "steps": 223,
+        "total_reward": 29.695000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30893117482772653
+      },
+      {
+        "run": 74,
+        "seed": 2065198732,
+        "success": true,
+        "steps": 179,
+        "total_reward": 38.26500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4663804054450507
+      },
+      {
+        "run": 75,
+        "seed": 2065198733,
+        "success": true,
+        "steps": 233,
+        "total_reward": 42.69500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40857162263652036
+      },
+      {
+        "run": 76,
+        "seed": 2065198734,
+        "success": true,
+        "steps": 215,
+        "total_reward": 40.315000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5114017248900969
+      },
+      {
+        "run": 77,
+        "seed": 2065198735,
+        "success": true,
+        "steps": 207,
+        "total_reward": 39.33500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44650461525044394
+      },
+      {
+        "run": 78,
+        "seed": 2065198736,
+        "success": true,
+        "steps": 217,
+        "total_reward": 39.04500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4385317727492465
+      },
+      {
+        "run": 79,
+        "seed": 2065198737,
+        "success": true,
+        "steps": 220,
+        "total_reward": 42.0500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.431005931005931
+      },
+      {
+        "run": 80,
+        "seed": 2065198738,
+        "success": true,
+        "steps": 211,
+        "total_reward": 36.63500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38910944298053557
+      },
+      {
+        "run": 81,
+        "seed": 2065198739,
+        "success": true,
+        "steps": 193,
+        "total_reward": 35.49500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38523597175771085
+      },
+      {
+        "run": 82,
+        "seed": 2065198740,
+        "success": true,
+        "steps": 240,
+        "total_reward": 35.580000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36373506022962543
+      },
+      {
+        "run": 83,
+        "seed": 2065198741,
+        "success": true,
+        "steps": 215,
+        "total_reward": 30.92500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43082849168375487
+      },
+      {
+        "run": 84,
+        "seed": 2065198742,
+        "success": true,
+        "steps": 190,
+        "total_reward": 35.110000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4546548516842634
+      },
+      {
+        "run": 85,
+        "seed": 2065198743,
+        "success": true,
+        "steps": 222,
+        "total_reward": 34.540000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40001970515253243
+      },
+      {
+        "run": 86,
+        "seed": 2065198744,
+        "success": true,
+        "steps": 219,
+        "total_reward": 33.48500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4053963339721854
+      },
+      {
+        "run": 87,
+        "seed": 2065198745,
+        "success": true,
+        "steps": 211,
+        "total_reward": 35.915000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3465391030713611
+      },
+      {
+        "run": 88,
+        "seed": 2065198746,
+        "success": true,
+        "steps": 200,
+        "total_reward": 36.200000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45692775521579865
+      },
+      {
+        "run": 89,
+        "seed": 2065198747,
+        "success": true,
+        "steps": 247,
+        "total_reward": 29.5650000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3351335331335331
+      },
+      {
+        "run": 90,
+        "seed": 2065198748,
+        "success": true,
+        "steps": 194,
+        "total_reward": 36.63000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4537631161634949
+      },
+      {
+        "run": 91,
+        "seed": 2065198749,
+        "success": true,
+        "steps": 256,
+        "total_reward": 46.5600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4286754095577625
+      },
+      {
+        "run": 92,
+        "seed": 2065198750,
+        "success": true,
+        "steps": 189,
+        "total_reward": 37.96500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43175337961271465
+      },
+      {
+        "run": 93,
+        "seed": 2065198751,
+        "success": true,
+        "steps": 194,
+        "total_reward": 40.92,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49532097687559873
+      },
+      {
+        "run": 94,
+        "seed": 2065198752,
+        "success": true,
+        "steps": 266,
+        "total_reward": 38.11000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35508298683298684
+      },
+      {
+        "run": 95,
+        "seed": 2065198753,
+        "success": true,
+        "steps": 167,
+        "total_reward": 31.745000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5670232901773149
+      },
+      {
+        "run": 96,
+        "seed": 2065198754,
+        "success": true,
+        "steps": 204,
+        "total_reward": 35.33000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.390967025043112
+      },
+      {
+        "run": 97,
+        "seed": 2065198755,
+        "success": true,
+        "steps": 288,
+        "total_reward": 44.3300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.418537831005599
+      },
+      {
+        "run": 98,
+        "seed": 2065198756,
+        "success": true,
+        "steps": 177,
+        "total_reward": 32.12500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45761896905272587
+      },
+      {
+        "run": 99,
+        "seed": 2065198757,
+        "success": true,
+        "steps": 193,
+        "total_reward": 41.96500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47044086947535224
+      },
+      {
+        "run": 100,
+        "seed": 2065198758,
+        "success": true,
+        "steps": 269,
+        "total_reward": 29.935000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38663036030228337
+      },
+      {
+        "run": 101,
+        "seed": 2065198759,
+        "success": true,
+        "steps": 183,
+        "total_reward": 34.34500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4193524993524994
+      },
+      {
+        "run": 102,
+        "seed": 2065198760,
+        "success": true,
+        "steps": 195,
+        "total_reward": 36.46500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46492950487515705
+      },
+      {
+        "run": 103,
+        "seed": 2065198761,
+        "success": true,
+        "steps": 237,
+        "total_reward": 37.174999999999976,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4271787303924565
+      },
+      {
+        "run": 104,
+        "seed": 2065198762,
+        "success": true,
+        "steps": 246,
+        "total_reward": 35.040000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2918437826844777
+      },
+      {
+        "run": 105,
+        "seed": 2065198763,
+        "success": true,
+        "steps": 185,
+        "total_reward": 34.5350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4613421443799018
+      },
+      {
+        "run": 106,
+        "seed": 2065198764,
+        "success": true,
+        "steps": 209,
+        "total_reward": 30.995000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3350063077019599
+      },
+      {
+        "run": 107,
+        "seed": 2065198765,
+        "success": true,
+        "steps": 246,
+        "total_reward": 37.79000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39192411473718186
+      },
+      {
+        "run": 108,
+        "seed": 2065198766,
+        "success": true,
+        "steps": 198,
+        "total_reward": 27.65000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3328375749964955
+      },
+      {
+        "run": 109,
+        "seed": 2065198767,
+        "success": true,
+        "steps": 171,
+        "total_reward": 31.145000000000078,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43459179709179707
+      },
+      {
+        "run": 110,
+        "seed": 2065198768,
+        "success": true,
+        "steps": 215,
+        "total_reward": 31.615000000000098,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3501048606195665
+      },
+      {
+        "run": 111,
+        "seed": 2065198769,
+        "success": true,
+        "steps": 206,
+        "total_reward": 33.18000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42654978999483417
+      },
+      {
+        "run": 112,
+        "seed": 2065198770,
+        "success": true,
+        "steps": 228,
+        "total_reward": 36.68000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.422960275381328
+      },
+      {
+        "run": 113,
+        "seed": 2065198771,
+        "success": true,
+        "steps": 219,
+        "total_reward": 36.56500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3972632465765632
+      },
+      {
+        "run": 114,
+        "seed": 2065198772,
+        "success": true,
+        "steps": 257,
+        "total_reward": 33.13500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3144263736372718
+      },
+      {
+        "run": 115,
+        "seed": 2065198773,
+        "success": true,
+        "steps": 169,
+        "total_reward": 31.725000000000133,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5181287462537463
+      },
+      {
+        "run": 116,
+        "seed": 2065198774,
+        "success": true,
+        "steps": 281,
+        "total_reward": 38.1550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33950170756561737
+      },
+      {
+        "run": 117,
+        "seed": 2065198775,
+        "success": true,
+        "steps": 232,
+        "total_reward": 37.87000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3762161556127304
+      },
+      {
+        "run": 118,
+        "seed": 2065198776,
+        "success": true,
+        "steps": 265,
+        "total_reward": 39.22500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37542604468688057
+      },
+      {
+        "run": 119,
+        "seed": 2065198777,
+        "success": true,
+        "steps": 155,
+        "total_reward": 33.67500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4546549773755656
+      },
+      {
+        "run": 120,
+        "seed": 2065198778,
+        "success": true,
+        "steps": 217,
+        "total_reward": 39.48500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4566438895600854
+      },
+      {
+        "run": 121,
+        "seed": 2065198779,
+        "success": true,
+        "steps": 184,
+        "total_reward": 33.42000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4171845258571265
+      },
+      {
+        "run": 122,
+        "seed": 2065198780,
+        "success": true,
+        "steps": 285,
+        "total_reward": 38.92500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3216406843369759
+      },
+      {
+        "run": 123,
+        "seed": 2065198781,
+        "success": true,
+        "steps": 200,
+        "total_reward": 38.220000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4197162322820217
+      },
+      {
+        "run": 124,
+        "seed": 2065198782,
+        "success": true,
+        "steps": 216,
+        "total_reward": 41.03000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4232115450768702
+      },
+      {
+        "run": 125,
+        "seed": 2065198783,
+        "success": true,
+        "steps": 182,
+        "total_reward": 40.77000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4974759354654621
+      },
+      {
+        "run": 126,
+        "seed": 2065198784,
+        "success": true,
+        "steps": 220,
+        "total_reward": 35.240000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35380317072848033
+      },
+      {
+        "run": 127,
+        "seed": 2065198785,
+        "success": true,
+        "steps": 200,
+        "total_reward": 41.83000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4454625170226193
+      },
+      {
+        "run": 128,
+        "seed": 2065198786,
+        "success": true,
+        "steps": 195,
+        "total_reward": 28.76500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38831121166415283
+      },
+      {
+        "run": 129,
+        "seed": 2065198787,
+        "success": true,
+        "steps": 272,
+        "total_reward": 35.690000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3317893465112135
+      },
+      {
+        "run": 130,
+        "seed": 2065198788,
+        "success": true,
+        "steps": 161,
+        "total_reward": 35.47500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.530046796340914
+      },
+      {
+        "run": 131,
+        "seed": 2065198789,
+        "success": true,
+        "steps": 281,
+        "total_reward": 40.44500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39183109769729485
+      },
+      {
+        "run": 132,
+        "seed": 2065198790,
+        "success": true,
+        "steps": 341,
+        "total_reward": 51.18500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32627429065084257
+      },
+      {
+        "run": 133,
+        "seed": 2065198791,
+        "success": true,
+        "steps": 247,
+        "total_reward": 41.675000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3686990130029292
+      },
+      {
+        "run": 134,
+        "seed": 2065198792,
+        "success": true,
+        "steps": 243,
+        "total_reward": 42.185000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41525152408873345
+      },
+      {
+        "run": 135,
+        "seed": 2065198793,
+        "success": true,
+        "steps": 248,
+        "total_reward": 36.09000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36935872993021723
+      },
+      {
+        "run": 136,
+        "seed": 2065198794,
+        "success": true,
+        "steps": 192,
+        "total_reward": 41.450000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4720459549411162
+      },
+      {
+        "run": 137,
+        "seed": 2065198795,
+        "success": true,
+        "steps": 289,
+        "total_reward": 31.855000000000192,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2931506370990735
+      },
+      {
+        "run": 138,
+        "seed": 2065198796,
+        "success": true,
+        "steps": 178,
+        "total_reward": 38.24000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5063559806206865
+      },
+      {
+        "run": 139,
+        "seed": 2065198797,
+        "success": true,
+        "steps": 274,
+        "total_reward": 40.090000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37571514163585773
+      },
+      {
+        "run": 140,
+        "seed": 2065198798,
+        "success": true,
+        "steps": 233,
+        "total_reward": 34.91500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4172901922092563
+      },
+      {
+        "run": 141,
+        "seed": 2065198799,
+        "success": true,
+        "steps": 206,
+        "total_reward": 41.30000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4743425140113945
+      },
+      {
+        "run": 142,
+        "seed": 2065198800,
+        "success": true,
+        "steps": 225,
+        "total_reward": 37.34500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3916577962267617
+      },
+      {
+        "run": 143,
+        "seed": 2065198801,
+        "success": true,
+        "steps": 251,
+        "total_reward": 35.54500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3639964021485761
+      },
+      {
+        "run": 144,
+        "seed": 2065198802,
+        "success": true,
+        "steps": 202,
+        "total_reward": 37.5500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4666020322270322
+      },
+      {
+        "run": 145,
+        "seed": 2065198803,
+        "success": true,
+        "steps": 264,
+        "total_reward": 36.670000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4057656369183829
+      },
+      {
+        "run": 146,
+        "seed": 2065198804,
+        "success": true,
+        "steps": 188,
+        "total_reward": 40.33000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46395035807104773
+      },
+      {
+        "run": 147,
+        "seed": 2065198805,
+        "success": true,
+        "steps": 191,
+        "total_reward": 30.47500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3836064456773839
+      },
+      {
+        "run": 148,
+        "seed": 2065198806,
+        "success": true,
+        "steps": 220,
+        "total_reward": 29.82000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3661342315765608
+      },
+      {
+        "run": 149,
+        "seed": 2065198807,
+        "success": true,
+        "steps": 232,
+        "total_reward": 34.04000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35000513721314613
+      },
+      {
+        "run": 150,
+        "seed": 2065198808,
+        "success": true,
+        "steps": 265,
+        "total_reward": 42.4950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4237854585797696
+      },
+      {
+        "run": 151,
+        "seed": 2065198809,
+        "success": true,
+        "steps": 167,
+        "total_reward": 36.75500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5176183012389909
+      },
+      {
+        "run": 152,
+        "seed": 2065198810,
+        "success": true,
+        "steps": 226,
+        "total_reward": 35.58000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4126756175669219
+      },
+      {
+        "run": 153,
+        "seed": 2065198811,
+        "success": true,
+        "steps": 223,
+        "total_reward": 32.42500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3780765993265993
+      },
+      {
+        "run": 154,
+        "seed": 2065198812,
+        "success": true,
+        "steps": 222,
+        "total_reward": 39.2900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4143674870880753
+      },
+      {
+        "run": 155,
+        "seed": 2065198813,
+        "success": true,
+        "steps": 298,
+        "total_reward": 47.08000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4062096969754433
+      },
+      {
+        "run": 156,
+        "seed": 2065198814,
+        "success": true,
+        "steps": 234,
+        "total_reward": 36.540000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3667023050049366
+      },
+      {
+        "run": 157,
+        "seed": 2065198815,
+        "success": true,
+        "steps": 221,
+        "total_reward": 30.805000000000195,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36947323227811035
+      },
+      {
+        "run": 158,
+        "seed": 2065198816,
+        "success": true,
+        "steps": 179,
+        "total_reward": 33.695000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44520250853377785
+      },
+      {
+        "run": 159,
+        "seed": 2065198817,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.03500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4752914295874822
+      },
+      {
+        "run": 160,
+        "seed": 2065198818,
+        "success": true,
+        "steps": 257,
+        "total_reward": 39.425000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3302789425486794
+      },
+      {
+        "run": 161,
+        "seed": 2065198819,
+        "success": true,
+        "steps": 198,
+        "total_reward": 36.640000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45446652638142
+      },
+      {
+        "run": 162,
+        "seed": 2065198820,
+        "success": true,
+        "steps": 239,
+        "total_reward": 32.90500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32835229601818555
+      },
+      {
+        "run": 163,
+        "seed": 2065198821,
+        "success": true,
+        "steps": 277,
+        "total_reward": 42.175000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33542016127415086
+      },
+      {
+        "run": 164,
+        "seed": 2065198822,
+        "success": true,
+        "steps": 219,
+        "total_reward": 38.28500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3697840982546865
+      },
+      {
+        "run": 165,
+        "seed": 2065198823,
+        "success": true,
+        "steps": 167,
+        "total_reward": 38.24500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5164209401709401
+      },
+      {
+        "run": 166,
+        "seed": 2065198824,
+        "success": true,
+        "steps": 248,
+        "total_reward": 40.42000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3625044807194909
+      },
+      {
+        "run": 167,
+        "seed": 2065198825,
+        "success": true,
+        "steps": 234,
+        "total_reward": 30.300000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3625025769143416
+      },
+      {
+        "run": 168,
+        "seed": 2065198826,
+        "success": true,
+        "steps": 235,
+        "total_reward": 40.23500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4388100472310999
+      },
+      {
+        "run": 169,
+        "seed": 2065198827,
+        "success": true,
+        "steps": 163,
+        "total_reward": 31.315000000000108,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44760295260295263
+      },
+      {
+        "run": 170,
+        "seed": 2065198828,
+        "success": true,
+        "steps": 190,
+        "total_reward": 39.9200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44802548179403956
+      },
+      {
+        "run": 171,
+        "seed": 2065198829,
+        "success": true,
+        "steps": 228,
+        "total_reward": 31.470000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3764149158335205
+      },
+      {
+        "run": 172,
+        "seed": 2065198830,
+        "success": true,
+        "steps": 221,
+        "total_reward": 35.74500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4019259859134001
+      },
+      {
+        "run": 173,
+        "seed": 2065198831,
+        "success": true,
+        "steps": 214,
+        "total_reward": 40.730000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5048044163438901
+      },
+      {
+        "run": 174,
+        "seed": 2065198832,
+        "success": true,
+        "steps": 242,
+        "total_reward": 32.57000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30283004258614016
+      },
+      {
+        "run": 175,
+        "seed": 2065198833,
+        "success": true,
+        "steps": 266,
+        "total_reward": 31.880000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3443927914082234
+      },
+      {
+        "run": 176,
+        "seed": 2065198834,
+        "success": true,
+        "steps": 163,
+        "total_reward": 36.965000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4900113775113775
+      },
+      {
+        "run": 177,
+        "seed": 2065198835,
+        "success": true,
+        "steps": 227,
+        "total_reward": 39.525000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39952048129031964
+      },
+      {
+        "run": 178,
+        "seed": 2065198836,
+        "success": true,
+        "steps": 242,
+        "total_reward": 39.860000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4071730272311668
+      },
+      {
+        "run": 179,
+        "seed": 2065198837,
+        "success": true,
+        "steps": 217,
+        "total_reward": 35.97500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4629831585239555
+      },
+      {
+        "run": 180,
+        "seed": 2065198838,
+        "success": true,
+        "steps": 211,
+        "total_reward": 36.11500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4132795939692492
+      },
+      {
+        "run": 181,
+        "seed": 2065198839,
+        "success": true,
+        "steps": 187,
+        "total_reward": 32.12500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3914224664224664
+      },
+      {
+        "run": 182,
+        "seed": 2065198840,
+        "success": true,
+        "steps": 241,
+        "total_reward": 35.845000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3189567484698039
+      },
+      {
+        "run": 183,
+        "seed": 2065198841,
+        "success": true,
+        "steps": 238,
+        "total_reward": 33.700000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31771454048479575
+      },
+      {
+        "run": 184,
+        "seed": 2065198842,
+        "success": true,
+        "steps": 272,
+        "total_reward": 35.28000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32706356610658294
+      },
+      {
+        "run": 185,
+        "seed": 2065198843,
+        "success": true,
+        "steps": 198,
+        "total_reward": 39.02000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46745315299138646
+      },
+      {
+        "run": 186,
+        "seed": 2065198844,
+        "success": true,
+        "steps": 187,
+        "total_reward": 30.325000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3952789844255361
+      },
+      {
+        "run": 187,
+        "seed": 2065198845,
+        "success": true,
+        "steps": 232,
+        "total_reward": 42.74000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43710641954663687
+      },
+      {
+        "run": 188,
+        "seed": 2065198846,
+        "success": true,
+        "steps": 320,
+        "total_reward": 34.400000000000254,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33151414398761436
+      },
+      {
+        "run": 189,
+        "seed": 2065198847,
+        "success": true,
+        "steps": 196,
+        "total_reward": 35.83000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3858746364238355
+      },
+      {
+        "run": 190,
+        "seed": 2065198848,
+        "success": true,
+        "steps": 186,
+        "total_reward": 29.980000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39993899261850924
+      },
+      {
+        "run": 191,
+        "seed": 2065198849,
+        "success": true,
+        "steps": 255,
+        "total_reward": 40.095000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40728779079998595
+      },
+      {
+        "run": 192,
+        "seed": 2065198850,
+        "success": true,
+        "steps": 260,
+        "total_reward": 28.610000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3277449849001573
+      },
+      {
+        "run": 193,
+        "seed": 2065198851,
+        "success": true,
+        "steps": 217,
+        "total_reward": 27.285000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3079127796867735
+      },
+      {
+        "run": 194,
+        "seed": 2065198852,
+        "success": true,
+        "steps": 244,
+        "total_reward": 40.94000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4052093019075941
+      },
+      {
+        "run": 195,
+        "seed": 2065198853,
+        "success": true,
+        "steps": 211,
+        "total_reward": 37.03500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3918531738714294
+      },
+      {
+        "run": 196,
+        "seed": 2065198854,
+        "success": true,
+        "steps": 220,
+        "total_reward": 35.32000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38313703443013786
+      },
+      {
+        "run": 197,
+        "seed": 2065198855,
+        "success": true,
+        "steps": 206,
+        "total_reward": 34.96000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4646550620571053
+      },
+      {
+        "run": 198,
+        "seed": 2065198856,
+        "success": true,
+        "steps": 181,
+        "total_reward": 44.325000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5425966190672072
+      },
+      {
+        "run": 199,
+        "seed": 2065198857,
+        "success": true,
+        "steps": 175,
+        "total_reward": 33.69500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43629867383242626
+      },
+      {
+        "run": 200,
+        "seed": 2065198858,
+        "success": true,
+        "steps": 241,
+        "total_reward": 36.55500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37466824994521253
+      }
+    ],
+    "avg_chemotaxis_index": 0.41597052639919135,
+    "avg_time_in_attractant": 0.7079852631995956,
+    "avg_approach_frequency": 0.4006001154809987,
+    "avg_path_efficiency": 0.05001061333450414,
+    "post_convergence_chemotaxis_index": 0.41497600972244386,
+    "post_convergence_time_in_attractant": 0.707488004861222,
+    "post_convergence_approach_frequency": 0.403138701528777,
+    "post_convergence_path_efficiency": 0.05273188139825783,
+    "chemotaxis_validation_level": "minimum",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_105138/config.yml
+++ b/artifacts/benchmarks/20251229_105138/config.yml
@@ -1,0 +1,51 @@
+# Dynamic Foraging Environment - Small Configuration
+# Curriculum level 1: Easy foraging scenario for initial training
+# Uses MLP (classical neural network) brain architecture
+
+max_steps: 500
+brain:
+  name: mlp
+  config:
+    baseline: 0.0
+    baseline_alpha: 0.05
+    entropy_beta: 0.01
+    gamma: 0.99
+    hidden_dim: 64
+    learning_rate: 0.001
+    lr_scheduler_step_size: 100
+    lr_scheduler_gamma: 0.9
+    num_hidden_layers: 2
+
+body_length: 2
+
+reward:
+  reward_goal: 2.0
+  reward_distance_scale: 0.5
+  reward_exploration: 0.05
+  penalty_step: 0.005
+  penalty_anti_dithering: 0.02
+  penalty_stuck_position: 0
+  penalty_starvation: 10.0
+  stuck_position_threshold: 0
+
+satiety:
+  initial_satiety: 200.0
+  satiety_decay_rate: 1.0
+  satiety_gain_per_food: 0.2
+
+environment:
+  type: dynamic
+  dynamic:
+    grid_size: 20
+    viewport_size: [11, 11]
+
+    foraging:
+      foods_on_grid: 5
+      target_foods_to_collect: 10
+      min_food_distance: 3
+      agent_exclusion_radius: 5
+      gradient_decay_constant: 8.0
+      gradient_strength: 1.0
+
+gradient:
+  method: clip

--- a/benchmarks/foraging_small/classical/20251229_105138.json
+++ b/benchmarks/foraging_small/classical/20251229_105138.json
@@ -1,0 +1,132 @@
+{
+  "submission_id": "20251229_105138",
+  "timestamp": "2025-12-29T10:51:38.705762+00:00",
+  "brain_type": "mlp",
+  "brain_config": {
+    "type": "mlp"
+  },
+  "environment": {
+    "type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": false
+  },
+  "category": "foraging_small/classical",
+  "sessions": [
+    {
+      "experiment_id": "20251229_092236",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_092236.json",
+      "session_seed": 3480737277,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_092239",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_092239.json",
+      "session_seed": 1153438571,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_092242",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_092242.json",
+      "session_seed": 3873361179,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_092245",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_092245.json",
+      "session_seed": 3044572106,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_093722",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_093722.json",
+      "session_seed": 2639263735,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_093725",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_093725.json",
+      "session_seed": 3823494742,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_093727",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_093727.json",
+      "session_seed": 48887489,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_093730",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_093730.json",
+      "session_seed": 765322463,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_095326",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_095326.json",
+      "session_seed": 4255614831,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_095329",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_095329.json",
+      "session_seed": 3429436109,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_095331",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_095331.json",
+      "session_seed": 3896509289,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_095334",
+      "file_path": "artifacts/benchmarks/20251229_105138/20251229_095334.json",
+      "session_seed": 2065198659,
+      "num_runs": 200
+    }
+  ],
+  "total_sessions": 12,
+  "total_runs": 2400,
+  "metrics": {
+    "success_rate": {
+      "mean": 0.9508333333333333,
+      "std": 0.019346977943739806,
+      "min": 0.91,
+      "max": 0.98
+    },
+    "composite_score": {
+      "mean": 0.8095906548376773,
+      "std": 0.013877377920320615,
+      "min": 0.7770409243555142,
+      "max": 0.8293494134861493
+    },
+    "distance_efficiency": {
+      "mean": 0.39122816972724106,
+      "std": 0.03805115397243159,
+      "min": 0.3052288586955186,
+      "max": 0.45369966988002797
+    },
+    "learning_speed": {
+      "mean": 0.9108333333333333,
+      "std": 0.021098314835286926,
+      "min": 0.865,
+      "max": 0.94
+    },
+    "learning_speed_episodes": {
+      "mean": 17.833333333333332,
+      "std": 4.2196629670573875,
+      "min": 12.0,
+      "max": 27.0
+    },
+    "stability": {
+      "mean": 0.9879558999928442,
+      "std": 0.026931674204066,
+      "min": 0.9274523749889988,
+      "max": 1.0
+    }
+  },
+  "all_seeds_unique": true,
+  "contributor": "Chris Zaharia",
+  "github_username": "chrisjz",
+  "notes": "REINFORCE policy gradient MLP"
+}

--- a/docs/nematodebench/LEADERBOARD.md
+++ b/docs/nematodebench/LEADERBOARD.md
@@ -32,6 +32,7 @@ _No NematodeBench submissions yet._
 | Brain | Score | Success Rate | Learning Speed | Stability | Distance Efficiency | Sessions | Contributor | Date |
 |---|---|---|---|---|---|---|---|---|
 | ppo | 0.835 ± 0.007 | 96.7% ± 1.3% | 0.93 ± 0.01 | 0.95 ± 0.05 | 0.47 ± 0.02 | 12 | @chrisjz | 2025-12-28 |
+| mlp | 0.810 ± 0.014 | 95.1% ± 1.9% | 0.91 ± 0.02 | 0.99 ± 0.03 | 0.39 ± 0.04 | 12 | @chrisjz | 2025-12-29 |
 
 ### Foraging Medium (≤50x50)
 


### PR DESCRIPTION
## NematodeBench Submission

**Brain Architecture:** REINFORCE MLP
**Category:** foraging_small/classical
**Composite Score:** 0.810 ± 0.014
**Success Rate:** 95.1% ± 1.9%

### Configuration
- Optimization: REINFORCE policy gradient MLP

### Approach
REINFORCE MLP using current default config.

### Reproducibility
- [x] 10+ independent sessions completed
- [x] 50+ runs per session
- [x] All seeds unique across all runs
- [x] evaluate_submission.py passes
- [x] Config files in artifacts/experiments/
- [x] Leaderboards regenerated

### Files Changed
- `benchmarks/foraging_small/20251229_105138.json`
- `artifacts/experiments/20251229_105138/` (10+ session folders)
- `README.md` (Current Leaders section updated)
- `docs/nematodebench/LEADERBOARD.md` (Full leaderboard updated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new ML model entry to the leaderboard with performance metrics and evaluation data.

* **Tests**
  * Added comprehensive benchmark datasets containing detailed experiment statistics, convergence metrics, aggregated performance analytics, and per-run results from model evaluations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->