### PR TITLE
[NematodeBench] Classical REINFORCE MLP on Predator Small - 0.624

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ uv run scripts/benchmark_submit.py regenerate
 | Brain | Score | Success Rate | Learning Speed | Stability | Distance Efficiency | Sessions | Contributor | Date |
 |---|---|---|---|---|---|---|---|---|
 | ppo | 0.728 ± 0.029 | 83.3% ± 2.9% | 0.92 ± 0.02 | 0.62 ± 0.05 | 0.51 ± 0.02 | 12 | @chrisjz | 2025-12-29 |
+| mlp | 0.624 ± 0.123 | 73.4% ± 10.9% | 0.84 ± 0.09 | 0.52 ± 0.19 | 0.39 ± 0.07 | 12 | @chrisjz | 2025-12-29 |
 
 #### Predator Small - Quantum
 

--- a/artifacts/benchmarks/20251229_110151/20251229_100737.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_100737.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_100737",
+  "timestamp": "2025-12-29T10:16:27.725152+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_100737",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.835,
+    "avg_steps": 192.02,
+    "avg_reward": 28.25770000000007,
+    "avg_foods_collected": 9.055,
+    "avg_distance_efficiency": 0.45565027060254104,
+    "completed_all_food": 167,
+    "starved": 7,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 25,
+    "avg_predator_encounters": 6.715,
+    "avg_successful_evasions": 6.33,
+    "converged": true,
+    "convergence_run": 45,
+    "runs_to_convergence": 44,
+    "post_convergence_success_rate": 0.9102564102564102,
+    "post_convergence_avg_steps": 191.22535211267606,
+    "post_convergence_avg_foods": 9.506410256410257,
+    "post_convergence_variance": 0.08168967784352402,
+    "post_convergence_distance_efficiency": 0.4847196915892076,
+    "composite_benchmark_score": 0.7246736326575645,
+    "learning_speed": 0.905,
+    "learning_speed_episodes": 19,
+    "stability": 0.6860070871886204,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3476363261,
+        "success": false,
+        "steps": 200,
+        "total_reward": -7.819999999999993,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 3476363262,
+        "success": false,
+        "steps": 200,
+        "total_reward": -13.129999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 3476363263,
+        "success": false,
+        "steps": 200,
+        "total_reward": -15.15,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 3476363264,
+        "success": false,
+        "steps": 109,
+        "total_reward": -12.104999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.20512820512820512
+      },
+      {
+        "run": 5,
+        "seed": 3476363265,
+        "success": false,
+        "steps": 221,
+        "total_reward": -5.624999999999997,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.3333333333333333
+      },
+      {
+        "run": 6,
+        "seed": 3476363266,
+        "success": false,
+        "steps": 280,
+        "total_reward": -5.649999999999997,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.0942622950819672
+      },
+      {
+        "run": 7,
+        "seed": 3476363267,
+        "success": false,
+        "steps": 221,
+        "total_reward": -0.05500000000001215,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.14588823850343532
+      },
+      {
+        "run": 8,
+        "seed": 3476363268,
+        "success": false,
+        "steps": 500,
+        "total_reward": 18.749999999999982,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.2760461186947913
+      },
+      {
+        "run": 9,
+        "seed": 3476363269,
+        "success": false,
+        "steps": 479,
+        "total_reward": 30.355000000000054,
+        "termination_reason": "starved",
+        "foods_collected": 8,
+        "distance_efficiency": 0.25473440819838555
+      },
+      {
+        "run": 10,
+        "seed": 3476363270,
+        "success": false,
+        "steps": 484,
+        "total_reward": 13.73999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.22881687821571173
+      },
+      {
+        "run": 11,
+        "seed": 3476363271,
+        "success": true,
+        "steps": 296,
+        "total_reward": 33.5100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31248342408662566
+      },
+      {
+        "run": 12,
+        "seed": 3476363272,
+        "success": true,
+        "steps": 247,
+        "total_reward": 40.78500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35444427226142095
+      },
+      {
+        "run": 13,
+        "seed": 3476363273,
+        "success": true,
+        "steps": 215,
+        "total_reward": 31.695000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45491082552278
+      },
+      {
+        "run": 14,
+        "seed": 3476363274,
+        "success": true,
+        "steps": 234,
+        "total_reward": 27.450000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46443052143052144
+      },
+      {
+        "run": 15,
+        "seed": 3476363275,
+        "success": true,
+        "steps": 248,
+        "total_reward": 34.74000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3565399969416324
+      },
+      {
+        "run": 16,
+        "seed": 3476363276,
+        "success": true,
+        "steps": 251,
+        "total_reward": 33.96500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3941221583294754
+      },
+      {
+        "run": 17,
+        "seed": 3476363277,
+        "success": true,
+        "steps": 372,
+        "total_reward": 40.26000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32834607207497235
+      },
+      {
+        "run": 18,
+        "seed": 3476363278,
+        "success": false,
+        "steps": 180,
+        "total_reward": 16.030000000000054,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.3765061692693272
+      },
+      {
+        "run": 19,
+        "seed": 3476363279,
+        "success": true,
+        "steps": 216,
+        "total_reward": 29.06000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41557584832520894
+      },
+      {
+        "run": 20,
+        "seed": 3476363280,
+        "success": false,
+        "steps": 182,
+        "total_reward": 4.779999999999971,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.36137570218743914
+      },
+      {
+        "run": 21,
+        "seed": 3476363281,
+        "success": false,
+        "steps": 40,
+        "total_reward": -1.3499999999999979,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 1.0
+      },
+      {
+        "run": 22,
+        "seed": 3476363282,
+        "success": true,
+        "steps": 213,
+        "total_reward": 32.25500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41502664002663997
+      },
+      {
+        "run": 23,
+        "seed": 3476363283,
+        "success": true,
+        "steps": 166,
+        "total_reward": 32.440000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4389079985725227
+      },
+      {
+        "run": 24,
+        "seed": 3476363284,
+        "success": true,
+        "steps": 249,
+        "total_reward": 32.77500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3759204906459271
+      },
+      {
+        "run": 25,
+        "seed": 3476363285,
+        "success": true,
+        "steps": 278,
+        "total_reward": 31.370000000000143,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3455501155990752
+      },
+      {
+        "run": 26,
+        "seed": 3476363286,
+        "success": true,
+        "steps": 223,
+        "total_reward": 41.18500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43982165065756396
+      },
+      {
+        "run": 27,
+        "seed": 3476363287,
+        "success": true,
+        "steps": 250,
+        "total_reward": 39.04000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38433337426539427
+      },
+      {
+        "run": 28,
+        "seed": 3476363288,
+        "success": true,
+        "steps": 260,
+        "total_reward": 33.23000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42814920016950053
+      },
+      {
+        "run": 29,
+        "seed": 3476363289,
+        "success": false,
+        "steps": 156,
+        "total_reward": 9.259999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3288721804511278
+      },
+      {
+        "run": 30,
+        "seed": 3476363290,
+        "success": true,
+        "steps": 127,
+        "total_reward": 22.825000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5443345543345544
+      },
+      {
+        "run": 31,
+        "seed": 3476363291,
+        "success": false,
+        "steps": 193,
+        "total_reward": 19.915000000000045,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.457050237695399
+      },
+      {
+        "run": 32,
+        "seed": 3476363292,
+        "success": true,
+        "steps": 201,
+        "total_reward": 32.195000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46744149570236526
+      },
+      {
+        "run": 33,
+        "seed": 3476363293,
+        "success": true,
+        "steps": 179,
+        "total_reward": 36.11500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5169449367836465
+      },
+      {
+        "run": 34,
+        "seed": 3476363294,
+        "success": true,
+        "steps": 196,
+        "total_reward": 26.260000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3881316872592616
+      },
+      {
+        "run": 35,
+        "seed": 3476363295,
+        "success": false,
+        "steps": 129,
+        "total_reward": 13.535000000000018,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4265980814294094
+      },
+      {
+        "run": 36,
+        "seed": 3476363296,
+        "success": true,
+        "steps": 233,
+        "total_reward": 36.49500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4286227238178236
+      },
+      {
+        "run": 37,
+        "seed": 3476363297,
+        "success": false,
+        "steps": 131,
+        "total_reward": 9.324999999999992,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3488311688311688
+      },
+      {
+        "run": 38,
+        "seed": 3476363298,
+        "success": false,
+        "steps": 69,
+        "total_reward": -1.4049999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4603174603174603
+      },
+      {
+        "run": 39,
+        "seed": 3476363299,
+        "success": true,
+        "steps": 203,
+        "total_reward": 43.29500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4480021893814997
+      },
+      {
+        "run": 40,
+        "seed": 3476363300,
+        "success": true,
+        "steps": 264,
+        "total_reward": 42.030000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3526879896101864
+      },
+      {
+        "run": 41,
+        "seed": 3476363301,
+        "success": true,
+        "steps": 213,
+        "total_reward": 34.99500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4519610467372493
+      },
+      {
+        "run": 42,
+        "seed": 3476363302,
+        "success": true,
+        "steps": 180,
+        "total_reward": 29.980000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5238406813774461
+      },
+      {
+        "run": 43,
+        "seed": 3476363303,
+        "success": true,
+        "steps": 175,
+        "total_reward": 28.455000000000112,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4359645179382022
+      },
+      {
+        "run": 44,
+        "seed": 3476363304,
+        "success": false,
+        "steps": 58,
+        "total_reward": 2.8099999999999916,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4497076023391813
+      },
+      {
+        "run": 45,
+        "seed": 3476363305,
+        "success": true,
+        "steps": 155,
+        "total_reward": 31.385000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49158658008658007
+      },
+      {
+        "run": 46,
+        "seed": 3476363306,
+        "success": true,
+        "steps": 167,
+        "total_reward": 31.63500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5145356037151703
+      },
+      {
+        "run": 47,
+        "seed": 3476363307,
+        "success": true,
+        "steps": 256,
+        "total_reward": 29.76000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3861640619150006
+      },
+      {
+        "run": 48,
+        "seed": 3476363308,
+        "success": true,
+        "steps": 197,
+        "total_reward": 38.7250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46269794721407626
+      },
+      {
+        "run": 49,
+        "seed": 3476363309,
+        "success": true,
+        "steps": 223,
+        "total_reward": 41.405000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4387872062495136
+      },
+      {
+        "run": 50,
+        "seed": 3476363310,
+        "success": true,
+        "steps": 140,
+        "total_reward": 25.670000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.550840874811463
+      },
+      {
+        "run": 51,
+        "seed": 3476363311,
+        "success": true,
+        "steps": 278,
+        "total_reward": 35.55000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4152041385647943
+      },
+      {
+        "run": 52,
+        "seed": 3476363312,
+        "success": true,
+        "steps": 153,
+        "total_reward": 26.515000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5127544351073763
+      },
+      {
+        "run": 53,
+        "seed": 3476363313,
+        "success": true,
+        "steps": 222,
+        "total_reward": 37.2000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39392923233467164
+      },
+      {
+        "run": 54,
+        "seed": 3476363314,
+        "success": true,
+        "steps": 136,
+        "total_reward": 27.600000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5553607503607504
+      },
+      {
+        "run": 55,
+        "seed": 3476363315,
+        "success": true,
+        "steps": 212,
+        "total_reward": 34.09000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3670690770818648
+      },
+      {
+        "run": 56,
+        "seed": 3476363316,
+        "success": true,
+        "steps": 215,
+        "total_reward": 38.35500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48094083112228275
+      },
+      {
+        "run": 57,
+        "seed": 3476363317,
+        "success": true,
+        "steps": 214,
+        "total_reward": 43.83000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44555973266499577
+      },
+      {
+        "run": 58,
+        "seed": 3476363318,
+        "success": true,
+        "steps": 193,
+        "total_reward": 23.69500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.465039291350267
+      },
+      {
+        "run": 59,
+        "seed": 3476363319,
+        "success": true,
+        "steps": 153,
+        "total_reward": 34.59500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5264254385964912
+      },
+      {
+        "run": 60,
+        "seed": 3476363320,
+        "success": true,
+        "steps": 164,
+        "total_reward": 29.550000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5527842809364548
+      },
+      {
+        "run": 61,
+        "seed": 3476363321,
+        "success": true,
+        "steps": 200,
+        "total_reward": 34.7100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4179675414153635
+      },
+      {
+        "run": 62,
+        "seed": 3476363322,
+        "success": true,
+        "steps": 153,
+        "total_reward": 27.915000000000028,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.574095845674793
+      },
+      {
+        "run": 63,
+        "seed": 3476363323,
+        "success": true,
+        "steps": 194,
+        "total_reward": 28.590000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43278396153783144
+      },
+      {
+        "run": 64,
+        "seed": 3476363324,
+        "success": true,
+        "steps": 187,
+        "total_reward": 20.29500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4021370167500199
+      },
+      {
+        "run": 65,
+        "seed": 3476363325,
+        "success": true,
+        "steps": 170,
+        "total_reward": 40.250000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5520628044677784
+      },
+      {
+        "run": 66,
+        "seed": 3476363326,
+        "success": true,
+        "steps": 178,
+        "total_reward": 28.95000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4969880373463216
+      },
+      {
+        "run": 67,
+        "seed": 3476363327,
+        "success": true,
+        "steps": 151,
+        "total_reward": 31.545000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5236050826568068
+      },
+      {
+        "run": 68,
+        "seed": 3476363328,
+        "success": true,
+        "steps": 319,
+        "total_reward": 28.295000000000275,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46982194762731677
+      },
+      {
+        "run": 69,
+        "seed": 3476363329,
+        "success": true,
+        "steps": 148,
+        "total_reward": 28.800000000000033,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5265752765752765
+      },
+      {
+        "run": 70,
+        "seed": 3476363330,
+        "success": true,
+        "steps": 156,
+        "total_reward": 24.390000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4383687923329867
+      },
+      {
+        "run": 71,
+        "seed": 3476363331,
+        "success": true,
+        "steps": 210,
+        "total_reward": 32.55000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45519517758227435
+      },
+      {
+        "run": 72,
+        "seed": 3476363332,
+        "success": true,
+        "steps": 210,
+        "total_reward": 37.19000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4014250272145009
+      },
+      {
+        "run": 73,
+        "seed": 3476363333,
+        "success": true,
+        "steps": 130,
+        "total_reward": 27.980000000000043,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.568989054423837
+      },
+      {
+        "run": 74,
+        "seed": 3476363334,
+        "success": true,
+        "steps": 178,
+        "total_reward": 40.540000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5074499030381383
+      },
+      {
+        "run": 75,
+        "seed": 3476363335,
+        "success": true,
+        "steps": 125,
+        "total_reward": 27.82500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.609297780763298
+      },
+      {
+        "run": 76,
+        "seed": 3476363336,
+        "success": false,
+        "steps": 71,
+        "total_reward": 3.915000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5125541125541125
+      },
+      {
+        "run": 77,
+        "seed": 3476363337,
+        "success": true,
+        "steps": 207,
+        "total_reward": 28.575000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44213264676499975
+      },
+      {
+        "run": 78,
+        "seed": 3476363338,
+        "success": true,
+        "steps": 171,
+        "total_reward": 31.11500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46009167303284954
+      },
+      {
+        "run": 79,
+        "seed": 3476363339,
+        "success": true,
+        "steps": 195,
+        "total_reward": 43.0950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5271317642289509
+      },
+      {
+        "run": 80,
+        "seed": 3476363340,
+        "success": true,
+        "steps": 171,
+        "total_reward": 37.19500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5271741363211951
+      },
+      {
+        "run": 81,
+        "seed": 3476363341,
+        "success": false,
+        "steps": 24,
+        "total_reward": -6.169999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.6363636363636364
+      },
+      {
+        "run": 82,
+        "seed": 3476363342,
+        "success": true,
+        "steps": 190,
+        "total_reward": 36.26000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5010878443815786
+      },
+      {
+        "run": 83,
+        "seed": 3476363343,
+        "success": true,
+        "steps": 146,
+        "total_reward": 37.95000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5832729468599034
+      },
+      {
+        "run": 84,
+        "seed": 3476363344,
+        "success": true,
+        "steps": 221,
+        "total_reward": 36.38500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5609804496711518
+      },
+      {
+        "run": 85,
+        "seed": 3476363345,
+        "success": true,
+        "steps": 184,
+        "total_reward": 32.02000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49335427709920615
+      },
+      {
+        "run": 86,
+        "seed": 3476363346,
+        "success": true,
+        "steps": 150,
+        "total_reward": 32.00000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5960535594436523
+      },
+      {
+        "run": 87,
+        "seed": 3476363347,
+        "success": true,
+        "steps": 211,
+        "total_reward": 30.265000000000057,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4247295714754323
+      },
+      {
+        "run": 88,
+        "seed": 3476363348,
+        "success": true,
+        "steps": 186,
+        "total_reward": 39.530000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48927871148459384
+      },
+      {
+        "run": 89,
+        "seed": 3476363349,
+        "success": true,
+        "steps": 211,
+        "total_reward": 29.025000000000148,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4479673192304771
+      },
+      {
+        "run": 90,
+        "seed": 3476363350,
+        "success": true,
+        "steps": 146,
+        "total_reward": 36.28000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5615176644820608
+      },
+      {
+        "run": 91,
+        "seed": 3476363351,
+        "success": true,
+        "steps": 161,
+        "total_reward": 30.445000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49209924799505006
+      },
+      {
+        "run": 92,
+        "seed": 3476363352,
+        "success": true,
+        "steps": 238,
+        "total_reward": 44.79000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46057473610317795
+      },
+      {
+        "run": 93,
+        "seed": 3476363353,
+        "success": true,
+        "steps": 176,
+        "total_reward": 34.26000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6020007331849437
+      },
+      {
+        "run": 94,
+        "seed": 3476363354,
+        "success": true,
+        "steps": 167,
+        "total_reward": 28.185000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44033996309847706
+      },
+      {
+        "run": 95,
+        "seed": 3476363355,
+        "success": true,
+        "steps": 181,
+        "total_reward": 19.794999999999998,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39404997514043794
+      },
+      {
+        "run": 96,
+        "seed": 3476363356,
+        "success": true,
+        "steps": 231,
+        "total_reward": 40.90500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4234445823784059
+      },
+      {
+        "run": 97,
+        "seed": 3476363357,
+        "success": true,
+        "steps": 229,
+        "total_reward": 34.96500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48119938530967943
+      },
+      {
+        "run": 98,
+        "seed": 3476363358,
+        "success": true,
+        "steps": 153,
+        "total_reward": 23.365000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4444372113393852
+      },
+      {
+        "run": 99,
+        "seed": 3476363359,
+        "success": true,
+        "steps": 233,
+        "total_reward": 28.595000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46371175393234215
+      },
+      {
+        "run": 100,
+        "seed": 3476363360,
+        "success": true,
+        "steps": 165,
+        "total_reward": 22.75500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41501135928129973
+      },
+      {
+        "run": 101,
+        "seed": 3476363361,
+        "success": true,
+        "steps": 178,
+        "total_reward": 38.06000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5815520600089565
+      },
+      {
+        "run": 102,
+        "seed": 3476363362,
+        "success": true,
+        "steps": 183,
+        "total_reward": 32.605000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47036114149721336
+      },
+      {
+        "run": 103,
+        "seed": 3476363363,
+        "success": true,
+        "steps": 188,
+        "total_reward": 31.580000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4228977815338264
+      },
+      {
+        "run": 104,
+        "seed": 3476363364,
+        "success": false,
+        "steps": 286,
+        "total_reward": -9.630000000000042,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.38456654456654454
+      },
+      {
+        "run": 105,
+        "seed": 3476363365,
+        "success": true,
+        "steps": 157,
+        "total_reward": 35.98500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5536285936285936
+      },
+      {
+        "run": 106,
+        "seed": 3476363366,
+        "success": true,
+        "steps": 196,
+        "total_reward": 24.240000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4216423164935751
+      },
+      {
+        "run": 107,
+        "seed": 3476363367,
+        "success": true,
+        "steps": 157,
+        "total_reward": 31.855000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5139203525232937
+      },
+      {
+        "run": 108,
+        "seed": 3476363368,
+        "success": false,
+        "steps": 154,
+        "total_reward": 15.980000000000043,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.3913086913086913
+      },
+      {
+        "run": 109,
+        "seed": 3476363369,
+        "success": true,
+        "steps": 150,
+        "total_reward": 29.41000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5429366222013281
+      },
+      {
+        "run": 110,
+        "seed": 3476363370,
+        "success": true,
+        "steps": 296,
+        "total_reward": 37.29000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38261578333695395
+      },
+      {
+        "run": 111,
+        "seed": 3476363371,
+        "success": false,
+        "steps": 131,
+        "total_reward": 4.765000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.40838961038961036
+      },
+      {
+        "run": 112,
+        "seed": 3476363372,
+        "success": true,
+        "steps": 215,
+        "total_reward": 28.875000000000107,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48196780257925764
+      },
+      {
+        "run": 113,
+        "seed": 3476363373,
+        "success": true,
+        "steps": 379,
+        "total_reward": 31.40500000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36452172760996293
+      },
+      {
+        "run": 114,
+        "seed": 3476363374,
+        "success": false,
+        "steps": 111,
+        "total_reward": 12.565000000000026,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.45617357788410423
+      },
+      {
+        "run": 115,
+        "seed": 3476363375,
+        "success": true,
+        "steps": 175,
+        "total_reward": 28.225000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4235939060939061
+      },
+      {
+        "run": 116,
+        "seed": 3476363376,
+        "success": true,
+        "steps": 172,
+        "total_reward": 27.130000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47792982791672534
+      },
+      {
+        "run": 117,
+        "seed": 3476363377,
+        "success": false,
+        "steps": 123,
+        "total_reward": 11.28500000000001,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.46946853542726114
+      },
+      {
+        "run": 118,
+        "seed": 3476363378,
+        "success": true,
+        "steps": 162,
+        "total_reward": 25.920000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5045380655150475
+      },
+      {
+        "run": 119,
+        "seed": 3476363379,
+        "success": true,
+        "steps": 158,
+        "total_reward": 26.87000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5510322523480419
+      },
+      {
+        "run": 120,
+        "seed": 3476363380,
+        "success": true,
+        "steps": 188,
+        "total_reward": 30.390000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43244185123442086
+      },
+      {
+        "run": 121,
+        "seed": 3476363381,
+        "success": false,
+        "steps": 138,
+        "total_reward": 19.960000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.6171825159489633
+      },
+      {
+        "run": 122,
+        "seed": 3476363382,
+        "success": false,
+        "steps": 81,
+        "total_reward": 7.454999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.49126373626373626
+      },
+      {
+        "run": 123,
+        "seed": 3476363383,
+        "success": true,
+        "steps": 177,
+        "total_reward": 26.16500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4221001221001221
+      },
+      {
+        "run": 124,
+        "seed": 3476363384,
+        "success": true,
+        "steps": 230,
+        "total_reward": 38.21000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4821449139096198
+      },
+      {
+        "run": 125,
+        "seed": 3476363385,
+        "success": true,
+        "steps": 236,
+        "total_reward": 37.3700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4154270543976426
+      },
+      {
+        "run": 126,
+        "seed": 3476363386,
+        "success": true,
+        "steps": 148,
+        "total_reward": 31.840000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5584330484330484
+      },
+      {
+        "run": 127,
+        "seed": 3476363387,
+        "success": true,
+        "steps": 206,
+        "total_reward": 34.50000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5237659200702679
+      },
+      {
+        "run": 128,
+        "seed": 3476363388,
+        "success": true,
+        "steps": 162,
+        "total_reward": 25.55000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40947782290173595
+      },
+      {
+        "run": 129,
+        "seed": 3476363389,
+        "success": true,
+        "steps": 130,
+        "total_reward": 32.44000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6218612708241191
+      },
+      {
+        "run": 130,
+        "seed": 3476363390,
+        "success": true,
+        "steps": 174,
+        "total_reward": 30.30000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46073773690078035
+      },
+      {
+        "run": 131,
+        "seed": 3476363391,
+        "success": true,
+        "steps": 175,
+        "total_reward": 34.115000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4901134301270417
+      },
+      {
+        "run": 132,
+        "seed": 3476363392,
+        "success": true,
+        "steps": 169,
+        "total_reward": 30.855000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46476395289298517
+      },
+      {
+        "run": 133,
+        "seed": 3476363393,
+        "success": true,
+        "steps": 161,
+        "total_reward": 34.72500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5669386880057612
+      },
+      {
+        "run": 134,
+        "seed": 3476363394,
+        "success": true,
+        "steps": 193,
+        "total_reward": 32.62500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.527173189013606
+      },
+      {
+        "run": 135,
+        "seed": 3476363395,
+        "success": true,
+        "steps": 144,
+        "total_reward": 30.010000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5115521080226962
+      },
+      {
+        "run": 136,
+        "seed": 3476363396,
+        "success": true,
+        "steps": 172,
+        "total_reward": 29.960000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5007361853832443
+      },
+      {
+        "run": 137,
+        "seed": 3476363397,
+        "success": true,
+        "steps": 225,
+        "total_reward": 30.025000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40915728470875534
+      },
+      {
+        "run": 138,
+        "seed": 3476363398,
+        "success": true,
+        "steps": 240,
+        "total_reward": 37.68000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4602231150007333
+      },
+      {
+        "run": 139,
+        "seed": 3476363399,
+        "success": false,
+        "steps": 37,
+        "total_reward": -2.084999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.3125
+      },
+      {
+        "run": 140,
+        "seed": 3476363400,
+        "success": true,
+        "steps": 186,
+        "total_reward": 38.880000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5290150882256145
+      },
+      {
+        "run": 141,
+        "seed": 3476363401,
+        "success": true,
+        "steps": 161,
+        "total_reward": 41.655000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5575434491978609
+      },
+      {
+        "run": 142,
+        "seed": 3476363402,
+        "success": true,
+        "steps": 234,
+        "total_reward": 31.13000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46335796587378864
+      },
+      {
+        "run": 143,
+        "seed": 3476363403,
+        "success": true,
+        "steps": 153,
+        "total_reward": 37.095000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5355003819709702
+      },
+      {
+        "run": 144,
+        "seed": 3476363404,
+        "success": true,
+        "steps": 243,
+        "total_reward": 35.63500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44204758968576946
+      },
+      {
+        "run": 145,
+        "seed": 3476363405,
+        "success": true,
+        "steps": 229,
+        "total_reward": 26.685000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46896031746031747
+      },
+      {
+        "run": 146,
+        "seed": 3476363406,
+        "success": true,
+        "steps": 157,
+        "total_reward": 32.73500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5592459992757476
+      },
+      {
+        "run": 147,
+        "seed": 3476363407,
+        "success": true,
+        "steps": 226,
+        "total_reward": 38.30000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4391331898613104
+      },
+      {
+        "run": 148,
+        "seed": 3476363408,
+        "success": true,
+        "steps": 234,
+        "total_reward": 36.800000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5274697789919367
+      },
+      {
+        "run": 149,
+        "seed": 3476363409,
+        "success": true,
+        "steps": 222,
+        "total_reward": 34.590000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44182403747621135
+      },
+      {
+        "run": 150,
+        "seed": 3476363410,
+        "success": true,
+        "steps": 219,
+        "total_reward": 31.535000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.439094456623229
+      },
+      {
+        "run": 151,
+        "seed": 3476363411,
+        "success": false,
+        "steps": 59,
+        "total_reward": -0.34499999999999353,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.474264705882353
+      },
+      {
+        "run": 152,
+        "seed": 3476363412,
+        "success": true,
+        "steps": 259,
+        "total_reward": 38.00500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43431602631602634
+      },
+      {
+        "run": 153,
+        "seed": 3476363413,
+        "success": true,
+        "steps": 178,
+        "total_reward": 28.960000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5351054664289958
+      },
+      {
+        "run": 154,
+        "seed": 3476363414,
+        "success": true,
+        "steps": 165,
+        "total_reward": 29.34500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.449746336996337
+      },
+      {
+        "run": 155,
+        "seed": 3476363415,
+        "success": true,
+        "steps": 213,
+        "total_reward": 39.05500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4419160561660561
+      },
+      {
+        "run": 156,
+        "seed": 3476363416,
+        "success": true,
+        "steps": 243,
+        "total_reward": 29.13500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38422313161679156
+      },
+      {
+        "run": 157,
+        "seed": 3476363417,
+        "success": true,
+        "steps": 227,
+        "total_reward": 39.70500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42118497488268847
+      },
+      {
+        "run": 158,
+        "seed": 3476363418,
+        "success": true,
+        "steps": 171,
+        "total_reward": 27.97500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5026245791245791
+      },
+      {
+        "run": 159,
+        "seed": 3476363419,
+        "success": true,
+        "steps": 179,
+        "total_reward": 34.665000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5098919340463458
+      },
+      {
+        "run": 160,
+        "seed": 3476363420,
+        "success": true,
+        "steps": 150,
+        "total_reward": 25.120000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4448290839595187
+      },
+      {
+        "run": 161,
+        "seed": 3476363421,
+        "success": true,
+        "steps": 200,
+        "total_reward": 36.01000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43228646110225055
+      },
+      {
+        "run": 162,
+        "seed": 3476363422,
+        "success": true,
+        "steps": 172,
+        "total_reward": 29.870000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5088375392723219
+      },
+      {
+        "run": 163,
+        "seed": 3476363423,
+        "success": true,
+        "steps": 163,
+        "total_reward": 26.825000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5164015171579132
+      },
+      {
+        "run": 164,
+        "seed": 3476363424,
+        "success": true,
+        "steps": 162,
+        "total_reward": 32.27000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5105684666210981
+      },
+      {
+        "run": 165,
+        "seed": 3476363425,
+        "success": true,
+        "steps": 274,
+        "total_reward": 30.240000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3507733779378516
+      },
+      {
+        "run": 166,
+        "seed": 3476363426,
+        "success": true,
+        "steps": 195,
+        "total_reward": 35.37500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4826540352052686
+      },
+      {
+        "run": 167,
+        "seed": 3476363427,
+        "success": true,
+        "steps": 164,
+        "total_reward": 41.98000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6305114709851551
+      },
+      {
+        "run": 168,
+        "seed": 3476363428,
+        "success": true,
+        "steps": 175,
+        "total_reward": 36.84500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5149244691167983
+      },
+      {
+        "run": 169,
+        "seed": 3476363429,
+        "success": true,
+        "steps": 181,
+        "total_reward": 35.23500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5160711072553178
+      },
+      {
+        "run": 170,
+        "seed": 3476363430,
+        "success": true,
+        "steps": 168,
+        "total_reward": 35.9200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5272397348648222
+      },
+      {
+        "run": 171,
+        "seed": 3476363431,
+        "success": true,
+        "steps": 128,
+        "total_reward": 32.73000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5483383283383283
+      },
+      {
+        "run": 172,
+        "seed": 3476363432,
+        "success": true,
+        "steps": 222,
+        "total_reward": 36.66000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49867335115864525
+      },
+      {
+        "run": 173,
+        "seed": 3476363433,
+        "success": true,
+        "steps": 211,
+        "total_reward": 35.06500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5066444118317184
+      },
+      {
+        "run": 174,
+        "seed": 3476363434,
+        "success": true,
+        "steps": 198,
+        "total_reward": 37.17000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48381997313031794
+      },
+      {
+        "run": 175,
+        "seed": 3476363435,
+        "success": true,
+        "steps": 284,
+        "total_reward": 29.15000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44533883728930174
+      },
+      {
+        "run": 176,
+        "seed": 3476363436,
+        "success": false,
+        "steps": 116,
+        "total_reward": 17.470000000000063,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.5304841897233201
+      },
+      {
+        "run": 177,
+        "seed": 3476363437,
+        "success": true,
+        "steps": 219,
+        "total_reward": 27.54500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.359864820144956
+      },
+      {
+        "run": 178,
+        "seed": 3476363438,
+        "success": true,
+        "steps": 190,
+        "total_reward": 34.86000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46870005419841493
+      },
+      {
+        "run": 179,
+        "seed": 3476363439,
+        "success": true,
+        "steps": 179,
+        "total_reward": 28.885000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4671338684535279
+      },
+      {
+        "run": 180,
+        "seed": 3476363440,
+        "success": true,
+        "steps": 168,
+        "total_reward": 36.41000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5362235803412274
+      },
+      {
+        "run": 181,
+        "seed": 3476363441,
+        "success": false,
+        "steps": 6,
+        "total_reward": -8.78,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 182,
+        "seed": 3476363442,
+        "success": true,
+        "steps": 245,
+        "total_reward": 35.45500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43164979770787665
+      },
+      {
+        "run": 183,
+        "seed": 3476363443,
+        "success": true,
+        "steps": 183,
+        "total_reward": 27.36500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48318414322250636
+      },
+      {
+        "run": 184,
+        "seed": 3476363444,
+        "success": true,
+        "steps": 151,
+        "total_reward": 25.095000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4638020836795792
+      },
+      {
+        "run": 185,
+        "seed": 3476363445,
+        "success": false,
+        "steps": 192,
+        "total_reward": 12.650000000000023,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.401375567000567
+      },
+      {
+        "run": 186,
+        "seed": 3476363446,
+        "success": true,
+        "steps": 161,
+        "total_reward": 26.875000000000032,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5063534382284383
+      },
+      {
+        "run": 187,
+        "seed": 3476363447,
+        "success": true,
+        "steps": 212,
+        "total_reward": 37.820000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4850762621645474
+      },
+      {
+        "run": 188,
+        "seed": 3476363448,
+        "success": true,
+        "steps": 162,
+        "total_reward": 30.200000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4588566662096074
+      },
+      {
+        "run": 189,
+        "seed": 3476363449,
+        "success": true,
+        "steps": 134,
+        "total_reward": 27.610000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5302940605146487
+      },
+      {
+        "run": 190,
+        "seed": 3476363450,
+        "success": true,
+        "steps": 180,
+        "total_reward": 38.28000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5003989782618815
+      },
+      {
+        "run": 191,
+        "seed": 3476363451,
+        "success": true,
+        "steps": 140,
+        "total_reward": 30.230000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5189980143250934
+      },
+      {
+        "run": 192,
+        "seed": 3476363452,
+        "success": true,
+        "steps": 224,
+        "total_reward": 42.80000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5152150244537175
+      },
+      {
+        "run": 193,
+        "seed": 3476363453,
+        "success": true,
+        "steps": 131,
+        "total_reward": 31.075000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6214733950260266
+      },
+      {
+        "run": 194,
+        "seed": 3476363454,
+        "success": true,
+        "steps": 260,
+        "total_reward": 45.760000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.428883549525091
+      },
+      {
+        "run": 195,
+        "seed": 3476363455,
+        "success": true,
+        "steps": 138,
+        "total_reward": 32.44000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5762319122226243
+      },
+      {
+        "run": 196,
+        "seed": 3476363456,
+        "success": true,
+        "steps": 169,
+        "total_reward": 38.18500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6143806895340906
+      },
+      {
+        "run": 197,
+        "seed": 3476363457,
+        "success": true,
+        "steps": 172,
+        "total_reward": 32.030000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.538659756808902
+      },
+      {
+        "run": 198,
+        "seed": 3476363458,
+        "success": true,
+        "steps": 288,
+        "total_reward": 33.410000000000224,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4186800873710051
+      },
+      {
+        "run": 199,
+        "seed": 3476363459,
+        "success": true,
+        "steps": 262,
+        "total_reward": 41.12000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3824051132456305
+      },
+      {
+        "run": 200,
+        "seed": 3476363460,
+        "success": true,
+        "steps": 234,
+        "total_reward": 34.74000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.405347813610064
+      }
+    ],
+    "avg_chemotaxis_index": 0.31345051253478645,
+    "avg_time_in_attractant": 0.6567252562673932,
+    "avg_approach_frequency": 0.39804619887924886,
+    "avg_path_efficiency": 0.054791697167896655,
+    "post_convergence_chemotaxis_index": 0.3306208785133426,
+    "post_convergence_time_in_attractant": 0.6653104392566713,
+    "post_convergence_approach_frequency": 0.40295448849979915,
+    "post_convergence_path_efficiency": 0.06248996637584847,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_100739.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_100739.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_100739",
+  "timestamp": "2025-12-29T10:16:53.941419+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_100739",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.81,
+    "avg_steps": 201.355,
+    "avg_reward": 26.655375000000067,
+    "avg_foods_collected": 8.87,
+    "avg_distance_efficiency": 0.4257625390700511,
+    "completed_all_food": 162,
+    "starved": 7,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 30,
+    "avg_predator_encounters": 7.335,
+    "avg_successful_evasions": 6.93,
+    "converged": true,
+    "convergence_run": 59,
+    "runs_to_convergence": 58,
+    "post_convergence_success_rate": 0.8661971830985915,
+    "post_convergence_avg_steps": 199.6910569105691,
+    "post_convergence_avg_foods": 9.330985915492958,
+    "post_convergence_variance": 0.11589962309065661,
+    "post_convergence_distance_efficiency": 0.4573065104105211,
+    "composite_benchmark_score": 0.6677210148172646,
+    "learning_speed": 0.905,
+    "learning_speed_episodes": 19,
+    "stability": 0.6069713182025425,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 1622328474,
+        "success": false,
+        "steps": 15,
+        "total_reward": -7.0249999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 1622328475,
+        "success": false,
+        "steps": 240,
+        "total_reward": -1.2100000000000222,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.10465116279069768
+      },
+      {
+        "run": 3,
+        "seed": 1622328476,
+        "success": false,
+        "steps": 240,
+        "total_reward": -17.23000000000001,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.041176470588235294
+      },
+      {
+        "run": 4,
+        "seed": 1622328477,
+        "success": false,
+        "steps": 240,
+        "total_reward": -16.439999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.07339449541284404
+      },
+      {
+        "run": 5,
+        "seed": 1622328478,
+        "success": false,
+        "steps": 259,
+        "total_reward": 0.45499999999999474,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.22021052631578947
+      },
+      {
+        "run": 6,
+        "seed": 1622328479,
+        "success": false,
+        "steps": 200,
+        "total_reward": -4.38,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 7,
+        "seed": 1622328480,
+        "success": false,
+        "steps": 200,
+        "total_reward": -4.069999999999997,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 8,
+        "seed": 1622328481,
+        "success": false,
+        "steps": 500,
+        "total_reward": 24.3800000000001,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.18486264270786368
+      },
+      {
+        "run": 9,
+        "seed": 1622328482,
+        "success": false,
+        "steps": 180,
+        "total_reward": -6.210000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.20570054945054944
+      },
+      {
+        "run": 10,
+        "seed": 1622328483,
+        "success": false,
+        "steps": 127,
+        "total_reward": -12.025,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.5343137254901961
+      },
+      {
+        "run": 11,
+        "seed": 1622328484,
+        "success": true,
+        "steps": 392,
+        "total_reward": 33.75000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2013351328802928
+      },
+      {
+        "run": 12,
+        "seed": 1622328485,
+        "success": true,
+        "steps": 450,
+        "total_reward": 34.95000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22958103835876256
+      },
+      {
+        "run": 13,
+        "seed": 1622328486,
+        "success": true,
+        "steps": 390,
+        "total_reward": 25.76000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3029035990676102
+      },
+      {
+        "run": 14,
+        "seed": 1622328487,
+        "success": true,
+        "steps": 407,
+        "total_reward": 30.56500000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26065786210640046
+      },
+      {
+        "run": 15,
+        "seed": 1622328488,
+        "success": true,
+        "steps": 264,
+        "total_reward": 26.56000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3557041515816273
+      },
+      {
+        "run": 16,
+        "seed": 1622328489,
+        "success": false,
+        "steps": 106,
+        "total_reward": 5.28999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.33207547169811324
+      },
+      {
+        "run": 17,
+        "seed": 1622328490,
+        "success": true,
+        "steps": 291,
+        "total_reward": 30.565000000000122,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34053621158636205
+      },
+      {
+        "run": 18,
+        "seed": 1622328491,
+        "success": true,
+        "steps": 490,
+        "total_reward": 29.110000000000205,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26895163438685193
+      },
+      {
+        "run": 19,
+        "seed": 1622328492,
+        "success": true,
+        "steps": 229,
+        "total_reward": 28.85500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36516572692616245
+      },
+      {
+        "run": 20,
+        "seed": 1622328493,
+        "success": true,
+        "steps": 275,
+        "total_reward": 30.46500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2841323905649587
+      },
+      {
+        "run": 21,
+        "seed": 1622328494,
+        "success": true,
+        "steps": 303,
+        "total_reward": 35.81500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40619374300588723
+      },
+      {
+        "run": 22,
+        "seed": 1622328495,
+        "success": true,
+        "steps": 168,
+        "total_reward": 33.000000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5076057373357513
+      },
+      {
+        "run": 23,
+        "seed": 1622328496,
+        "success": true,
+        "steps": 305,
+        "total_reward": 21.124999999999982,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2641726296421333
+      },
+      {
+        "run": 24,
+        "seed": 1622328497,
+        "success": true,
+        "steps": 240,
+        "total_reward": 23.67000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3062395194475539
+      },
+      {
+        "run": 25,
+        "seed": 1622328498,
+        "success": false,
+        "steps": 248,
+        "total_reward": 13.66000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.4699114571439554
+      },
+      {
+        "run": 26,
+        "seed": 1622328499,
+        "success": true,
+        "steps": 235,
+        "total_reward": 28.93500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41994068355145464
+      },
+      {
+        "run": 27,
+        "seed": 1622328500,
+        "success": true,
+        "steps": 340,
+        "total_reward": 40.95000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4236689686585726
+      },
+      {
+        "run": 28,
+        "seed": 1622328501,
+        "success": true,
+        "steps": 230,
+        "total_reward": 40.59000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45442219214278035
+      },
+      {
+        "run": 29,
+        "seed": 1622328502,
+        "success": false,
+        "steps": 134,
+        "total_reward": 11.840000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.43333333333333335
+      },
+      {
+        "run": 30,
+        "seed": 1622328503,
+        "success": true,
+        "steps": 268,
+        "total_reward": 35.37000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32128427594413095
+      },
+      {
+        "run": 31,
+        "seed": 1622328504,
+        "success": true,
+        "steps": 188,
+        "total_reward": 36.66000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4872680664535503
+      },
+      {
+        "run": 32,
+        "seed": 1622328505,
+        "success": false,
+        "steps": 180,
+        "total_reward": 11.22999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.35343915343915344
+      },
+      {
+        "run": 33,
+        "seed": 1622328506,
+        "success": true,
+        "steps": 231,
+        "total_reward": 33.40500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3735090835090835
+      },
+      {
+        "run": 34,
+        "seed": 1622328507,
+        "success": true,
+        "steps": 269,
+        "total_reward": 32.9750000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.470640664160401
+      },
+      {
+        "run": 35,
+        "seed": 1622328508,
+        "success": true,
+        "steps": 211,
+        "total_reward": 34.415000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4095588546578841
+      },
+      {
+        "run": 36,
+        "seed": 1622328509,
+        "success": true,
+        "steps": 158,
+        "total_reward": 36.42000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5773920046500691
+      },
+      {
+        "run": 37,
+        "seed": 1622328510,
+        "success": false,
+        "steps": 118,
+        "total_reward": 5.789999999999996,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4164725346774028
+      },
+      {
+        "run": 38,
+        "seed": 1622328511,
+        "success": true,
+        "steps": 231,
+        "total_reward": 28.365000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4044811962702455
+      },
+      {
+        "run": 39,
+        "seed": 1622328512,
+        "success": true,
+        "steps": 277,
+        "total_reward": 25.585000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3218917420598886
+      },
+      {
+        "run": 40,
+        "seed": 1622328513,
+        "success": true,
+        "steps": 267,
+        "total_reward": 36.61500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3859772066997131
+      },
+      {
+        "run": 41,
+        "seed": 1622328514,
+        "success": false,
+        "steps": 257,
+        "total_reward": 31.255000000000067,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4126022355019645
+      },
+      {
+        "run": 42,
+        "seed": 1622328515,
+        "success": true,
+        "steps": 270,
+        "total_reward": 27.140000000000214,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46983849426080126
+      },
+      {
+        "run": 43,
+        "seed": 1622328516,
+        "success": true,
+        "steps": 157,
+        "total_reward": 32.92500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5269856800119957
+      },
+      {
+        "run": 44,
+        "seed": 1622328517,
+        "success": true,
+        "steps": 206,
+        "total_reward": 43.38000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5093822843822844
+      },
+      {
+        "run": 45,
+        "seed": 1622328518,
+        "success": true,
+        "steps": 232,
+        "total_reward": 42.60000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41344690659720645
+      },
+      {
+        "run": 46,
+        "seed": 1622328519,
+        "success": false,
+        "steps": 23,
+        "total_reward": -5.014999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.5555555555555556
+      },
+      {
+        "run": 47,
+        "seed": 1622328520,
+        "success": true,
+        "steps": 199,
+        "total_reward": 35.27500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4791941180854897
+      },
+      {
+        "run": 48,
+        "seed": 1622328521,
+        "success": true,
+        "steps": 213,
+        "total_reward": 30.425000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3752594594655065
+      },
+      {
+        "run": 49,
+        "seed": 1622328522,
+        "success": true,
+        "steps": 229,
+        "total_reward": 33.05500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3939121755487512
+      },
+      {
+        "run": 50,
+        "seed": 1622328523,
+        "success": true,
+        "steps": 223,
+        "total_reward": 39.45500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48132460426030876
+      },
+      {
+        "run": 51,
+        "seed": 1622328524,
+        "success": true,
+        "steps": 183,
+        "total_reward": 30.395000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5205204216073781
+      },
+      {
+        "run": 52,
+        "seed": 1622328525,
+        "success": true,
+        "steps": 227,
+        "total_reward": 35.51500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39443779331335554
+      },
+      {
+        "run": 53,
+        "seed": 1622328526,
+        "success": true,
+        "steps": 161,
+        "total_reward": 25.935000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4380831668331668
+      },
+      {
+        "run": 54,
+        "seed": 1622328527,
+        "success": true,
+        "steps": 214,
+        "total_reward": 39.410000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4838526999316473
+      },
+      {
+        "run": 55,
+        "seed": 1622328528,
+        "success": false,
+        "steps": 21,
+        "total_reward": -5.104999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.6263736263736264
+      },
+      {
+        "run": 56,
+        "seed": 1622328529,
+        "success": true,
+        "steps": 236,
+        "total_reward": 23.59000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3699697406614063
+      },
+      {
+        "run": 57,
+        "seed": 1622328530,
+        "success": true,
+        "steps": 250,
+        "total_reward": 37.14000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4907510414114188
+      },
+      {
+        "run": 58,
+        "seed": 1622328531,
+        "success": false,
+        "steps": 274,
+        "total_reward": 0.6699999999999502,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.618530701754386
+      },
+      {
+        "run": 59,
+        "seed": 1622328532,
+        "success": true,
+        "steps": 212,
+        "total_reward": 24.23000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4212818233602026
+      },
+      {
+        "run": 60,
+        "seed": 1622328533,
+        "success": true,
+        "steps": 214,
+        "total_reward": 36.310000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39150954180440845
+      },
+      {
+        "run": 61,
+        "seed": 1622328534,
+        "success": true,
+        "steps": 194,
+        "total_reward": 28.88000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.507907992390751
+      },
+      {
+        "run": 62,
+        "seed": 1622328535,
+        "success": true,
+        "steps": 214,
+        "total_reward": 26.450000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42206533706533705
+      },
+      {
+        "run": 63,
+        "seed": 1622328536,
+        "success": true,
+        "steps": 240,
+        "total_reward": 33.74000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4457135607908853
+      },
+      {
+        "run": 64,
+        "seed": 1622328537,
+        "success": true,
+        "steps": 204,
+        "total_reward": 25.850000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37714306190312386
+      },
+      {
+        "run": 65,
+        "seed": 1622328538,
+        "success": true,
+        "steps": 226,
+        "total_reward": 35.900000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4209479636165597
+      },
+      {
+        "run": 66,
+        "seed": 1622328539,
+        "success": true,
+        "steps": 213,
+        "total_reward": 35.265000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4073393264441652
+      },
+      {
+        "run": 67,
+        "seed": 1622328540,
+        "success": true,
+        "steps": 169,
+        "total_reward": 26.015000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4513711417581387
+      },
+      {
+        "run": 68,
+        "seed": 1622328541,
+        "success": true,
+        "steps": 169,
+        "total_reward": 33.16500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5191607639866154
+      },
+      {
+        "run": 69,
+        "seed": 1622328542,
+        "success": true,
+        "steps": 237,
+        "total_reward": 36.32500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4499784580486123
+      },
+      {
+        "run": 70,
+        "seed": 1622328543,
+        "success": false,
+        "steps": 215,
+        "total_reward": 23.33500000000008,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.47368125701459035
+      },
+      {
+        "run": 71,
+        "seed": 1622328544,
+        "success": true,
+        "steps": 256,
+        "total_reward": 21.930000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33904005626475037
+      },
+      {
+        "run": 72,
+        "seed": 1622328545,
+        "success": true,
+        "steps": 209,
+        "total_reward": 27.99500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44242967073494455
+      },
+      {
+        "run": 73,
+        "seed": 1622328546,
+        "success": true,
+        "steps": 190,
+        "total_reward": 26.590000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4100118835412953
+      },
+      {
+        "run": 74,
+        "seed": 1622328547,
+        "success": true,
+        "steps": 190,
+        "total_reward": 38.99000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4685338663262283
+      },
+      {
+        "run": 75,
+        "seed": 1622328548,
+        "success": false,
+        "steps": 156,
+        "total_reward": 17.720000000000024,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.45891690855590483
+      },
+      {
+        "run": 76,
+        "seed": 1622328549,
+        "success": true,
+        "steps": 197,
+        "total_reward": 38.6450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5680794167573221
+      },
+      {
+        "run": 77,
+        "seed": 1622328550,
+        "success": true,
+        "steps": 191,
+        "total_reward": 33.44500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5062366969074287
+      },
+      {
+        "run": 78,
+        "seed": 1622328551,
+        "success": true,
+        "steps": 226,
+        "total_reward": 36.28000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4275770699888347
+      },
+      {
+        "run": 79,
+        "seed": 1622328552,
+        "success": true,
+        "steps": 218,
+        "total_reward": 41.650000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4234765234765234
+      },
+      {
+        "run": 80,
+        "seed": 1622328553,
+        "success": true,
+        "steps": 216,
+        "total_reward": 27.030000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4919430027553598
+      },
+      {
+        "run": 81,
+        "seed": 1622328554,
+        "success": true,
+        "steps": 248,
+        "total_reward": 38.15000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3874607458817985
+      },
+      {
+        "run": 82,
+        "seed": 1622328555,
+        "success": false,
+        "steps": 111,
+        "total_reward": 5.054999999999978,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3704968719674602
+      },
+      {
+        "run": 83,
+        "seed": 1622328556,
+        "success": true,
+        "steps": 168,
+        "total_reward": 30.94000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4863066319645267
+      },
+      {
+        "run": 84,
+        "seed": 1622328557,
+        "success": true,
+        "steps": 192,
+        "total_reward": 33.230000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48810075410574505
+      },
+      {
+        "run": 85,
+        "seed": 1622328558,
+        "success": true,
+        "steps": 238,
+        "total_reward": 29.230000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36643081444300957
+      },
+      {
+        "run": 86,
+        "seed": 1622328559,
+        "success": true,
+        "steps": 260,
+        "total_reward": 44.94000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46926330613830614
+      },
+      {
+        "run": 87,
+        "seed": 1622328560,
+        "success": true,
+        "steps": 225,
+        "total_reward": 23.71500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3566721797304774
+      },
+      {
+        "run": 88,
+        "seed": 1622328561,
+        "success": false,
+        "steps": 48,
+        "total_reward": 2.0900000000000016,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.6342592592592592
+      },
+      {
+        "run": 89,
+        "seed": 1622328562,
+        "success": true,
+        "steps": 138,
+        "total_reward": 23.920000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5083434065934066
+      },
+      {
+        "run": 90,
+        "seed": 1622328563,
+        "success": true,
+        "steps": 185,
+        "total_reward": 25.73500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4500241820768136
+      },
+      {
+        "run": 91,
+        "seed": 1622328564,
+        "success": true,
+        "steps": 238,
+        "total_reward": 41.57000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43457040035987404
+      },
+      {
+        "run": 92,
+        "seed": 1622328565,
+        "success": true,
+        "steps": 205,
+        "total_reward": 35.37500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4875123054756922
+      },
+      {
+        "run": 93,
+        "seed": 1622328566,
+        "success": true,
+        "steps": 148,
+        "total_reward": 26.360000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.500690464219876
+      },
+      {
+        "run": 94,
+        "seed": 1622328567,
+        "success": false,
+        "steps": 121,
+        "total_reward": 9.89500000000001,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.47363739017874357
+      },
+      {
+        "run": 95,
+        "seed": 1622328568,
+        "success": true,
+        "steps": 148,
+        "total_reward": 31.180000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5267111056584741
+      },
+      {
+        "run": 96,
+        "seed": 1622328569,
+        "success": true,
+        "steps": 186,
+        "total_reward": 37.33000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46302267756441984
+      },
+      {
+        "run": 97,
+        "seed": 1622328570,
+        "success": true,
+        "steps": 190,
+        "total_reward": 39.93000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4620600967659791
+      },
+      {
+        "run": 98,
+        "seed": 1622328571,
+        "success": true,
+        "steps": 158,
+        "total_reward": 34.21000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5909572685379137
+      },
+      {
+        "run": 99,
+        "seed": 1622328572,
+        "success": true,
+        "steps": 237,
+        "total_reward": 36.88500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4219264069264069
+      },
+      {
+        "run": 100,
+        "seed": 1622328573,
+        "success": false,
+        "steps": 116,
+        "total_reward": 10.849999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.537630579297246
+      },
+      {
+        "run": 101,
+        "seed": 1622328574,
+        "success": false,
+        "steps": 124,
+        "total_reward": 13.860000000000042,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.4878670301011651
+      },
+      {
+        "run": 102,
+        "seed": 1622328575,
+        "success": true,
+        "steps": 183,
+        "total_reward": 36.99500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45925541125541125
+      },
+      {
+        "run": 103,
+        "seed": 1622328576,
+        "success": true,
+        "steps": 205,
+        "total_reward": 26.855000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37624026199315164
+      },
+      {
+        "run": 104,
+        "seed": 1622328577,
+        "success": true,
+        "steps": 246,
+        "total_reward": 32.6700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33891657556766497
+      },
+      {
+        "run": 105,
+        "seed": 1622328578,
+        "success": true,
+        "steps": 186,
+        "total_reward": 35.03000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4929562594268477
+      },
+      {
+        "run": 106,
+        "seed": 1622328579,
+        "success": false,
+        "steps": 79,
+        "total_reward": 8.685000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.5650793650793651
+      },
+      {
+        "run": 107,
+        "seed": 1622328580,
+        "success": true,
+        "steps": 207,
+        "total_reward": 29.85500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4733209691999569
+      },
+      {
+        "run": 108,
+        "seed": 1622328581,
+        "success": true,
+        "steps": 189,
+        "total_reward": 29.205000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42451183371899487
+      },
+      {
+        "run": 109,
+        "seed": 1622328582,
+        "success": true,
+        "steps": 162,
+        "total_reward": 30.87000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5164124522820175
+      },
+      {
+        "run": 110,
+        "seed": 1622328583,
+        "success": true,
+        "steps": 193,
+        "total_reward": 32.24500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4611196985621538
+      },
+      {
+        "run": 111,
+        "seed": 1622328584,
+        "success": true,
+        "steps": 197,
+        "total_reward": 32.715000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4842664117765538
+      },
+      {
+        "run": 112,
+        "seed": 1622328585,
+        "success": true,
+        "steps": 191,
+        "total_reward": 28.905000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4266244703009409
+      },
+      {
+        "run": 113,
+        "seed": 1622328586,
+        "success": true,
+        "steps": 197,
+        "total_reward": 27.77500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4184853888786445
+      },
+      {
+        "run": 114,
+        "seed": 1622328587,
+        "success": true,
+        "steps": 194,
+        "total_reward": 35.8400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40328048053112
+      },
+      {
+        "run": 115,
+        "seed": 1622328588,
+        "success": true,
+        "steps": 217,
+        "total_reward": 39.17500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4516347051641169
+      },
+      {
+        "run": 116,
+        "seed": 1622328589,
+        "success": true,
+        "steps": 182,
+        "total_reward": 29.75000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45523006069176486
+      },
+      {
+        "run": 117,
+        "seed": 1622328590,
+        "success": true,
+        "steps": 286,
+        "total_reward": 37.63000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3933757257033119
+      },
+      {
+        "run": 118,
+        "seed": 1622328591,
+        "success": true,
+        "steps": 255,
+        "total_reward": 30.715000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3528335264364676
+      },
+      {
+        "run": 119,
+        "seed": 1622328592,
+        "success": true,
+        "steps": 196,
+        "total_reward": 31.050000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4191344561115432
+      },
+      {
+        "run": 120,
+        "seed": 1622328593,
+        "success": true,
+        "steps": 169,
+        "total_reward": 24.78500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4886351367930315
+      },
+      {
+        "run": 121,
+        "seed": 1622328594,
+        "success": true,
+        "steps": 158,
+        "total_reward": 24.75000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4477931627196333
+      },
+      {
+        "run": 122,
+        "seed": 1622328595,
+        "success": true,
+        "steps": 300,
+        "total_reward": 26.900000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4505108861726509
+      },
+      {
+        "run": 123,
+        "seed": 1622328596,
+        "success": true,
+        "steps": 272,
+        "total_reward": 34.94000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36796989890270954
+      },
+      {
+        "run": 124,
+        "seed": 1622328597,
+        "success": true,
+        "steps": 185,
+        "total_reward": 29.57500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4619421816573519
+      },
+      {
+        "run": 125,
+        "seed": 1622328598,
+        "success": true,
+        "steps": 157,
+        "total_reward": 26.405000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4773137354561503
+      },
+      {
+        "run": 126,
+        "seed": 1622328599,
+        "success": true,
+        "steps": 147,
+        "total_reward": 23.185000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5363131313131313
+      },
+      {
+        "run": 127,
+        "seed": 1622328600,
+        "success": true,
+        "steps": 156,
+        "total_reward": 28.470000000000024,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5363137408568444
+      },
+      {
+        "run": 128,
+        "seed": 1622328601,
+        "success": true,
+        "steps": 249,
+        "total_reward": 25.895000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43006165988407946
+      },
+      {
+        "run": 129,
+        "seed": 1622328602,
+        "success": true,
+        "steps": 232,
+        "total_reward": 30.680000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3821713038838319
+      },
+      {
+        "run": 130,
+        "seed": 1622328603,
+        "success": true,
+        "steps": 175,
+        "total_reward": 29.23500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4207720057720058
+      },
+      {
+        "run": 131,
+        "seed": 1622328604,
+        "success": false,
+        "steps": 170,
+        "total_reward": 10.600000000000009,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.34349888799663103
+      },
+      {
+        "run": 132,
+        "seed": 1622328605,
+        "success": true,
+        "steps": 156,
+        "total_reward": 30.060000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5143993751346693
+      },
+      {
+        "run": 133,
+        "seed": 1622328606,
+        "success": true,
+        "steps": 205,
+        "total_reward": 33.475000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4201184122894649
+      },
+      {
+        "run": 134,
+        "seed": 1622328607,
+        "success": false,
+        "steps": 152,
+        "total_reward": 5.379999999999981,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3661970583023214
+      },
+      {
+        "run": 135,
+        "seed": 1622328608,
+        "success": true,
+        "steps": 178,
+        "total_reward": 31.020000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4925438596491228
+      },
+      {
+        "run": 136,
+        "seed": 1622328609,
+        "success": true,
+        "steps": 194,
+        "total_reward": 28.420000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46683724119018233
+      },
+      {
+        "run": 137,
+        "seed": 1622328610,
+        "success": false,
+        "steps": 50,
+        "total_reward": -0.360000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.4772727272727273
+      },
+      {
+        "run": 138,
+        "seed": 1622328611,
+        "success": true,
+        "steps": 191,
+        "total_reward": 29.675000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4224496336996337
+      },
+      {
+        "run": 139,
+        "seed": 1622328612,
+        "success": true,
+        "steps": 226,
+        "total_reward": 34.880000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3661841062847255
+      },
+      {
+        "run": 140,
+        "seed": 1622328613,
+        "success": false,
+        "steps": 38,
+        "total_reward": -2.089999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.34782608695652173
+      },
+      {
+        "run": 141,
+        "seed": 1622328614,
+        "success": false,
+        "steps": 93,
+        "total_reward": -1.6750000000000078,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.4027777777777778
+      },
+      {
+        "run": 142,
+        "seed": 1622328615,
+        "success": true,
+        "steps": 174,
+        "total_reward": 36.28000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5448502675515059
+      },
+      {
+        "run": 143,
+        "seed": 1622328616,
+        "success": false,
+        "steps": 134,
+        "total_reward": 16.610000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.5115961784065233
+      },
+      {
+        "run": 144,
+        "seed": 1622328617,
+        "success": true,
+        "steps": 186,
+        "total_reward": 30.930000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4952608115398813
+      },
+      {
+        "run": 145,
+        "seed": 1622328618,
+        "success": true,
+        "steps": 241,
+        "total_reward": 32.24500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4565229215229215
+      },
+      {
+        "run": 146,
+        "seed": 1622328619,
+        "success": false,
+        "steps": 65,
+        "total_reward": -0.9149999999999956,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.5351851851851852
+      },
+      {
+        "run": 147,
+        "seed": 1622328620,
+        "success": true,
+        "steps": 142,
+        "total_reward": 35.670000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5900671550671551
+      },
+      {
+        "run": 148,
+        "seed": 1622328621,
+        "success": true,
+        "steps": 190,
+        "total_reward": 35.17000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47396240490705105
+      },
+      {
+        "run": 149,
+        "seed": 1622328622,
+        "success": false,
+        "steps": 143,
+        "total_reward": 17.57500000000005,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.45599162742019883
+      },
+      {
+        "run": 150,
+        "seed": 1622328623,
+        "success": true,
+        "steps": 218,
+        "total_reward": 27.7300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37080981217959247
+      },
+      {
+        "run": 151,
+        "seed": 1622328624,
+        "success": true,
+        "steps": 155,
+        "total_reward": 36.605000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5614298201798202
+      },
+      {
+        "run": 152,
+        "seed": 1622328625,
+        "success": true,
+        "steps": 151,
+        "total_reward": 30.825000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5043192640692641
+      },
+      {
+        "run": 153,
+        "seed": 1622328626,
+        "success": true,
+        "steps": 260,
+        "total_reward": 29.16000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33733812878921504
+      },
+      {
+        "run": 154,
+        "seed": 1622328627,
+        "success": true,
+        "steps": 252,
+        "total_reward": 33.97000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43188620213928164
+      },
+      {
+        "run": 155,
+        "seed": 1622328628,
+        "success": true,
+        "steps": 170,
+        "total_reward": 31.11000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4352994309611956
+      },
+      {
+        "run": 156,
+        "seed": 1622328629,
+        "success": true,
+        "steps": 213,
+        "total_reward": 42.145000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5013369963369964
+      },
+      {
+        "run": 157,
+        "seed": 1622328630,
+        "success": true,
+        "steps": 176,
+        "total_reward": 35.99000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.58109929522973
+      },
+      {
+        "run": 158,
+        "seed": 1622328631,
+        "success": true,
+        "steps": 197,
+        "total_reward": 30.22500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44527736968913445
+      },
+      {
+        "run": 159,
+        "seed": 1622328632,
+        "success": true,
+        "steps": 163,
+        "total_reward": 23.02500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5116599862555745
+      },
+      {
+        "run": 160,
+        "seed": 1622328633,
+        "success": true,
+        "steps": 191,
+        "total_reward": 39.305000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5484882320806468
+      },
+      {
+        "run": 161,
+        "seed": 1622328634,
+        "success": true,
+        "steps": 195,
+        "total_reward": 26.115000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3901443001443001
+      },
+      {
+        "run": 162,
+        "seed": 1622328635,
+        "success": true,
+        "steps": 176,
+        "total_reward": 32.58000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4447958356563032
+      },
+      {
+        "run": 163,
+        "seed": 1622328636,
+        "success": true,
+        "steps": 213,
+        "total_reward": 35.625000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42327662817432643
+      },
+      {
+        "run": 164,
+        "seed": 1622328637,
+        "success": true,
+        "steps": 302,
+        "total_reward": 36.060000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4927552977125109
+      },
+      {
+        "run": 165,
+        "seed": 1622328638,
+        "success": true,
+        "steps": 189,
+        "total_reward": 26.335000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4101501989001989
+      },
+      {
+        "run": 166,
+        "seed": 1622328639,
+        "success": false,
+        "steps": 22,
+        "total_reward": -6.609999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 167,
+        "seed": 1622328640,
+        "success": true,
+        "steps": 135,
+        "total_reward": 33.80500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5747451486422075
+      },
+      {
+        "run": 168,
+        "seed": 1622328641,
+        "success": true,
+        "steps": 173,
+        "total_reward": 41.115000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5278665348432791
+      },
+      {
+        "run": 169,
+        "seed": 1622328642,
+        "success": true,
+        "steps": 167,
+        "total_reward": 30.32500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5317223134464514
+      },
+      {
+        "run": 170,
+        "seed": 1622328643,
+        "success": true,
+        "steps": 203,
+        "total_reward": 37.45500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43898493472695926
+      },
+      {
+        "run": 171,
+        "seed": 1622328644,
+        "success": true,
+        "steps": 187,
+        "total_reward": 25.68500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4282912025045892
+      },
+      {
+        "run": 172,
+        "seed": 1622328645,
+        "success": true,
+        "steps": 118,
+        "total_reward": 27.73000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6175014459224986
+      },
+      {
+        "run": 173,
+        "seed": 1622328646,
+        "success": true,
+        "steps": 235,
+        "total_reward": 25.33500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3543924682623313
+      },
+      {
+        "run": 174,
+        "seed": 1622328647,
+        "success": true,
+        "steps": 184,
+        "total_reward": 30.8000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47705317511620027
+      },
+      {
+        "run": 175,
+        "seed": 1622328648,
+        "success": true,
+        "steps": 253,
+        "total_reward": 29.99500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3743668606860612
+      },
+      {
+        "run": 176,
+        "seed": 1622328649,
+        "success": true,
+        "steps": 201,
+        "total_reward": 31.565000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47968940255147147
+      },
+      {
+        "run": 177,
+        "seed": 1622328650,
+        "success": true,
+        "steps": 163,
+        "total_reward": 28.525000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4468648018648018
+      },
+      {
+        "run": 178,
+        "seed": 1622328651,
+        "success": true,
+        "steps": 163,
+        "total_reward": 26.92500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45884469847318143
+      },
+      {
+        "run": 179,
+        "seed": 1622328652,
+        "success": true,
+        "steps": 178,
+        "total_reward": 22.819999999999997,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42575689016865487
+      },
+      {
+        "run": 180,
+        "seed": 1622328653,
+        "success": true,
+        "steps": 164,
+        "total_reward": 30.060000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4686185546479664
+      },
+      {
+        "run": 181,
+        "seed": 1622328654,
+        "success": true,
+        "steps": 161,
+        "total_reward": 28.39500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.532971127788201
+      },
+      {
+        "run": 182,
+        "seed": 1622328655,
+        "success": true,
+        "steps": 134,
+        "total_reward": 29.64000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5641883035265388
+      },
+      {
+        "run": 183,
+        "seed": 1622328656,
+        "success": true,
+        "steps": 212,
+        "total_reward": 34.03000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5058250692899031
+      },
+      {
+        "run": 184,
+        "seed": 1622328657,
+        "success": true,
+        "steps": 194,
+        "total_reward": 29.33000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40862905016130824
+      },
+      {
+        "run": 185,
+        "seed": 1622328658,
+        "success": true,
+        "steps": 208,
+        "total_reward": 31.930000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44494901809556986
+      },
+      {
+        "run": 186,
+        "seed": 1622328659,
+        "success": true,
+        "steps": 207,
+        "total_reward": 33.225000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41641146762751174
+      },
+      {
+        "run": 187,
+        "seed": 1622328660,
+        "success": true,
+        "steps": 265,
+        "total_reward": 38.04500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42226436354343333
+      },
+      {
+        "run": 188,
+        "seed": 1622328661,
+        "success": true,
+        "steps": 228,
+        "total_reward": 31.17000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37914822967130546
+      },
+      {
+        "run": 189,
+        "seed": 1622328662,
+        "success": true,
+        "steps": 160,
+        "total_reward": 33.57000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5108871520636227
+      },
+      {
+        "run": 190,
+        "seed": 1622328663,
+        "success": false,
+        "steps": 17,
+        "total_reward": -8.684999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 191,
+        "seed": 1622328664,
+        "success": true,
+        "steps": 159,
+        "total_reward": 29.095000000000038,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4783304071229768
+      },
+      {
+        "run": 192,
+        "seed": 1622328665,
+        "success": true,
+        "steps": 196,
+        "total_reward": 32.94000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39242850455059364
+      },
+      {
+        "run": 193,
+        "seed": 1622328666,
+        "success": true,
+        "steps": 169,
+        "total_reward": 37.19500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5278480618997861
+      },
+      {
+        "run": 194,
+        "seed": 1622328667,
+        "success": true,
+        "steps": 260,
+        "total_reward": 33.54000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45491570435214507
+      },
+      {
+        "run": 195,
+        "seed": 1622328668,
+        "success": true,
+        "steps": 203,
+        "total_reward": 37.85500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45125670382249333
+      },
+      {
+        "run": 196,
+        "seed": 1622328669,
+        "success": false,
+        "steps": 184,
+        "total_reward": 16.37000000000005,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.38911629849199053
+      },
+      {
+        "run": 197,
+        "seed": 1622328670,
+        "success": true,
+        "steps": 191,
+        "total_reward": 31.585000000000047,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47252543643720113
+      },
+      {
+        "run": 198,
+        "seed": 1622328671,
+        "success": true,
+        "steps": 289,
+        "total_reward": 30.085000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45508589850695114
+      },
+      {
+        "run": 199,
+        "seed": 1622328672,
+        "success": true,
+        "steps": 172,
+        "total_reward": 34.81000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49193121693121694
+      },
+      {
+        "run": 200,
+        "seed": 1622328673,
+        "success": true,
+        "steps": 291,
+        "total_reward": 24.115000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46194821053599205
+      }
+    ],
+    "avg_chemotaxis_index": 0.33065558614660867,
+    "avg_time_in_attractant": 0.6653277930733043,
+    "avg_approach_frequency": 0.3997213624324549,
+    "avg_path_efficiency": 0.046285130044220295,
+    "post_convergence_chemotaxis_index": 0.36159699003927614,
+    "post_convergence_time_in_attractant": 0.6807984950196382,
+    "post_convergence_approach_frequency": 0.40526864836043497,
+    "post_convergence_path_efficiency": 0.04881583824358956,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_100742.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_100742.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_100742",
+  "timestamp": "2025-12-29T10:16:11.499397+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_100742",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.81,
+    "avg_steps": 182.66,
+    "avg_reward": 27.01460000000007,
+    "avg_foods_collected": 8.94,
+    "avg_distance_efficiency": 0.47072625179057376,
+    "completed_all_food": 162,
+    "starved": 4,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 34,
+    "avg_predator_encounters": 6.555,
+    "avg_successful_evasions": 6.105,
+    "converged": true,
+    "convergence_run": 33,
+    "runs_to_convergence": 32,
+    "post_convergence_success_rate": 0.8630952380952381,
+    "post_convergence_avg_steps": 184.79310344827587,
+    "post_convergence_avg_foods": 9.351190476190476,
+    "post_convergence_variance": 0.11816184807256234,
+    "post_convergence_distance_efficiency": 0.4979497928936012,
+    "composite_benchmark_score": 0.7035421090698945,
+    "learning_speed": 0.865,
+    "learning_speed_episodes": 27,
+    "stability": 0.6017278698488024,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3491961207,
+        "success": false,
+        "steps": 161,
+        "total_reward": -17.845000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 3491961208,
+        "success": false,
+        "steps": 51,
+        "total_reward": -13.885000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 3491961209,
+        "success": false,
+        "steps": 137,
+        "total_reward": -14.574999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 3491961210,
+        "success": false,
+        "steps": 240,
+        "total_reward": -6.769999999999991,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.046296296296296294
+      },
+      {
+        "run": 5,
+        "seed": 3491961211,
+        "success": false,
+        "steps": 152,
+        "total_reward": -0.020000000000008455,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.46111111111111114
+      },
+      {
+        "run": 6,
+        "seed": 3491961212,
+        "success": false,
+        "steps": 240,
+        "total_reward": -6.350000000000005,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.11392405063291139
+      },
+      {
+        "run": 7,
+        "seed": 3491961213,
+        "success": false,
+        "steps": 66,
+        "total_reward": -11.559999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 8,
+        "seed": 3491961214,
+        "success": false,
+        "steps": 322,
+        "total_reward": -2.7400000000000198,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.2280577892871746
+      },
+      {
+        "run": 9,
+        "seed": 3491961215,
+        "success": false,
+        "steps": 442,
+        "total_reward": 9.150000000000091,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.23367331274003206
+      },
+      {
+        "run": 10,
+        "seed": 3491961216,
+        "success": true,
+        "steps": 490,
+        "total_reward": 17.249999999999957,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.17063160355388632
+      },
+      {
+        "run": 11,
+        "seed": 3491961217,
+        "success": true,
+        "steps": 284,
+        "total_reward": 20.030000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3782417582417582
+      },
+      {
+        "run": 12,
+        "seed": 3491961218,
+        "success": true,
+        "steps": 224,
+        "total_reward": 36.06000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44485907315191203
+      },
+      {
+        "run": 13,
+        "seed": 3491961219,
+        "success": true,
+        "steps": 176,
+        "total_reward": 22.42000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41118081435472736
+      },
+      {
+        "run": 14,
+        "seed": 3491961220,
+        "success": true,
+        "steps": 205,
+        "total_reward": 26.66500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29743488992354694
+      },
+      {
+        "run": 15,
+        "seed": 3491961221,
+        "success": true,
+        "steps": 286,
+        "total_reward": 34.330000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3319407955121391
+      },
+      {
+        "run": 16,
+        "seed": 3491961222,
+        "success": false,
+        "steps": 113,
+        "total_reward": 8.35499999999999,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.4869093672285162
+      },
+      {
+        "run": 17,
+        "seed": 3491961223,
+        "success": false,
+        "steps": 58,
+        "total_reward": -2.2300000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.2916666666666667
+      },
+      {
+        "run": 18,
+        "seed": 3491961224,
+        "success": true,
+        "steps": 252,
+        "total_reward": 22.95000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3768280481568166
+      },
+      {
+        "run": 19,
+        "seed": 3491961225,
+        "success": false,
+        "steps": 188,
+        "total_reward": 12.470000000000049,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.31894319131161236
+      },
+      {
+        "run": 20,
+        "seed": 3491961226,
+        "success": true,
+        "steps": 237,
+        "total_reward": 27.845000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3574845616095616
+      },
+      {
+        "run": 21,
+        "seed": 3491961227,
+        "success": true,
+        "steps": 248,
+        "total_reward": 30.69000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30695647876293036
+      },
+      {
+        "run": 22,
+        "seed": 3491961228,
+        "success": true,
+        "steps": 238,
+        "total_reward": 27.030000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3179961787039827
+      },
+      {
+        "run": 23,
+        "seed": 3491961229,
+        "success": false,
+        "steps": 107,
+        "total_reward": 6.394999999999975,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4257783882783882
+      },
+      {
+        "run": 24,
+        "seed": 3491961230,
+        "success": true,
+        "steps": 247,
+        "total_reward": 18.924999999999983,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3637062007382894
+      },
+      {
+        "run": 25,
+        "seed": 3491961231,
+        "success": true,
+        "steps": 167,
+        "total_reward": 30.395000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4290536948431686
+      },
+      {
+        "run": 26,
+        "seed": 3491961232,
+        "success": true,
+        "steps": 201,
+        "total_reward": 27.975000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4463083566760037
+      },
+      {
+        "run": 27,
+        "seed": 3491961233,
+        "success": true,
+        "steps": 225,
+        "total_reward": 28.16500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40196205755029285
+      },
+      {
+        "run": 28,
+        "seed": 3491961234,
+        "success": true,
+        "steps": 189,
+        "total_reward": 33.34500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44118015626781404
+      },
+      {
+        "run": 29,
+        "seed": 3491961235,
+        "success": true,
+        "steps": 307,
+        "total_reward": 31.325000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3675992391010362
+      },
+      {
+        "run": 30,
+        "seed": 3491961236,
+        "success": true,
+        "steps": 165,
+        "total_reward": 39.19500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5716231756545056
+      },
+      {
+        "run": 31,
+        "seed": 3491961237,
+        "success": false,
+        "steps": 175,
+        "total_reward": 21.025000000000112,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.52008177580933
+      },
+      {
+        "run": 32,
+        "seed": 3491961238,
+        "success": false,
+        "steps": 132,
+        "total_reward": 15.720000000000049,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.432670480916095
+      },
+      {
+        "run": 33,
+        "seed": 3491961239,
+        "success": true,
+        "steps": 235,
+        "total_reward": 44.545000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41650400049141467
+      },
+      {
+        "run": 34,
+        "seed": 3491961240,
+        "success": true,
+        "steps": 192,
+        "total_reward": 27.78000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4897231840317152
+      },
+      {
+        "run": 35,
+        "seed": 3491961241,
+        "success": true,
+        "steps": 288,
+        "total_reward": 37.49000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5248458868834052
+      },
+      {
+        "run": 36,
+        "seed": 3491961242,
+        "success": true,
+        "steps": 199,
+        "total_reward": 29.28500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41495925642984466
+      },
+      {
+        "run": 37,
+        "seed": 3491961243,
+        "success": true,
+        "steps": 215,
+        "total_reward": 27.56500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44157695947649006
+      },
+      {
+        "run": 38,
+        "seed": 3491961244,
+        "success": true,
+        "steps": 213,
+        "total_reward": 34.42500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4423358547197557
+      },
+      {
+        "run": 39,
+        "seed": 3491961245,
+        "success": true,
+        "steps": 160,
+        "total_reward": 24.10000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5511803547329863
+      },
+      {
+        "run": 40,
+        "seed": 3491961246,
+        "success": true,
+        "steps": 180,
+        "total_reward": 33.5800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4939033954551196
+      },
+      {
+        "run": 41,
+        "seed": 3491961247,
+        "success": true,
+        "steps": 249,
+        "total_reward": 36.14500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4278627165962693
+      },
+      {
+        "run": 42,
+        "seed": 3491961248,
+        "success": true,
+        "steps": 208,
+        "total_reward": 23.840000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3802456479738427
+      },
+      {
+        "run": 43,
+        "seed": 3491961249,
+        "success": true,
+        "steps": 214,
+        "total_reward": 32.99000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4551044995193932
+      },
+      {
+        "run": 44,
+        "seed": 3491961250,
+        "success": true,
+        "steps": 173,
+        "total_reward": 34.065000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5859498396340501
+      },
+      {
+        "run": 45,
+        "seed": 3491961251,
+        "success": true,
+        "steps": 291,
+        "total_reward": 50.96500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47441045417350136
+      },
+      {
+        "run": 46,
+        "seed": 3491961252,
+        "success": true,
+        "steps": 207,
+        "total_reward": 34.72500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4329301394470832
+      },
+      {
+        "run": 47,
+        "seed": 3491961253,
+        "success": true,
+        "steps": 173,
+        "total_reward": 27.855000000000032,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4664573732718894
+      },
+      {
+        "run": 48,
+        "seed": 3491961254,
+        "success": false,
+        "steps": 43,
+        "total_reward": 3.1149999999999984,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.6263736263736264
+      },
+      {
+        "run": 49,
+        "seed": 3491961255,
+        "success": true,
+        "steps": 175,
+        "total_reward": 35.10500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49570202020202025
+      },
+      {
+        "run": 50,
+        "seed": 3491961256,
+        "success": true,
+        "steps": 184,
+        "total_reward": 35.30000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5106830126395343
+      },
+      {
+        "run": 51,
+        "seed": 3491961257,
+        "success": true,
+        "steps": 142,
+        "total_reward": 28.090000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.591531713900135
+      },
+      {
+        "run": 52,
+        "seed": 3491961258,
+        "success": true,
+        "steps": 187,
+        "total_reward": 27.0050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47522642390289455
+      },
+      {
+        "run": 53,
+        "seed": 3491961259,
+        "success": true,
+        "steps": 149,
+        "total_reward": 37.10500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5602912453547663
+      },
+      {
+        "run": 54,
+        "seed": 3491961260,
+        "success": true,
+        "steps": 170,
+        "total_reward": 30.0000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4800590685932242
+      },
+      {
+        "run": 55,
+        "seed": 3491961261,
+        "success": true,
+        "steps": 151,
+        "total_reward": 34.98500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6751287309182046
+      },
+      {
+        "run": 56,
+        "seed": 3491961262,
+        "success": false,
+        "steps": 104,
+        "total_reward": 8.820000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5208333333333334
+      },
+      {
+        "run": 57,
+        "seed": 3491961263,
+        "success": true,
+        "steps": 184,
+        "total_reward": 31.170000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4549898763853367
+      },
+      {
+        "run": 58,
+        "seed": 3491961264,
+        "success": true,
+        "steps": 161,
+        "total_reward": 24.15500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5105879141448806
+      },
+      {
+        "run": 59,
+        "seed": 3491961265,
+        "success": true,
+        "steps": 261,
+        "total_reward": 34.525000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40247504602677014
+      },
+      {
+        "run": 60,
+        "seed": 3491961266,
+        "success": true,
+        "steps": 196,
+        "total_reward": 31.03000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5009705653823301
+      },
+      {
+        "run": 61,
+        "seed": 3491961267,
+        "success": true,
+        "steps": 269,
+        "total_reward": 33.19500000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4237695252953027
+      },
+      {
+        "run": 62,
+        "seed": 3491961268,
+        "success": true,
+        "steps": 171,
+        "total_reward": 27.935000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.467677607480239
+      },
+      {
+        "run": 63,
+        "seed": 3491961269,
+        "success": true,
+        "steps": 135,
+        "total_reward": 29.27500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5230313548344239
+      },
+      {
+        "run": 64,
+        "seed": 3491961270,
+        "success": true,
+        "steps": 160,
+        "total_reward": 23.28000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.490183682058682
+      },
+      {
+        "run": 65,
+        "seed": 3491961271,
+        "success": true,
+        "steps": 204,
+        "total_reward": 30.780000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5225069375069376
+      },
+      {
+        "run": 66,
+        "seed": 3491961272,
+        "success": true,
+        "steps": 184,
+        "total_reward": 23.009999999999998,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4300101214574899
+      },
+      {
+        "run": 67,
+        "seed": 3491961273,
+        "success": true,
+        "steps": 168,
+        "total_reward": 38.24000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5680952380952381
+      },
+      {
+        "run": 68,
+        "seed": 3491961274,
+        "success": true,
+        "steps": 185,
+        "total_reward": 41.18500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4771441952066868
+      },
+      {
+        "run": 69,
+        "seed": 3491961275,
+        "success": true,
+        "steps": 166,
+        "total_reward": 30.70000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45370322270322266
+      },
+      {
+        "run": 70,
+        "seed": 3491961276,
+        "success": true,
+        "steps": 211,
+        "total_reward": 31.02500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4328752435855064
+      },
+      {
+        "run": 71,
+        "seed": 3491961277,
+        "success": false,
+        "steps": 153,
+        "total_reward": 21.565000000000094,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5387728937728937
+      },
+      {
+        "run": 72,
+        "seed": 3491961278,
+        "success": true,
+        "steps": 175,
+        "total_reward": 39.135000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5824306875919779
+      },
+      {
+        "run": 73,
+        "seed": 3491961279,
+        "success": true,
+        "steps": 233,
+        "total_reward": 22.905000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3454347674742412
+      },
+      {
+        "run": 74,
+        "seed": 3491961280,
+        "success": true,
+        "steps": 173,
+        "total_reward": 33.18500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5269130611390673
+      },
+      {
+        "run": 75,
+        "seed": 3491961281,
+        "success": false,
+        "steps": 104,
+        "total_reward": 4.189999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.5589326765188833
+      },
+      {
+        "run": 76,
+        "seed": 3491961282,
+        "success": true,
+        "steps": 180,
+        "total_reward": 36.76000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4622060013629781
+      },
+      {
+        "run": 77,
+        "seed": 3491961283,
+        "success": false,
+        "steps": 119,
+        "total_reward": 9.80500000000001,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.4833365164247517
+      },
+      {
+        "run": 78,
+        "seed": 3491961284,
+        "success": false,
+        "steps": 318,
+        "total_reward": 15.239999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4485206151872818
+      },
+      {
+        "run": 79,
+        "seed": 3491961285,
+        "success": true,
+        "steps": 204,
+        "total_reward": 21.19999999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3885612081337116
+      },
+      {
+        "run": 80,
+        "seed": 3491961286,
+        "success": true,
+        "steps": 166,
+        "total_reward": 27.980000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49201877590415516
+      },
+      {
+        "run": 81,
+        "seed": 3491961287,
+        "success": true,
+        "steps": 134,
+        "total_reward": 35.23000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6329276430365359
+      },
+      {
+        "run": 82,
+        "seed": 3491961288,
+        "success": true,
+        "steps": 146,
+        "total_reward": 22.700000000000028,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49583057980890793
+      },
+      {
+        "run": 83,
+        "seed": 3491961289,
+        "success": true,
+        "steps": 262,
+        "total_reward": 34.3200000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3576467916141829
+      },
+      {
+        "run": 84,
+        "seed": 3491961290,
+        "success": true,
+        "steps": 192,
+        "total_reward": 34.73000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5236848787655239
+      },
+      {
+        "run": 85,
+        "seed": 3491961291,
+        "success": true,
+        "steps": 154,
+        "total_reward": 36.87000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5999358076563959
+      },
+      {
+        "run": 86,
+        "seed": 3491961292,
+        "success": false,
+        "steps": 249,
+        "total_reward": -1.2250000000000423,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.6959273182957394
+      },
+      {
+        "run": 87,
+        "seed": 3491961293,
+        "success": true,
+        "steps": 224,
+        "total_reward": 33.660000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38004762909948664
+      },
+      {
+        "run": 88,
+        "seed": 3491961294,
+        "success": true,
+        "steps": 220,
+        "total_reward": 36.63000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49802207856872105
+      },
+      {
+        "run": 89,
+        "seed": 3491961295,
+        "success": false,
+        "steps": 284,
+        "total_reward": 10.44999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.382094518384841
+      },
+      {
+        "run": 90,
+        "seed": 3491961296,
+        "success": false,
+        "steps": 133,
+        "total_reward": 11.015000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3792403327440047
+      },
+      {
+        "run": 91,
+        "seed": 3491961297,
+        "success": true,
+        "steps": 254,
+        "total_reward": 40.91000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4576885632667187
+      },
+      {
+        "run": 92,
+        "seed": 3491961298,
+        "success": true,
+        "steps": 182,
+        "total_reward": 42.40000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5574182883217877
+      },
+      {
+        "run": 93,
+        "seed": 3491961299,
+        "success": true,
+        "steps": 172,
+        "total_reward": 35.100000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5390943851470167
+      },
+      {
+        "run": 94,
+        "seed": 3491961300,
+        "success": true,
+        "steps": 229,
+        "total_reward": 27.435000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43294635919635915
+      },
+      {
+        "run": 95,
+        "seed": 3491961301,
+        "success": true,
+        "steps": 168,
+        "total_reward": 34.68000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5675025464731347
+      },
+      {
+        "run": 96,
+        "seed": 3491961302,
+        "success": false,
+        "steps": 84,
+        "total_reward": 6.1399999999999935,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.531802398989899
+      },
+      {
+        "run": 97,
+        "seed": 3491961303,
+        "success": false,
+        "steps": 51,
+        "total_reward": -2.755000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.47039473684210525
+      },
+      {
+        "run": 98,
+        "seed": 3491961304,
+        "success": true,
+        "steps": 156,
+        "total_reward": 27.980000000000057,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43212987012987014
+      },
+      {
+        "run": 99,
+        "seed": 3491961305,
+        "success": true,
+        "steps": 163,
+        "total_reward": 27.39500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4397262386736071
+      },
+      {
+        "run": 100,
+        "seed": 3491961306,
+        "success": true,
+        "steps": 253,
+        "total_reward": 34.4350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40433028083028083
+      },
+      {
+        "run": 101,
+        "seed": 3491961307,
+        "success": true,
+        "steps": 181,
+        "total_reward": 39.0850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5495937837650766
+      },
+      {
+        "run": 102,
+        "seed": 3491961308,
+        "success": true,
+        "steps": 196,
+        "total_reward": 42.050000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46284818555997054
+      },
+      {
+        "run": 103,
+        "seed": 3491961309,
+        "success": true,
+        "steps": 246,
+        "total_reward": 25.28000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4791607411139335
+      },
+      {
+        "run": 104,
+        "seed": 3491961310,
+        "success": true,
+        "steps": 166,
+        "total_reward": 35.77000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5552011410624856
+      },
+      {
+        "run": 105,
+        "seed": 3491961311,
+        "success": true,
+        "steps": 191,
+        "total_reward": 29.585000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5196603641456583
+      },
+      {
+        "run": 106,
+        "seed": 3491961312,
+        "success": true,
+        "steps": 139,
+        "total_reward": 28.35500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5402676563202878
+      },
+      {
+        "run": 107,
+        "seed": 3491961313,
+        "success": true,
+        "steps": 187,
+        "total_reward": 36.265000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5480599592823701
+      },
+      {
+        "run": 108,
+        "seed": 3491961314,
+        "success": true,
+        "steps": 201,
+        "total_reward": 32.765000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4676252090405014
+      },
+      {
+        "run": 109,
+        "seed": 3491961315,
+        "success": true,
+        "steps": 227,
+        "total_reward": 23.044999999999995,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40406998499002134
+      },
+      {
+        "run": 110,
+        "seed": 3491961316,
+        "success": true,
+        "steps": 148,
+        "total_reward": 33.000000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5174862914862914
+      },
+      {
+        "run": 111,
+        "seed": 3491961317,
+        "success": false,
+        "steps": 101,
+        "total_reward": 11.195,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5940205627705628
+      },
+      {
+        "run": 112,
+        "seed": 3491961318,
+        "success": true,
+        "steps": 184,
+        "total_reward": 34.410000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45606807940567534
+      },
+      {
+        "run": 113,
+        "seed": 3491961319,
+        "success": false,
+        "steps": 65,
+        "total_reward": -3.245000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4251984126984127
+      },
+      {
+        "run": 114,
+        "seed": 3491961320,
+        "success": true,
+        "steps": 184,
+        "total_reward": 33.71000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47299756227876844
+      },
+      {
+        "run": 115,
+        "seed": 3491961321,
+        "success": true,
+        "steps": 181,
+        "total_reward": 25.795000000000048,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4119434113358261
+      },
+      {
+        "run": 116,
+        "seed": 3491961322,
+        "success": true,
+        "steps": 177,
+        "total_reward": 38.465000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5699530843552583
+      },
+      {
+        "run": 117,
+        "seed": 3491961323,
+        "success": true,
+        "steps": 153,
+        "total_reward": 31.8950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5292154740684152
+      },
+      {
+        "run": 118,
+        "seed": 3491961324,
+        "success": true,
+        "steps": 160,
+        "total_reward": 33.29000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4644027922907233
+      },
+      {
+        "run": 119,
+        "seed": 3491961325,
+        "success": true,
+        "steps": 167,
+        "total_reward": 36.83500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.511138005441411
+      },
+      {
+        "run": 120,
+        "seed": 3491961326,
+        "success": true,
+        "steps": 139,
+        "total_reward": 33.23500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.570801282051282
+      },
+      {
+        "run": 121,
+        "seed": 3491961327,
+        "success": true,
+        "steps": 193,
+        "total_reward": 38.87500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5199431153641679
+      },
+      {
+        "run": 122,
+        "seed": 3491961328,
+        "success": false,
+        "steps": 58,
+        "total_reward": 1.560000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5615079365079365
+      },
+      {
+        "run": 123,
+        "seed": 3491961329,
+        "success": true,
+        "steps": 195,
+        "total_reward": 30.025000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.449777066354041
+      },
+      {
+        "run": 124,
+        "seed": 3491961330,
+        "success": false,
+        "steps": 138,
+        "total_reward": 20.53000000000008,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.48819444444444443
+      },
+      {
+        "run": 125,
+        "seed": 3491961331,
+        "success": true,
+        "steps": 136,
+        "total_reward": 25.87000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5272431077694235
+      },
+      {
+        "run": 126,
+        "seed": 3491961332,
+        "success": false,
+        "steps": 143,
+        "total_reward": 16.53500000000004,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4821656170340381
+      },
+      {
+        "run": 127,
+        "seed": 3491961333,
+        "success": true,
+        "steps": 187,
+        "total_reward": 33.745000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5472845599219724
+      },
+      {
+        "run": 128,
+        "seed": 3491961334,
+        "success": true,
+        "steps": 183,
+        "total_reward": 32.70500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.53001443001443
+      },
+      {
+        "run": 129,
+        "seed": 3491961335,
+        "success": true,
+        "steps": 180,
+        "total_reward": 30.65000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49417448430034244
+      },
+      {
+        "run": 130,
+        "seed": 3491961336,
+        "success": true,
+        "steps": 162,
+        "total_reward": 38.62000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6084517042411779
+      },
+      {
+        "run": 131,
+        "seed": 3491961337,
+        "success": true,
+        "steps": 168,
+        "total_reward": 24.390000000000036,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43976495726495723
+      },
+      {
+        "run": 132,
+        "seed": 3491961338,
+        "success": true,
+        "steps": 137,
+        "total_reward": 34.37500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6284638467827323
+      },
+      {
+        "run": 133,
+        "seed": 3491961339,
+        "success": true,
+        "steps": 153,
+        "total_reward": 33.5150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5627705627705628
+      },
+      {
+        "run": 134,
+        "seed": 3491961340,
+        "success": true,
+        "steps": 155,
+        "total_reward": 36.195000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5607653819610341
+      },
+      {
+        "run": 135,
+        "seed": 3491961341,
+        "success": true,
+        "steps": 189,
+        "total_reward": 31.36500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4727450980392157
+      },
+      {
+        "run": 136,
+        "seed": 3491961342,
+        "success": true,
+        "steps": 203,
+        "total_reward": 30.235000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3564524967785837
+      },
+      {
+        "run": 137,
+        "seed": 3491961343,
+        "success": true,
+        "steps": 171,
+        "total_reward": 33.85500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4969928804139331
+      },
+      {
+        "run": 138,
+        "seed": 3491961344,
+        "success": false,
+        "steps": 36,
+        "total_reward": -4.729999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.5590909090909091
+      },
+      {
+        "run": 139,
+        "seed": 3491961345,
+        "success": true,
+        "steps": 187,
+        "total_reward": 34.585000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4343595718766718
+      },
+      {
+        "run": 140,
+        "seed": 3491961346,
+        "success": true,
+        "steps": 225,
+        "total_reward": 36.77500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4648534798534799
+      },
+      {
+        "run": 141,
+        "seed": 3491961347,
+        "success": true,
+        "steps": 167,
+        "total_reward": 26.825000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45648086562560247
+      },
+      {
+        "run": 142,
+        "seed": 3491961348,
+        "success": true,
+        "steps": 251,
+        "total_reward": 26.875000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46027255424314245
+      },
+      {
+        "run": 143,
+        "seed": 3491961349,
+        "success": true,
+        "steps": 231,
+        "total_reward": 47.005000000000166,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4923721067374318
+      },
+      {
+        "run": 144,
+        "seed": 3491961350,
+        "success": true,
+        "steps": 188,
+        "total_reward": 35.130000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5243358078702907
+      },
+      {
+        "run": 145,
+        "seed": 3491961351,
+        "success": true,
+        "steps": 191,
+        "total_reward": 32.5850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5375804770454653
+      },
+      {
+        "run": 146,
+        "seed": 3491961352,
+        "success": true,
+        "steps": 133,
+        "total_reward": 27.92500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5049104880626619
+      },
+      {
+        "run": 147,
+        "seed": 3491961353,
+        "success": true,
+        "steps": 144,
+        "total_reward": 28.61000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5222846108140226
+      },
+      {
+        "run": 148,
+        "seed": 3491961354,
+        "success": true,
+        "steps": 134,
+        "total_reward": 26.830000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.55995670995671
+      },
+      {
+        "run": 149,
+        "seed": 3491961355,
+        "success": true,
+        "steps": 167,
+        "total_reward": 34.81500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5506790713312453
+      },
+      {
+        "run": 150,
+        "seed": 3491961356,
+        "success": true,
+        "steps": 161,
+        "total_reward": 28.845000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5067075358851675
+      },
+      {
+        "run": 151,
+        "seed": 3491961357,
+        "success": true,
+        "steps": 136,
+        "total_reward": 31.470000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.580437353567149
+      },
+      {
+        "run": 152,
+        "seed": 3491961358,
+        "success": true,
+        "steps": 194,
+        "total_reward": 30.46000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4525177635431719
+      },
+      {
+        "run": 153,
+        "seed": 3491961359,
+        "success": true,
+        "steps": 186,
+        "total_reward": 34.65000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5376469182990922
+      },
+      {
+        "run": 154,
+        "seed": 3491961360,
+        "success": true,
+        "steps": 141,
+        "total_reward": 26.02500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5744445750328103
+      },
+      {
+        "run": 155,
+        "seed": 3491961361,
+        "success": true,
+        "steps": 169,
+        "total_reward": 31.53500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5565007784613047
+      },
+      {
+        "run": 156,
+        "seed": 3491961362,
+        "success": true,
+        "steps": 154,
+        "total_reward": 22.64000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43275016377957554
+      },
+      {
+        "run": 157,
+        "seed": 3491961363,
+        "success": true,
+        "steps": 127,
+        "total_reward": 32.41500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6213927588579291
+      },
+      {
+        "run": 158,
+        "seed": 3491961364,
+        "success": true,
+        "steps": 173,
+        "total_reward": 32.28500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5095856898477866
+      },
+      {
+        "run": 159,
+        "seed": 3491961365,
+        "success": true,
+        "steps": 144,
+        "total_reward": 29.210000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5160642135642136
+      },
+      {
+        "run": 160,
+        "seed": 3491961366,
+        "success": true,
+        "steps": 152,
+        "total_reward": 36.960000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5715974025974025
+      },
+      {
+        "run": 161,
+        "seed": 3491961367,
+        "success": false,
+        "steps": 289,
+        "total_reward": 2.4249999999999847,
+        "termination_reason": "starved",
+        "foods_collected": 5,
+        "distance_efficiency": 0.5166777237210674
+      },
+      {
+        "run": 162,
+        "seed": 3491961368,
+        "success": true,
+        "steps": 198,
+        "total_reward": 27.520000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4288502470081418
+      },
+      {
+        "run": 163,
+        "seed": 3491961369,
+        "success": true,
+        "steps": 177,
+        "total_reward": 27.16500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5133086883876358
+      },
+      {
+        "run": 164,
+        "seed": 3491961370,
+        "success": false,
+        "steps": 49,
+        "total_reward": 0.3550000000000022,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.6016666666666667
+      },
+      {
+        "run": 165,
+        "seed": 3491961371,
+        "success": true,
+        "steps": 192,
+        "total_reward": 40.130000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5006440139331512
+      },
+      {
+        "run": 166,
+        "seed": 3491961372,
+        "success": false,
+        "steps": 173,
+        "total_reward": 22.795000000000044,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.5662687675432774
+      },
+      {
+        "run": 167,
+        "seed": 3491961373,
+        "success": true,
+        "steps": 168,
+        "total_reward": 29.70000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5669857455671246
+      },
+      {
+        "run": 168,
+        "seed": 3491961374,
+        "success": true,
+        "steps": 142,
+        "total_reward": 35.14000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5249240525556316
+      },
+      {
+        "run": 169,
+        "seed": 3491961375,
+        "success": true,
+        "steps": 214,
+        "total_reward": 39.410000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4598828405636916
+      },
+      {
+        "run": 170,
+        "seed": 3491961376,
+        "success": true,
+        "steps": 153,
+        "total_reward": 35.11500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5221895698078562
+      },
+      {
+        "run": 171,
+        "seed": 3491961377,
+        "success": true,
+        "steps": 151,
+        "total_reward": 35.41500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5954876110479559
+      },
+      {
+        "run": 172,
+        "seed": 3491961378,
+        "success": true,
+        "steps": 137,
+        "total_reward": 30.495000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5496893972900165
+      },
+      {
+        "run": 173,
+        "seed": 3491961379,
+        "success": true,
+        "steps": 284,
+        "total_reward": 39.61000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46208076569153683
+      },
+      {
+        "run": 174,
+        "seed": 3491961380,
+        "success": true,
+        "steps": 200,
+        "total_reward": 37.960000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4315743593757631
+      },
+      {
+        "run": 175,
+        "seed": 3491961381,
+        "success": true,
+        "steps": 176,
+        "total_reward": 35.480000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4720915223978633
+      },
+      {
+        "run": 176,
+        "seed": 3491961382,
+        "success": true,
+        "steps": 164,
+        "total_reward": 33.630000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5631963431305537
+      },
+      {
+        "run": 177,
+        "seed": 3491961383,
+        "success": false,
+        "steps": 100,
+        "total_reward": 17.710000000000022,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.6788969861660079
+      },
+      {
+        "run": 178,
+        "seed": 3491961384,
+        "success": true,
+        "steps": 168,
+        "total_reward": 29.770000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46558269628921806
+      },
+      {
+        "run": 179,
+        "seed": 3491961385,
+        "success": true,
+        "steps": 178,
+        "total_reward": 35.210000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4927346055479048
+      },
+      {
+        "run": 180,
+        "seed": 3491961386,
+        "success": true,
+        "steps": 398,
+        "total_reward": 32.47000000000024,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3736114264911733
+      },
+      {
+        "run": 181,
+        "seed": 3491961387,
+        "success": true,
+        "steps": 179,
+        "total_reward": 32.655000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42107287449392716
+      },
+      {
+        "run": 182,
+        "seed": 3491961388,
+        "success": true,
+        "steps": 208,
+        "total_reward": 35.9900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4459214315096668
+      },
+      {
+        "run": 183,
+        "seed": 3491961389,
+        "success": true,
+        "steps": 208,
+        "total_reward": 41.03000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47393382457800437
+      },
+      {
+        "run": 184,
+        "seed": 3491961390,
+        "success": false,
+        "steps": 61,
+        "total_reward": -4.494999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3857142857142857
+      },
+      {
+        "run": 185,
+        "seed": 3491961391,
+        "success": true,
+        "steps": 139,
+        "total_reward": 37.13500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.568467234519866
+      },
+      {
+        "run": 186,
+        "seed": 3491961392,
+        "success": true,
+        "steps": 210,
+        "total_reward": 35.00000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4365482543008675
+      },
+      {
+        "run": 187,
+        "seed": 3491961393,
+        "success": true,
+        "steps": 192,
+        "total_reward": 35.80000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5136923708475433
+      },
+      {
+        "run": 188,
+        "seed": 3491961394,
+        "success": true,
+        "steps": 128,
+        "total_reward": 23.410000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5358585858585859
+      },
+      {
+        "run": 189,
+        "seed": 3491961395,
+        "success": true,
+        "steps": 196,
+        "total_reward": 32.6200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45629483543276644
+      },
+      {
+        "run": 190,
+        "seed": 3491961396,
+        "success": true,
+        "steps": 187,
+        "total_reward": 34.615000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47900814077632886
+      },
+      {
+        "run": 191,
+        "seed": 3491961397,
+        "success": true,
+        "steps": 121,
+        "total_reward": 31.86500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6179383116883117
+      },
+      {
+        "run": 192,
+        "seed": 3491961398,
+        "success": true,
+        "steps": 145,
+        "total_reward": 33.72500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5915758397376044
+      },
+      {
+        "run": 193,
+        "seed": 3491961399,
+        "success": true,
+        "steps": 182,
+        "total_reward": 37.61000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5288654776476074
+      },
+      {
+        "run": 194,
+        "seed": 3491961400,
+        "success": true,
+        "steps": 274,
+        "total_reward": 30.26000000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47569318651848674
+      },
+      {
+        "run": 195,
+        "seed": 3491961401,
+        "success": false,
+        "steps": 157,
+        "total_reward": 16.765000000000008,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.4727995962370962
+      },
+      {
+        "run": 196,
+        "seed": 3491961402,
+        "success": true,
+        "steps": 187,
+        "total_reward": 34.61500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4988188893179819
+      },
+      {
+        "run": 197,
+        "seed": 3491961403,
+        "success": true,
+        "steps": 192,
+        "total_reward": 31.660000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4381530407045281
+      },
+      {
+        "run": 198,
+        "seed": 3491961404,
+        "success": true,
+        "steps": 169,
+        "total_reward": 37.80500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5463861302096596
+      },
+      {
+        "run": 199,
+        "seed": 3491961405,
+        "success": true,
+        "steps": 204,
+        "total_reward": 42.69000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5167780051926394
+      },
+      {
+        "run": 200,
+        "seed": 3491961406,
+        "success": true,
+        "steps": 130,
+        "total_reward": 30.92000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5806833036244801
+      }
+    ],
+    "avg_chemotaxis_index": 0.31960095597464133,
+    "avg_time_in_attractant": 0.6598004779873208,
+    "avg_approach_frequency": 0.4101416358544671,
+    "avg_path_efficiency": 0.03592097585739065,
+    "post_convergence_chemotaxis_index": 0.324413831371088,
+    "post_convergence_time_in_attractant": 0.662206915685544,
+    "post_convergence_approach_frequency": 0.41577787908035163,
+    "post_convergence_path_efficiency": 0.036484941915164035,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_100745.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_100745.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_100745",
+  "timestamp": "2025-12-29T10:17:23.865627+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_100745",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.78,
+    "avg_steps": 208.045,
+    "avg_reward": 26.847775000000073,
+    "avg_foods_collected": 8.78,
+    "avg_distance_efficiency": 0.4100127805536297,
+    "completed_all_food": 156,
+    "starved": 8,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 36,
+    "avg_predator_encounters": 7.43,
+    "avg_successful_evasions": 6.995,
+    "converged": true,
+    "convergence_run": 32,
+    "runs_to_convergence": 31,
+    "post_convergence_success_rate": 0.8698224852071006,
+    "post_convergence_avg_steps": 213.10884353741497,
+    "post_convergence_avg_foods": 9.455621301775148,
+    "post_convergence_variance": 0.11323132943524387,
+    "post_convergence_distance_efficiency": 0.44792411712294306,
+    "composite_benchmark_score": 0.6946905645021013,
+    "learning_speed": 0.85,
+    "learning_speed_episodes": 30,
+    "stability": 0.6131410283506685,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 2040640726,
+        "success": false,
+        "steps": 292,
+        "total_reward": 2.619999999999912,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3625532023345312
+      },
+      {
+        "run": 2,
+        "seed": 2040640727,
+        "success": false,
+        "steps": 38,
+        "total_reward": -8.290000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.25
+      },
+      {
+        "run": 3,
+        "seed": 2040640728,
+        "success": false,
+        "steps": 200,
+        "total_reward": -14.859999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 2040640729,
+        "success": false,
+        "steps": 240,
+        "total_reward": -13.600000000000028,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.0425531914893617
+      },
+      {
+        "run": 5,
+        "seed": 2040640730,
+        "success": false,
+        "steps": 240,
+        "total_reward": -11.099999999999993,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.055944055944055944
+      },
+      {
+        "run": 6,
+        "seed": 2040640731,
+        "success": false,
+        "steps": 280,
+        "total_reward": -12.379999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.08216594827586207
+      },
+      {
+        "run": 7,
+        "seed": 2040640732,
+        "success": false,
+        "steps": 61,
+        "total_reward": -11.415,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 8,
+        "seed": 2040640733,
+        "success": false,
+        "steps": 176,
+        "total_reward": -11.529999999999996,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 9,
+        "seed": 2040640734,
+        "success": false,
+        "steps": 34,
+        "total_reward": -11.23,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 10,
+        "seed": 2040640735,
+        "success": false,
+        "steps": 34,
+        "total_reward": -11.0,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 11,
+        "seed": 2040640736,
+        "success": false,
+        "steps": 197,
+        "total_reward": -8.564999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.08908091123330714
+      },
+      {
+        "run": 12,
+        "seed": 2040640737,
+        "success": false,
+        "steps": 159,
+        "total_reward": -0.24500000000000455,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.24673202614379083
+      },
+      {
+        "run": 13,
+        "seed": 2040640738,
+        "success": false,
+        "steps": 266,
+        "total_reward": 3.329999999999936,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.2902935041992793
+      },
+      {
+        "run": 14,
+        "seed": 2040640739,
+        "success": false,
+        "steps": 470,
+        "total_reward": 9.870000000000037,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.16214058908827667
+      },
+      {
+        "run": 15,
+        "seed": 2040640740,
+        "success": true,
+        "steps": 416,
+        "total_reward": 39.73999999999995,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3608368637590623
+      },
+      {
+        "run": 16,
+        "seed": 2040640741,
+        "success": false,
+        "steps": 262,
+        "total_reward": 13.499999999999986,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.21523613483408516
+      },
+      {
+        "run": 17,
+        "seed": 2040640742,
+        "success": false,
+        "steps": 461,
+        "total_reward": 16.06500000000026,
+        "termination_reason": "starved",
+        "foods_collected": 9,
+        "distance_efficiency": 0.30531358381933094
+      },
+      {
+        "run": 18,
+        "seed": 2040640743,
+        "success": false,
+        "steps": 172,
+        "total_reward": 3.0199999999999854,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.21904596904596904
+      },
+      {
+        "run": 19,
+        "seed": 2040640744,
+        "success": false,
+        "steps": 440,
+        "total_reward": 14.390000000000033,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.1964638292013813
+      },
+      {
+        "run": 20,
+        "seed": 2040640745,
+        "success": false,
+        "steps": 223,
+        "total_reward": 1.455,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.29432677418793607
+      },
+      {
+        "run": 21,
+        "seed": 2040640746,
+        "success": false,
+        "steps": 120,
+        "total_reward": 6.029999999999983,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.31783625730994153
+      },
+      {
+        "run": 22,
+        "seed": 2040640747,
+        "success": true,
+        "steps": 241,
+        "total_reward": 21.415000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2772918532924927
+      },
+      {
+        "run": 23,
+        "seed": 2040640748,
+        "success": true,
+        "steps": 351,
+        "total_reward": 31.475000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31598430803560884
+      },
+      {
+        "run": 24,
+        "seed": 2040640749,
+        "success": true,
+        "steps": 252,
+        "total_reward": 23.30000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2853717278145196
+      },
+      {
+        "run": 25,
+        "seed": 2040640750,
+        "success": true,
+        "steps": 336,
+        "total_reward": 34.13000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3043584664703276
+      },
+      {
+        "run": 26,
+        "seed": 2040640751,
+        "success": true,
+        "steps": 287,
+        "total_reward": 28.485000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2986513495030119
+      },
+      {
+        "run": 27,
+        "seed": 2040640752,
+        "success": true,
+        "steps": 199,
+        "total_reward": 34.33500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44244567552617087
+      },
+      {
+        "run": 28,
+        "seed": 2040640753,
+        "success": false,
+        "steps": 108,
+        "total_reward": 10.990000000000013,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.46661908962792814
+      },
+      {
+        "run": 29,
+        "seed": 2040640754,
+        "success": true,
+        "steps": 210,
+        "total_reward": 39.040000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.499220073404856
+      },
+      {
+        "run": 30,
+        "seed": 2040640755,
+        "success": true,
+        "steps": 203,
+        "total_reward": 36.05500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5234292691435549
+      },
+      {
+        "run": 31,
+        "seed": 2040640756,
+        "success": false,
+        "steps": 84,
+        "total_reward": -5.199999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.2951351351351351
+      },
+      {
+        "run": 32,
+        "seed": 2040640757,
+        "success": true,
+        "steps": 286,
+        "total_reward": 37.3700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3828372783767843
+      },
+      {
+        "run": 33,
+        "seed": 2040640758,
+        "success": true,
+        "steps": 273,
+        "total_reward": 46.98500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3494277759040275
+      },
+      {
+        "run": 34,
+        "seed": 2040640759,
+        "success": true,
+        "steps": 206,
+        "total_reward": 34.82000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45884199134199133
+      },
+      {
+        "run": 35,
+        "seed": 2040640760,
+        "success": true,
+        "steps": 250,
+        "total_reward": 36.21000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41644700930304646
+      },
+      {
+        "run": 36,
+        "seed": 2040640761,
+        "success": true,
+        "steps": 250,
+        "total_reward": 24.290000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45450611573645805
+      },
+      {
+        "run": 37,
+        "seed": 2040640762,
+        "success": true,
+        "steps": 193,
+        "total_reward": 41.05500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43871106963212225
+      },
+      {
+        "run": 38,
+        "seed": 2040640763,
+        "success": true,
+        "steps": 258,
+        "total_reward": 41.28000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41763581521314785
+      },
+      {
+        "run": 39,
+        "seed": 2040640764,
+        "success": true,
+        "steps": 248,
+        "total_reward": 33.040000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5085750360750361
+      },
+      {
+        "run": 40,
+        "seed": 2040640765,
+        "success": true,
+        "steps": 187,
+        "total_reward": 35.85500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4472737716286104
+      },
+      {
+        "run": 41,
+        "seed": 2040640766,
+        "success": true,
+        "steps": 176,
+        "total_reward": 30.720000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5094701213818861
+      },
+      {
+        "run": 42,
+        "seed": 2040640767,
+        "success": true,
+        "steps": 201,
+        "total_reward": 32.335000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4678867243867244
+      },
+      {
+        "run": 43,
+        "seed": 2040640768,
+        "success": true,
+        "steps": 287,
+        "total_reward": 29.84500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3077235083756823
+      },
+      {
+        "run": 44,
+        "seed": 2040640769,
+        "success": true,
+        "steps": 299,
+        "total_reward": 24.335000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38274905012147525
+      },
+      {
+        "run": 45,
+        "seed": 2040640770,
+        "success": true,
+        "steps": 232,
+        "total_reward": 28.060000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4222895704400731
+      },
+      {
+        "run": 46,
+        "seed": 2040640771,
+        "success": true,
+        "steps": 222,
+        "total_reward": 34.120000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44690257454963334
+      },
+      {
+        "run": 47,
+        "seed": 2040640772,
+        "success": true,
+        "steps": 248,
+        "total_reward": 25.520000000000028,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4642954608744082
+      },
+      {
+        "run": 48,
+        "seed": 2040640773,
+        "success": true,
+        "steps": 325,
+        "total_reward": 27.395000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28661061356482476
+      },
+      {
+        "run": 49,
+        "seed": 2040640774,
+        "success": true,
+        "steps": 261,
+        "total_reward": 37.96500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3931155160628845
+      },
+      {
+        "run": 50,
+        "seed": 2040640775,
+        "success": true,
+        "steps": 196,
+        "total_reward": 34.040000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5506837476574319
+      },
+      {
+        "run": 51,
+        "seed": 2040640776,
+        "success": false,
+        "steps": 218,
+        "total_reward": 11.560000000000137,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.38736658456486045
+      },
+      {
+        "run": 52,
+        "seed": 2040640777,
+        "success": true,
+        "steps": 240,
+        "total_reward": 35.310000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36173998447933364
+      },
+      {
+        "run": 53,
+        "seed": 2040640778,
+        "success": false,
+        "steps": 176,
+        "total_reward": 17.20000000000005,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.38189202953908835
+      },
+      {
+        "run": 54,
+        "seed": 2040640779,
+        "success": true,
+        "steps": 155,
+        "total_reward": 31.955000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5550924075924076
+      },
+      {
+        "run": 55,
+        "seed": 2040640780,
+        "success": true,
+        "steps": 204,
+        "total_reward": 19.99999999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36791808552051963
+      },
+      {
+        "run": 56,
+        "seed": 2040640781,
+        "success": true,
+        "steps": 234,
+        "total_reward": 27.67000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35716865554881355
+      },
+      {
+        "run": 57,
+        "seed": 2040640782,
+        "success": true,
+        "steps": 232,
+        "total_reward": 47.93000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49324288786193077
+      },
+      {
+        "run": 58,
+        "seed": 2040640783,
+        "success": true,
+        "steps": 242,
+        "total_reward": 33.65000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4229440951793011
+      },
+      {
+        "run": 59,
+        "seed": 2040640784,
+        "success": true,
+        "steps": 211,
+        "total_reward": 39.075000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4221224240245979
+      },
+      {
+        "run": 60,
+        "seed": 2040640785,
+        "success": true,
+        "steps": 205,
+        "total_reward": 32.96500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44142857142857145
+      },
+      {
+        "run": 61,
+        "seed": 2040640786,
+        "success": false,
+        "steps": 176,
+        "total_reward": 20.130000000000052,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4349825437421345
+      },
+      {
+        "run": 62,
+        "seed": 2040640787,
+        "success": true,
+        "steps": 227,
+        "total_reward": 29.555000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36338573463573465
+      },
+      {
+        "run": 63,
+        "seed": 2040640788,
+        "success": true,
+        "steps": 174,
+        "total_reward": 44.820000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5468478646110225
+      },
+      {
+        "run": 64,
+        "seed": 2040640789,
+        "success": true,
+        "steps": 188,
+        "total_reward": 26.670000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4690963203463204
+      },
+      {
+        "run": 65,
+        "seed": 2040640790,
+        "success": true,
+        "steps": 216,
+        "total_reward": 39.4000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4634770930823563
+      },
+      {
+        "run": 66,
+        "seed": 2040640791,
+        "success": true,
+        "steps": 198,
+        "total_reward": 38.68000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4476176142697882
+      },
+      {
+        "run": 67,
+        "seed": 2040640792,
+        "success": true,
+        "steps": 208,
+        "total_reward": 34.220000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4260572299817583
+      },
+      {
+        "run": 68,
+        "seed": 2040640793,
+        "success": true,
+        "steps": 280,
+        "total_reward": 34.39000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3168668420983727
+      },
+      {
+        "run": 69,
+        "seed": 2040640794,
+        "success": true,
+        "steps": 188,
+        "total_reward": 31.570000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47759009781068607
+      },
+      {
+        "run": 70,
+        "seed": 2040640795,
+        "success": true,
+        "steps": 219,
+        "total_reward": 42.7150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4853332365832366
+      },
+      {
+        "run": 71,
+        "seed": 2040640796,
+        "success": true,
+        "steps": 188,
+        "total_reward": 24.41000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3930056517556518
+      },
+      {
+        "run": 72,
+        "seed": 2040640797,
+        "success": false,
+        "steps": 111,
+        "total_reward": -1.4449999999999985,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.40432900432900426
+      },
+      {
+        "run": 73,
+        "seed": 2040640798,
+        "success": true,
+        "steps": 222,
+        "total_reward": 34.00000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43091813758996417
+      },
+      {
+        "run": 74,
+        "seed": 2040640799,
+        "success": false,
+        "steps": 112,
+        "total_reward": 2.8599999999999923,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.20516795865633075
+      },
+      {
+        "run": 75,
+        "seed": 2040640800,
+        "success": true,
+        "steps": 223,
+        "total_reward": 31.96500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41888600138600135
+      },
+      {
+        "run": 76,
+        "seed": 2040640801,
+        "success": true,
+        "steps": 182,
+        "total_reward": 26.960000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45694264069264073
+      },
+      {
+        "run": 77,
+        "seed": 2040640802,
+        "success": true,
+        "steps": 182,
+        "total_reward": 40.060000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48776153078384316
+      },
+      {
+        "run": 78,
+        "seed": 2040640803,
+        "success": true,
+        "steps": 206,
+        "total_reward": 43.48000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5590631808278868
+      },
+      {
+        "run": 79,
+        "seed": 2040640804,
+        "success": true,
+        "steps": 218,
+        "total_reward": 31.500000000000078,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4998921546289967
+      },
+      {
+        "run": 80,
+        "seed": 2040640805,
+        "success": true,
+        "steps": 182,
+        "total_reward": 34.65000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4680862444708834
+      },
+      {
+        "run": 81,
+        "seed": 2040640806,
+        "success": true,
+        "steps": 165,
+        "total_reward": 27.355000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.500508162861104
+      },
+      {
+        "run": 82,
+        "seed": 2040640807,
+        "success": true,
+        "steps": 151,
+        "total_reward": 27.21500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4570986260116695
+      },
+      {
+        "run": 83,
+        "seed": 2040640808,
+        "success": true,
+        "steps": 202,
+        "total_reward": 43.83000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5070628652277589
+      },
+      {
+        "run": 84,
+        "seed": 2040640809,
+        "success": true,
+        "steps": 163,
+        "total_reward": 38.36500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5193759018759019
+      },
+      {
+        "run": 85,
+        "seed": 2040640810,
+        "success": true,
+        "steps": 174,
+        "total_reward": 38.310000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5346846463986052
+      },
+      {
+        "run": 86,
+        "seed": 2040640811,
+        "success": true,
+        "steps": 186,
+        "total_reward": 31.120000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49790309106098574
+      },
+      {
+        "run": 87,
+        "seed": 2040640812,
+        "success": true,
+        "steps": 191,
+        "total_reward": 35.80500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46737898004027034
+      },
+      {
+        "run": 88,
+        "seed": 2040640813,
+        "success": false,
+        "steps": 262,
+        "total_reward": 19.600000000000012,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3830472125854795
+      },
+      {
+        "run": 89,
+        "seed": 2040640814,
+        "success": false,
+        "steps": 147,
+        "total_reward": 20.96500000000006,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.5490708637767461
+      },
+      {
+        "run": 90,
+        "seed": 2040640815,
+        "success": true,
+        "steps": 270,
+        "total_reward": 34.77000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38782417850181006
+      },
+      {
+        "run": 91,
+        "seed": 2040640816,
+        "success": true,
+        "steps": 255,
+        "total_reward": 32.44500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36834509332464443
+      },
+      {
+        "run": 92,
+        "seed": 2040640817,
+        "success": true,
+        "steps": 187,
+        "total_reward": 30.665000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47111165923859416
+      },
+      {
+        "run": 93,
+        "seed": 2040640818,
+        "success": true,
+        "steps": 200,
+        "total_reward": 36.69000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4366446257104837
+      },
+      {
+        "run": 94,
+        "seed": 2040640819,
+        "success": true,
+        "steps": 134,
+        "total_reward": 25.530000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5525776397515527
+      },
+      {
+        "run": 95,
+        "seed": 2040640820,
+        "success": true,
+        "steps": 339,
+        "total_reward": 31.305000000000366,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41115245593186767
+      },
+      {
+        "run": 96,
+        "seed": 2040640821,
+        "success": true,
+        "steps": 225,
+        "total_reward": 28.915000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36829486698958214
+      },
+      {
+        "run": 97,
+        "seed": 2040640822,
+        "success": false,
+        "steps": 13,
+        "total_reward": -6.765,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 98,
+        "seed": 2040640823,
+        "success": true,
+        "steps": 192,
+        "total_reward": 43.040000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4636726442420344
+      },
+      {
+        "run": 99,
+        "seed": 2040640824,
+        "success": true,
+        "steps": 209,
+        "total_reward": 31.40500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4619065336213012
+      },
+      {
+        "run": 100,
+        "seed": 2040640825,
+        "success": true,
+        "steps": 193,
+        "total_reward": 26.92500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.441244698489617
+      },
+      {
+        "run": 101,
+        "seed": 2040640826,
+        "success": true,
+        "steps": 231,
+        "total_reward": 40.915000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4072710325403464
+      },
+      {
+        "run": 102,
+        "seed": 2040640827,
+        "success": true,
+        "steps": 238,
+        "total_reward": 31.84000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4593587234973621
+      },
+      {
+        "run": 103,
+        "seed": 2040640828,
+        "success": false,
+        "steps": 69,
+        "total_reward": -1.6950000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.49603174603174605
+      },
+      {
+        "run": 104,
+        "seed": 2040640829,
+        "success": true,
+        "steps": 129,
+        "total_reward": 20.515000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48531746031746026
+      },
+      {
+        "run": 105,
+        "seed": 2040640830,
+        "success": true,
+        "steps": 285,
+        "total_reward": 43.05500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40374037774260263
+      },
+      {
+        "run": 106,
+        "seed": 2040640831,
+        "success": true,
+        "steps": 371,
+        "total_reward": 32.07500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48870004014364915
+      },
+      {
+        "run": 107,
+        "seed": 2040640832,
+        "success": false,
+        "steps": 186,
+        "total_reward": 22.47000000000007,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.38788731072139
+      },
+      {
+        "run": 108,
+        "seed": 2040640833,
+        "success": true,
+        "steps": 186,
+        "total_reward": 37.2200000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5205657539710644
+      },
+      {
+        "run": 109,
+        "seed": 2040640834,
+        "success": true,
+        "steps": 188,
+        "total_reward": 30.64000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42825994054254923
+      },
+      {
+        "run": 110,
+        "seed": 2040640835,
+        "success": true,
+        "steps": 162,
+        "total_reward": 30.560000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5224864158829676
+      },
+      {
+        "run": 111,
+        "seed": 2040640836,
+        "success": true,
+        "steps": 197,
+        "total_reward": 35.8750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4884458649158393
+      },
+      {
+        "run": 112,
+        "seed": 2040640837,
+        "success": true,
+        "steps": 191,
+        "total_reward": 32.20500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4948584229390681
+      },
+      {
+        "run": 113,
+        "seed": 2040640838,
+        "success": true,
+        "steps": 198,
+        "total_reward": 30.88000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3945010379969661
+      },
+      {
+        "run": 114,
+        "seed": 2040640839,
+        "success": true,
+        "steps": 240,
+        "total_reward": 38.25000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4845632306501872
+      },
+      {
+        "run": 115,
+        "seed": 2040640840,
+        "success": true,
+        "steps": 264,
+        "total_reward": 38.49000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44314683832990465
+      },
+      {
+        "run": 116,
+        "seed": 2040640841,
+        "success": true,
+        "steps": 187,
+        "total_reward": 38.04500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43647167679601057
+      },
+      {
+        "run": 117,
+        "seed": 2040640842,
+        "success": true,
+        "steps": 254,
+        "total_reward": 34.92000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39449975602666465
+      },
+      {
+        "run": 118,
+        "seed": 2040640843,
+        "success": true,
+        "steps": 168,
+        "total_reward": 36.0100000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5232240656946539
+      },
+      {
+        "run": 119,
+        "seed": 2040640844,
+        "success": true,
+        "steps": 219,
+        "total_reward": 35.695000000000164,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42728014932426694
+      },
+      {
+        "run": 120,
+        "seed": 2040640845,
+        "success": true,
+        "steps": 194,
+        "total_reward": 33.86000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45307075207303404
+      },
+      {
+        "run": 121,
+        "seed": 2040640846,
+        "success": true,
+        "steps": 201,
+        "total_reward": 26.805000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39630351130351127
+      },
+      {
+        "run": 122,
+        "seed": 2040640847,
+        "success": true,
+        "steps": 206,
+        "total_reward": 42.83000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5076743651085757
+      },
+      {
+        "run": 123,
+        "seed": 2040640848,
+        "success": true,
+        "steps": 170,
+        "total_reward": 32.240000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5758182957393483
+      },
+      {
+        "run": 124,
+        "seed": 2040640849,
+        "success": true,
+        "steps": 187,
+        "total_reward": 32.0550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4216992537754026
+      },
+      {
+        "run": 125,
+        "seed": 2040640850,
+        "success": true,
+        "steps": 203,
+        "total_reward": 25.835000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4081950430252637
+      },
+      {
+        "run": 126,
+        "seed": 2040640851,
+        "success": true,
+        "steps": 200,
+        "total_reward": 30.400000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43162534325577806
+      },
+      {
+        "run": 127,
+        "seed": 2040640852,
+        "success": true,
+        "steps": 232,
+        "total_reward": 30.510000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42152216748768473
+      },
+      {
+        "run": 128,
+        "seed": 2040640853,
+        "success": true,
+        "steps": 169,
+        "total_reward": 37.96500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48053065670712736
+      },
+      {
+        "run": 129,
+        "seed": 2040640854,
+        "success": true,
+        "steps": 208,
+        "total_reward": 38.0300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5083697566801015
+      },
+      {
+        "run": 130,
+        "seed": 2040640855,
+        "success": true,
+        "steps": 227,
+        "total_reward": 33.785000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38514665159402
+      },
+      {
+        "run": 131,
+        "seed": 2040640856,
+        "success": true,
+        "steps": 190,
+        "total_reward": 39.07000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47690580618212197
+      },
+      {
+        "run": 132,
+        "seed": 2040640857,
+        "success": true,
+        "steps": 158,
+        "total_reward": 26.16000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4635298146985454
+      },
+      {
+        "run": 133,
+        "seed": 2040640858,
+        "success": true,
+        "steps": 177,
+        "total_reward": 28.28500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48743223443223443
+      },
+      {
+        "run": 134,
+        "seed": 2040640859,
+        "success": false,
+        "steps": 82,
+        "total_reward": 3.2200000000000077,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4805194805194805
+      },
+      {
+        "run": 135,
+        "seed": 2040640860,
+        "success": true,
+        "steps": 222,
+        "total_reward": 43.70000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48095036759930376
+      },
+      {
+        "run": 136,
+        "seed": 2040640861,
+        "success": true,
+        "steps": 175,
+        "total_reward": 34.48500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5749781619346837
+      },
+      {
+        "run": 137,
+        "seed": 2040640862,
+        "success": true,
+        "steps": 191,
+        "total_reward": 28.765000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4283473836105415
+      },
+      {
+        "run": 138,
+        "seed": 2040640863,
+        "success": true,
+        "steps": 234,
+        "total_reward": 30.010000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38742748155515455
+      },
+      {
+        "run": 139,
+        "seed": 2040640864,
+        "success": true,
+        "steps": 166,
+        "total_reward": 29.200000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4660464958930432
+      },
+      {
+        "run": 140,
+        "seed": 2040640865,
+        "success": false,
+        "steps": 145,
+        "total_reward": 8.994999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3973192785886284
+      },
+      {
+        "run": 141,
+        "seed": 2040640866,
+        "success": false,
+        "steps": 79,
+        "total_reward": 10.285000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.5993297638034479
+      },
+      {
+        "run": 142,
+        "seed": 2040640867,
+        "success": true,
+        "steps": 203,
+        "total_reward": 26.24500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40657509157509153
+      },
+      {
+        "run": 143,
+        "seed": 2040640868,
+        "success": true,
+        "steps": 177,
+        "total_reward": 28.09500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44636694400909543
+      },
+      {
+        "run": 144,
+        "seed": 2040640869,
+        "success": true,
+        "steps": 235,
+        "total_reward": 38.70500000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47017760232172223
+      },
+      {
+        "run": 145,
+        "seed": 2040640870,
+        "success": false,
+        "steps": 129,
+        "total_reward": 17.61500000000007,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.5262896825396824
+      },
+      {
+        "run": 146,
+        "seed": 2040640871,
+        "success": true,
+        "steps": 266,
+        "total_reward": 37.48000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3728864921254543
+      },
+      {
+        "run": 147,
+        "seed": 2040640872,
+        "success": false,
+        "steps": 40,
+        "total_reward": -6.93,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.2413793103448276
+      },
+      {
+        "run": 148,
+        "seed": 2040640873,
+        "success": true,
+        "steps": 160,
+        "total_reward": 33.31000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5655718954248365
+      },
+      {
+        "run": 149,
+        "seed": 2040640874,
+        "success": false,
+        "steps": 113,
+        "total_reward": 11.965000000000025,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.5379298941798941
+      },
+      {
+        "run": 150,
+        "seed": 2040640875,
+        "success": true,
+        "steps": 206,
+        "total_reward": 34.8900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4610518954729481
+      },
+      {
+        "run": 151,
+        "seed": 2040640876,
+        "success": false,
+        "steps": 160,
+        "total_reward": 16.800000000000054,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.45476436188510494
+      },
+      {
+        "run": 152,
+        "seed": 2040640877,
+        "success": true,
+        "steps": 190,
+        "total_reward": 33.7600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4854698242933537
+      },
+      {
+        "run": 153,
+        "seed": 2040640878,
+        "success": true,
+        "steps": 216,
+        "total_reward": 36.180000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43847989806143667
+      },
+      {
+        "run": 154,
+        "seed": 2040640879,
+        "success": true,
+        "steps": 213,
+        "total_reward": 31.335000000000147,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3814890297484968
+      },
+      {
+        "run": 155,
+        "seed": 2040640880,
+        "success": false,
+        "steps": 448,
+        "total_reward": 0.8399999999999572,
+        "termination_reason": "starved",
+        "foods_collected": 9,
+        "distance_efficiency": 0.2869732751989306
+      },
+      {
+        "run": 156,
+        "seed": 2040640881,
+        "success": false,
+        "steps": 159,
+        "total_reward": 16.185000000000034,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4380854106365802
+      },
+      {
+        "run": 157,
+        "seed": 2040640882,
+        "success": true,
+        "steps": 201,
+        "total_reward": 38.02500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4656959083589518
+      },
+      {
+        "run": 158,
+        "seed": 2040640883,
+        "success": true,
+        "steps": 216,
+        "total_reward": 31.260000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4323052231446061
+      },
+      {
+        "run": 159,
+        "seed": 2040640884,
+        "success": true,
+        "steps": 159,
+        "total_reward": 30.275000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5267316017316017
+      },
+      {
+        "run": 160,
+        "seed": 2040640885,
+        "success": true,
+        "steps": 182,
+        "total_reward": 36.97000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5425289270116856
+      },
+      {
+        "run": 161,
+        "seed": 2040640886,
+        "success": true,
+        "steps": 218,
+        "total_reward": 33.300000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42365574022055374
+      },
+      {
+        "run": 162,
+        "seed": 2040640887,
+        "success": true,
+        "steps": 202,
+        "total_reward": 28.520000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3871937260366053
+      },
+      {
+        "run": 163,
+        "seed": 2040640888,
+        "success": true,
+        "steps": 210,
+        "total_reward": 28.880000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.434952815438749
+      },
+      {
+        "run": 164,
+        "seed": 2040640889,
+        "success": true,
+        "steps": 230,
+        "total_reward": 29.37000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.484779082029082
+      },
+      {
+        "run": 165,
+        "seed": 2040640890,
+        "success": true,
+        "steps": 196,
+        "total_reward": 33.8300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43300026240815714
+      },
+      {
+        "run": 166,
+        "seed": 2040640891,
+        "success": true,
+        "steps": 199,
+        "total_reward": 38.76500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.439627674258109
+      },
+      {
+        "run": 167,
+        "seed": 2040640892,
+        "success": true,
+        "steps": 166,
+        "total_reward": 22.780000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4282486959057417
+      },
+      {
+        "run": 168,
+        "seed": 2040640893,
+        "success": true,
+        "steps": 211,
+        "total_reward": 39.91500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4470679394564844
+      },
+      {
+        "run": 169,
+        "seed": 2040640894,
+        "success": true,
+        "steps": 183,
+        "total_reward": 32.88500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46544442866626207
+      },
+      {
+        "run": 170,
+        "seed": 2040640895,
+        "success": false,
+        "steps": 133,
+        "total_reward": 4.485000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.427989909414058
+      },
+      {
+        "run": 171,
+        "seed": 2040640896,
+        "success": true,
+        "steps": 216,
+        "total_reward": 28.390000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3659665718442314
+      },
+      {
+        "run": 172,
+        "seed": 2040640897,
+        "success": false,
+        "steps": 89,
+        "total_reward": 6.204999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4467836257309941
+      },
+      {
+        "run": 173,
+        "seed": 2040640898,
+        "success": true,
+        "steps": 172,
+        "total_reward": 23.920000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41933873829216406
+      },
+      {
+        "run": 174,
+        "seed": 2040640899,
+        "success": true,
+        "steps": 228,
+        "total_reward": 31.500000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32332225942032805
+      },
+      {
+        "run": 175,
+        "seed": 2040640900,
+        "success": true,
+        "steps": 193,
+        "total_reward": 39.91500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47725026790102676
+      },
+      {
+        "run": 176,
+        "seed": 2040640901,
+        "success": true,
+        "steps": 196,
+        "total_reward": 37.9300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4353500382486451
+      },
+      {
+        "run": 177,
+        "seed": 2040640902,
+        "success": true,
+        "steps": 173,
+        "total_reward": 33.095000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5015827161344403
+      },
+      {
+        "run": 178,
+        "seed": 2040640903,
+        "success": true,
+        "steps": 136,
+        "total_reward": 24.320000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6040337071283363
+      },
+      {
+        "run": 179,
+        "seed": 2040640904,
+        "success": true,
+        "steps": 392,
+        "total_reward": 44.430000000000305,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4129708597199401
+      },
+      {
+        "run": 180,
+        "seed": 2040640905,
+        "success": false,
+        "steps": 183,
+        "total_reward": 28.905000000000115,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.491541858045126
+      },
+      {
+        "run": 181,
+        "seed": 2040640906,
+        "success": true,
+        "steps": 249,
+        "total_reward": 32.61500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4778414195867026
+      },
+      {
+        "run": 182,
+        "seed": 2040640907,
+        "success": true,
+        "steps": 197,
+        "total_reward": 34.79500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47840723641235156
+      },
+      {
+        "run": 183,
+        "seed": 2040640908,
+        "success": true,
+        "steps": 218,
+        "total_reward": 22.860000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3671967221552868
+      },
+      {
+        "run": 184,
+        "seed": 2040640909,
+        "success": true,
+        "steps": 134,
+        "total_reward": 24.230000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5034493284493284
+      },
+      {
+        "run": 185,
+        "seed": 2040640910,
+        "success": true,
+        "steps": 224,
+        "total_reward": 36.36000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44188079022840343
+      },
+      {
+        "run": 186,
+        "seed": 2040640911,
+        "success": true,
+        "steps": 202,
+        "total_reward": 33.60000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46205569792526313
+      },
+      {
+        "run": 187,
+        "seed": 2040640912,
+        "success": true,
+        "steps": 285,
+        "total_reward": 39.53500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4618437520467923
+      },
+      {
+        "run": 188,
+        "seed": 2040640913,
+        "success": true,
+        "steps": 193,
+        "total_reward": 30.3150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38707832068126186
+      },
+      {
+        "run": 189,
+        "seed": 2040640914,
+        "success": true,
+        "steps": 336,
+        "total_reward": 31.970000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39313055365686944
+      },
+      {
+        "run": 190,
+        "seed": 2040640915,
+        "success": true,
+        "steps": 229,
+        "total_reward": 38.98500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4637227173139151
+      },
+      {
+        "run": 191,
+        "seed": 2040640916,
+        "success": true,
+        "steps": 222,
+        "total_reward": 37.01000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45775585264283397
+      },
+      {
+        "run": 192,
+        "seed": 2040640917,
+        "success": true,
+        "steps": 228,
+        "total_reward": 38.200000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45489587940439336
+      },
+      {
+        "run": 193,
+        "seed": 2040640918,
+        "success": true,
+        "steps": 201,
+        "total_reward": 25.285000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4861052836052836
+      },
+      {
+        "run": 194,
+        "seed": 2040640919,
+        "success": true,
+        "steps": 263,
+        "total_reward": 31.02500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4216649820303071
+      },
+      {
+        "run": 195,
+        "seed": 2040640920,
+        "success": true,
+        "steps": 294,
+        "total_reward": 37.840000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3605240021007716
+      },
+      {
+        "run": 196,
+        "seed": 2040640921,
+        "success": true,
+        "steps": 215,
+        "total_reward": 21.265000000000057,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3765704493179386
+      },
+      {
+        "run": 197,
+        "seed": 2040640922,
+        "success": true,
+        "steps": 178,
+        "total_reward": 35.28000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5106697589849764
+      },
+      {
+        "run": 198,
+        "seed": 2040640923,
+        "success": true,
+        "steps": 196,
+        "total_reward": 33.53000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4566429449677531
+      },
+      {
+        "run": 199,
+        "seed": 2040640924,
+        "success": true,
+        "steps": 195,
+        "total_reward": 21.38500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4150150772345723
+      },
+      {
+        "run": 200,
+        "seed": 2040640925,
+        "success": true,
+        "steps": 247,
+        "total_reward": 34.2050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34576015487780193
+      }
+    ],
+    "avg_chemotaxis_index": 0.28455650380169545,
+    "avg_time_in_attractant": 0.6422782519008478,
+    "avg_approach_frequency": 0.39184197980229835,
+    "avg_path_efficiency": 0.05852793342924158,
+    "post_convergence_chemotaxis_index": 0.30389864175442666,
+    "post_convergence_time_in_attractant": 0.6519493208772134,
+    "post_convergence_approach_frequency": 0.398334989634519,
+    "post_convergence_path_efficiency": 0.059808260297124036,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_101742.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_101742.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_101742",
+  "timestamp": "2025-12-29T10:25:59.946622+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_101742",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.82,
+    "avg_steps": 180.325,
+    "avg_reward": 28.31887500000007,
+    "avg_foods_collected": 8.945,
+    "avg_distance_efficiency": 0.4749385289440613,
+    "completed_all_food": 164,
+    "starved": 5,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 30,
+    "avg_predator_encounters": 6.665,
+    "avg_successful_evasions": 6.235,
+    "converged": true,
+    "convergence_run": 10,
+    "runs_to_convergence": 9,
+    "post_convergence_success_rate": 0.8586387434554974,
+    "post_convergence_avg_steps": 191.66463414634146,
+    "post_convergence_avg_foods": 9.235602094240837,
+    "post_convergence_variance": 0.12137825169266196,
+    "post_convergence_distance_efficiency": 0.4924591009854043,
+    "composite_benchmark_score": 0.7215041018314892,
+    "learning_speed": 0.915,
+    "learning_speed_episodes": 17,
+    "stability": 0.5942486643996554,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3489526730,
+        "success": false,
+        "steps": 78,
+        "total_reward": -10.33,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.10294117647058823
+      },
+      {
+        "run": 2,
+        "seed": 3489526731,
+        "success": false,
+        "steps": 200,
+        "total_reward": -15.020000000000003,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 3489526732,
+        "success": false,
+        "steps": 101,
+        "total_reward": -10.974999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.12656641604010024
+      },
+      {
+        "run": 4,
+        "seed": 3489526733,
+        "success": false,
+        "steps": 280,
+        "total_reward": -4.009999999999991,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.10639386189258312
+      },
+      {
+        "run": 5,
+        "seed": 3489526734,
+        "success": false,
+        "steps": 200,
+        "total_reward": -16.240000000000006,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 6,
+        "seed": 3489526735,
+        "success": false,
+        "steps": 240,
+        "total_reward": -6.339999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.031914893617021274
+      },
+      {
+        "run": 7,
+        "seed": 3489526736,
+        "success": false,
+        "steps": 232,
+        "total_reward": -8.069999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.1932207177742892
+      },
+      {
+        "run": 8,
+        "seed": 3489526737,
+        "success": false,
+        "steps": 480,
+        "total_reward": 15.57000000000016,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.20815540152541562
+      },
+      {
+        "run": 9,
+        "seed": 3489526738,
+        "success": false,
+        "steps": 500,
+        "total_reward": 19.80000000000004,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.30659338053343077
+      },
+      {
+        "run": 10,
+        "seed": 3489526739,
+        "success": true,
+        "steps": 431,
+        "total_reward": 27.28500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2911633671677983
+      },
+      {
+        "run": 11,
+        "seed": 3489526740,
+        "success": true,
+        "steps": 412,
+        "total_reward": 36.14000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25922988224282795
+      },
+      {
+        "run": 12,
+        "seed": 3489526741,
+        "success": true,
+        "steps": 343,
+        "total_reward": 28.74500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32789871895135053
+      },
+      {
+        "run": 13,
+        "seed": 3489526742,
+        "success": true,
+        "steps": 236,
+        "total_reward": 35.25000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4565438097038615
+      },
+      {
+        "run": 14,
+        "seed": 3489526743,
+        "success": true,
+        "steps": 256,
+        "total_reward": 27.580000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3947736200097763
+      },
+      {
+        "run": 15,
+        "seed": 3489526744,
+        "success": true,
+        "steps": 258,
+        "total_reward": 32.16000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36860395784996414
+      },
+      {
+        "run": 16,
+        "seed": 3489526745,
+        "success": true,
+        "steps": 343,
+        "total_reward": 25.525000000000112,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28339743589743593
+      },
+      {
+        "run": 17,
+        "seed": 3489526746,
+        "success": true,
+        "steps": 263,
+        "total_reward": 33.78500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3799164331846286
+      },
+      {
+        "run": 18,
+        "seed": 3489526747,
+        "success": true,
+        "steps": 198,
+        "total_reward": 24.820000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.419609743048362
+      },
+      {
+        "run": 19,
+        "seed": 3489526748,
+        "success": true,
+        "steps": 172,
+        "total_reward": 32.460000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5485441739278056
+      },
+      {
+        "run": 20,
+        "seed": 3489526749,
+        "success": true,
+        "steps": 218,
+        "total_reward": 32.840000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43160219120706644
+      },
+      {
+        "run": 21,
+        "seed": 3489526750,
+        "success": false,
+        "steps": 87,
+        "total_reward": 2.525000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.34613136979897147
+      },
+      {
+        "run": 22,
+        "seed": 3489526751,
+        "success": true,
+        "steps": 261,
+        "total_reward": 40.715000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3998162636477854
+      },
+      {
+        "run": 23,
+        "seed": 3489526752,
+        "success": true,
+        "steps": 228,
+        "total_reward": 38.23000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5187031556785655
+      },
+      {
+        "run": 24,
+        "seed": 3489526753,
+        "success": true,
+        "steps": 200,
+        "total_reward": 25.620000000000047,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36359585034322667
+      },
+      {
+        "run": 25,
+        "seed": 3489526754,
+        "success": true,
+        "steps": 268,
+        "total_reward": 33.360000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38137785625539566
+      },
+      {
+        "run": 26,
+        "seed": 3489526755,
+        "success": true,
+        "steps": 266,
+        "total_reward": 42.31000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39124206253516597
+      },
+      {
+        "run": 27,
+        "seed": 3489526756,
+        "success": true,
+        "steps": 201,
+        "total_reward": 37.67500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4940637645323407
+      },
+      {
+        "run": 28,
+        "seed": 3489526757,
+        "success": true,
+        "steps": 297,
+        "total_reward": 34.285000000000224,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42321713424654595
+      },
+      {
+        "run": 29,
+        "seed": 3489526758,
+        "success": true,
+        "steps": 277,
+        "total_reward": 24.80500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3786465048457977
+      },
+      {
+        "run": 30,
+        "seed": 3489526759,
+        "success": true,
+        "steps": 238,
+        "total_reward": 35.220000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5283762581847398
+      },
+      {
+        "run": 31,
+        "seed": 3489526760,
+        "success": true,
+        "steps": 161,
+        "total_reward": 33.825000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4964873211583738
+      },
+      {
+        "run": 32,
+        "seed": 3489526761,
+        "success": false,
+        "steps": 114,
+        "total_reward": 6.2599999999999945,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.5249859943977591
+      },
+      {
+        "run": 33,
+        "seed": 3489526762,
+        "success": true,
+        "steps": 179,
+        "total_reward": 36.1850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5019285392969604
+      },
+      {
+        "run": 34,
+        "seed": 3489526763,
+        "success": true,
+        "steps": 219,
+        "total_reward": 32.7150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4882564541720139
+      },
+      {
+        "run": 35,
+        "seed": 3489526764,
+        "success": true,
+        "steps": 205,
+        "total_reward": 39.4350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46885832538592487
+      },
+      {
+        "run": 36,
+        "seed": 3489526765,
+        "success": true,
+        "steps": 181,
+        "total_reward": 32.37500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5020620490620491
+      },
+      {
+        "run": 37,
+        "seed": 3489526766,
+        "success": true,
+        "steps": 158,
+        "total_reward": 37.190000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5067819004031818
+      },
+      {
+        "run": 38,
+        "seed": 3489526767,
+        "success": false,
+        "steps": 57,
+        "total_reward": 2.565000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5004960317460317
+      },
+      {
+        "run": 39,
+        "seed": 3489526768,
+        "success": false,
+        "steps": 41,
+        "total_reward": 2.695000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.6556036556036556
+      },
+      {
+        "run": 40,
+        "seed": 3489526769,
+        "success": true,
+        "steps": 162,
+        "total_reward": 28.670000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48297447650388825
+      },
+      {
+        "run": 41,
+        "seed": 3489526770,
+        "success": true,
+        "steps": 184,
+        "total_reward": 27.89000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40608695652173915
+      },
+      {
+        "run": 42,
+        "seed": 3489526771,
+        "success": true,
+        "steps": 174,
+        "total_reward": 29.830000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43563563887093293
+      },
+      {
+        "run": 43,
+        "seed": 3489526772,
+        "success": false,
+        "steps": 151,
+        "total_reward": 14.975000000000026,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5908433354085528
+      },
+      {
+        "run": 44,
+        "seed": 3489526773,
+        "success": true,
+        "steps": 166,
+        "total_reward": 31.420000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5128232495473874
+      },
+      {
+        "run": 45,
+        "seed": 3489526774,
+        "success": true,
+        "steps": 166,
+        "total_reward": 29.720000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40763867940338533
+      },
+      {
+        "run": 46,
+        "seed": 3489526775,
+        "success": false,
+        "steps": 50,
+        "total_reward": -0.6199999999999939,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.6502463054187192
+      },
+      {
+        "run": 47,
+        "seed": 3489526776,
+        "success": true,
+        "steps": 188,
+        "total_reward": 34.3900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4441038912778043
+      },
+      {
+        "run": 48,
+        "seed": 3489526777,
+        "success": true,
+        "steps": 158,
+        "total_reward": 29.880000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5181729908023012
+      },
+      {
+        "run": 49,
+        "seed": 3489526778,
+        "success": true,
+        "steps": 230,
+        "total_reward": 33.050000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3918633771031469
+      },
+      {
+        "run": 50,
+        "seed": 3489526779,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.845000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47944049517733733
+      },
+      {
+        "run": 51,
+        "seed": 3489526780,
+        "success": true,
+        "steps": 227,
+        "total_reward": 46.71500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5502669552669552
+      },
+      {
+        "run": 52,
+        "seed": 3489526781,
+        "success": true,
+        "steps": 213,
+        "total_reward": 34.5450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5004951298701299
+      },
+      {
+        "run": 53,
+        "seed": 3489526782,
+        "success": true,
+        "steps": 323,
+        "total_reward": 35.40500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5733975748421751
+      },
+      {
+        "run": 54,
+        "seed": 3489526783,
+        "success": true,
+        "steps": 186,
+        "total_reward": 34.58000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49386494457923025
+      },
+      {
+        "run": 55,
+        "seed": 3489526784,
+        "success": true,
+        "steps": 144,
+        "total_reward": 33.940000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6248337189126663
+      },
+      {
+        "run": 56,
+        "seed": 3489526785,
+        "success": true,
+        "steps": 182,
+        "total_reward": 33.44000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4330945539135194
+      },
+      {
+        "run": 57,
+        "seed": 3489526786,
+        "success": true,
+        "steps": 176,
+        "total_reward": 30.760000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4699712837079912
+      },
+      {
+        "run": 58,
+        "seed": 3489526787,
+        "success": true,
+        "steps": 201,
+        "total_reward": 35.09500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4494299595639406
+      },
+      {
+        "run": 59,
+        "seed": 3489526788,
+        "success": false,
+        "steps": 88,
+        "total_reward": 1.3599999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.5807274895646989
+      },
+      {
+        "run": 60,
+        "seed": 3489526789,
+        "success": true,
+        "steps": 203,
+        "total_reward": 46.40500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5303023404738675
+      },
+      {
+        "run": 61,
+        "seed": 3489526790,
+        "success": false,
+        "steps": 139,
+        "total_reward": 13.055000000000025,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.4714376992735933
+      },
+      {
+        "run": 62,
+        "seed": 3489526791,
+        "success": true,
+        "steps": 169,
+        "total_reward": 39.085000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.514597511565475
+      },
+      {
+        "run": 63,
+        "seed": 3489526792,
+        "success": true,
+        "steps": 129,
+        "total_reward": 28.705000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5047229404582346
+      },
+      {
+        "run": 64,
+        "seed": 3489526793,
+        "success": false,
+        "steps": 100,
+        "total_reward": 6.93,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4310741687979539
+      },
+      {
+        "run": 65,
+        "seed": 3489526794,
+        "success": false,
+        "steps": 63,
+        "total_reward": 9.634999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.7018849206349207
+      },
+      {
+        "run": 66,
+        "seed": 3489526795,
+        "success": true,
+        "steps": 193,
+        "total_reward": 29.185000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37765062823886353
+      },
+      {
+        "run": 67,
+        "seed": 3489526796,
+        "success": true,
+        "steps": 173,
+        "total_reward": 30.495000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4774783436228449
+      },
+      {
+        "run": 68,
+        "seed": 3489526797,
+        "success": true,
+        "steps": 183,
+        "total_reward": 27.115000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4440070346320346
+      },
+      {
+        "run": 69,
+        "seed": 3489526798,
+        "success": true,
+        "steps": 189,
+        "total_reward": 48.2650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5357333055960058
+      },
+      {
+        "run": 70,
+        "seed": 3489526799,
+        "success": true,
+        "steps": 192,
+        "total_reward": 32.02000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44927490096208267
+      },
+      {
+        "run": 71,
+        "seed": 3489526800,
+        "success": true,
+        "steps": 225,
+        "total_reward": 45.85500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.527878787878788
+      },
+      {
+        "run": 72,
+        "seed": 3489526801,
+        "success": true,
+        "steps": 155,
+        "total_reward": 28.665000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5464003759398496
+      },
+      {
+        "run": 73,
+        "seed": 3489526802,
+        "success": true,
+        "steps": 159,
+        "total_reward": 37.18500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49862547892720305
+      },
+      {
+        "run": 74,
+        "seed": 3489526803,
+        "success": false,
+        "steps": 150,
+        "total_reward": 17.430000000000042,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5473143730736442
+      },
+      {
+        "run": 75,
+        "seed": 3489526804,
+        "success": true,
+        "steps": 137,
+        "total_reward": 29.91500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5502272727272727
+      },
+      {
+        "run": 76,
+        "seed": 3489526805,
+        "success": true,
+        "steps": 224,
+        "total_reward": 37.6000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5919084755114167
+      },
+      {
+        "run": 77,
+        "seed": 3489526806,
+        "success": true,
+        "steps": 185,
+        "total_reward": 36.335000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46464279578884043
+      },
+      {
+        "run": 78,
+        "seed": 3489526807,
+        "success": true,
+        "steps": 159,
+        "total_reward": 27.565000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5052979906566863
+      },
+      {
+        "run": 79,
+        "seed": 3489526808,
+        "success": true,
+        "steps": 144,
+        "total_reward": 27.690000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5111638120333772
+      },
+      {
+        "run": 80,
+        "seed": 3489526809,
+        "success": false,
+        "steps": 149,
+        "total_reward": 3.954999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.3783170228893913
+      },
+      {
+        "run": 81,
+        "seed": 3489526810,
+        "success": true,
+        "steps": 185,
+        "total_reward": 33.78500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4865978294151668
+      },
+      {
+        "run": 82,
+        "seed": 3489526811,
+        "success": true,
+        "steps": 179,
+        "total_reward": 27.95500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47960526315789476
+      },
+      {
+        "run": 83,
+        "seed": 3489526812,
+        "success": true,
+        "steps": 202,
+        "total_reward": 41.180000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5421537737624693
+      },
+      {
+        "run": 84,
+        "seed": 3489526813,
+        "success": true,
+        "steps": 214,
+        "total_reward": 33.4900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4631207827260459
+      },
+      {
+        "run": 85,
+        "seed": 3489526814,
+        "success": true,
+        "steps": 220,
+        "total_reward": 36.05000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4963492063492064
+      },
+      {
+        "run": 86,
+        "seed": 3489526815,
+        "success": true,
+        "steps": 182,
+        "total_reward": 34.60000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.487560219507588
+      },
+      {
+        "run": 87,
+        "seed": 3489526816,
+        "success": true,
+        "steps": 194,
+        "total_reward": 31.11000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3584639406487232
+      },
+      {
+        "run": 88,
+        "seed": 3489526817,
+        "success": true,
+        "steps": 201,
+        "total_reward": 28.47500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4072122330713662
+      },
+      {
+        "run": 89,
+        "seed": 3489526818,
+        "success": true,
+        "steps": 152,
+        "total_reward": 31.630000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5490952870513494
+      },
+      {
+        "run": 90,
+        "seed": 3489526819,
+        "success": true,
+        "steps": 184,
+        "total_reward": 32.39000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5157866770910249
+      },
+      {
+        "run": 91,
+        "seed": 3489526820,
+        "success": true,
+        "steps": 146,
+        "total_reward": 39.690000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6338904151404152
+      },
+      {
+        "run": 92,
+        "seed": 3489526821,
+        "success": true,
+        "steps": 151,
+        "total_reward": 45.15500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6458119497249932
+      },
+      {
+        "run": 93,
+        "seed": 3489526822,
+        "success": true,
+        "steps": 172,
+        "total_reward": 37.05000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5504434731934732
+      },
+      {
+        "run": 94,
+        "seed": 3489526823,
+        "success": true,
+        "steps": 264,
+        "total_reward": 34.600000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42993418988894944
+      },
+      {
+        "run": 95,
+        "seed": 3489526824,
+        "success": true,
+        "steps": 211,
+        "total_reward": 41.91500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5983926491346689
+      },
+      {
+        "run": 96,
+        "seed": 3489526825,
+        "success": true,
+        "steps": 169,
+        "total_reward": 22.94500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4394859651477298
+      },
+      {
+        "run": 97,
+        "seed": 3489526826,
+        "success": true,
+        "steps": 167,
+        "total_reward": 37.51500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5514554073377603
+      },
+      {
+        "run": 98,
+        "seed": 3489526827,
+        "success": true,
+        "steps": 205,
+        "total_reward": 36.095000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49059752764971637
+      },
+      {
+        "run": 99,
+        "seed": 3489526828,
+        "success": false,
+        "steps": 13,
+        "total_reward": -7.115,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 100,
+        "seed": 3489526829,
+        "success": true,
+        "steps": 144,
+        "total_reward": 30.440000000000047,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5232151182151182
+      },
+      {
+        "run": 101,
+        "seed": 3489526830,
+        "success": true,
+        "steps": 128,
+        "total_reward": 36.700000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5697058823529412
+      },
+      {
+        "run": 102,
+        "seed": 3489526831,
+        "success": true,
+        "steps": 161,
+        "total_reward": 36.43500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5595252853829704
+      },
+      {
+        "run": 103,
+        "seed": 3489526832,
+        "success": true,
+        "steps": 253,
+        "total_reward": 41.90500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4915077877449011
+      },
+      {
+        "run": 104,
+        "seed": 3489526833,
+        "success": true,
+        "steps": 216,
+        "total_reward": 30.02000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48328210349591927
+      },
+      {
+        "run": 105,
+        "seed": 3489526834,
+        "success": true,
+        "steps": 154,
+        "total_reward": 35.38000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5393331668331668
+      },
+      {
+        "run": 106,
+        "seed": 3489526835,
+        "success": true,
+        "steps": 150,
+        "total_reward": 29.900000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5616530988347627
+      },
+      {
+        "run": 107,
+        "seed": 3489526836,
+        "success": true,
+        "steps": 173,
+        "total_reward": 30.035000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4801318564476459
+      },
+      {
+        "run": 108,
+        "seed": 3489526837,
+        "success": true,
+        "steps": 174,
+        "total_reward": 39.87000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5882788848988008
+      },
+      {
+        "run": 109,
+        "seed": 3489526838,
+        "success": true,
+        "steps": 165,
+        "total_reward": 31.70500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5357509303561935
+      },
+      {
+        "run": 110,
+        "seed": 3489526839,
+        "success": true,
+        "steps": 149,
+        "total_reward": 32.735000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5303653647272161
+      },
+      {
+        "run": 111,
+        "seed": 3489526840,
+        "success": true,
+        "steps": 176,
+        "total_reward": 36.8500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5547393957318263
+      },
+      {
+        "run": 112,
+        "seed": 3489526841,
+        "success": true,
+        "steps": 138,
+        "total_reward": 26.540000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5142335582038099
+      },
+      {
+        "run": 113,
+        "seed": 3489526842,
+        "success": true,
+        "steps": 162,
+        "total_reward": 32.790000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.548931623931624
+      },
+      {
+        "run": 114,
+        "seed": 3489526843,
+        "success": true,
+        "steps": 167,
+        "total_reward": 27.045000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5016917396329161
+      },
+      {
+        "run": 115,
+        "seed": 3489526844,
+        "success": true,
+        "steps": 194,
+        "total_reward": 43.62000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5161200860542966
+      },
+      {
+        "run": 116,
+        "seed": 3489526845,
+        "success": true,
+        "steps": 184,
+        "total_reward": 35.01000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5008080808080808
+      },
+      {
+        "run": 117,
+        "seed": 3489526846,
+        "success": true,
+        "steps": 151,
+        "total_reward": 34.795000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6366504410622058
+      },
+      {
+        "run": 118,
+        "seed": 3489526847,
+        "success": true,
+        "steps": 189,
+        "total_reward": 34.455000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4716723917161965
+      },
+      {
+        "run": 119,
+        "seed": 3489526848,
+        "success": true,
+        "steps": 164,
+        "total_reward": 38.8800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4916422094921081
+      },
+      {
+        "run": 120,
+        "seed": 3489526849,
+        "success": true,
+        "steps": 160,
+        "total_reward": 34.400000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.507339903818232
+      },
+      {
+        "run": 121,
+        "seed": 3489526850,
+        "success": false,
+        "steps": 88,
+        "total_reward": 9.960000000000008,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.5728132161955691
+      },
+      {
+        "run": 122,
+        "seed": 3489526851,
+        "success": false,
+        "steps": 63,
+        "total_reward": 2.3850000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5756090314913844
+      },
+      {
+        "run": 123,
+        "seed": 3489526852,
+        "success": true,
+        "steps": 223,
+        "total_reward": 45.33500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45690165154366574
+      },
+      {
+        "run": 124,
+        "seed": 3489526853,
+        "success": true,
+        "steps": 174,
+        "total_reward": 37.830000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5233075258075258
+      },
+      {
+        "run": 125,
+        "seed": 3489526854,
+        "success": true,
+        "steps": 180,
+        "total_reward": 35.08000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4987356760886173
+      },
+      {
+        "run": 126,
+        "seed": 3489526855,
+        "success": true,
+        "steps": 169,
+        "total_reward": 35.44500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5090802764486975
+      },
+      {
+        "run": 127,
+        "seed": 3489526856,
+        "success": false,
+        "steps": 64,
+        "total_reward": 7.179999999999996,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.6166666666666667
+      },
+      {
+        "run": 128,
+        "seed": 3489526857,
+        "success": true,
+        "steps": 160,
+        "total_reward": 29.300000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5469084938050456
+      },
+      {
+        "run": 129,
+        "seed": 3489526858,
+        "success": true,
+        "steps": 282,
+        "total_reward": 36.890000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41229839668340806
+      },
+      {
+        "run": 130,
+        "seed": 3489526859,
+        "success": true,
+        "steps": 165,
+        "total_reward": 37.52500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6300465506715507
+      },
+      {
+        "run": 131,
+        "seed": 3489526860,
+        "success": true,
+        "steps": 172,
+        "total_reward": 34.190000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4580293682925262
+      },
+      {
+        "run": 132,
+        "seed": 3489526861,
+        "success": false,
+        "steps": 27,
+        "total_reward": -5.535,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.5227272727272727
+      },
+      {
+        "run": 133,
+        "seed": 3489526862,
+        "success": true,
+        "steps": 161,
+        "total_reward": 34.83500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5318085700790304
+      },
+      {
+        "run": 134,
+        "seed": 3489526863,
+        "success": true,
+        "steps": 200,
+        "total_reward": 33.19000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3856989759466539
+      },
+      {
+        "run": 135,
+        "seed": 3489526864,
+        "success": true,
+        "steps": 139,
+        "total_reward": 37.955000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6338585099111416
+      },
+      {
+        "run": 136,
+        "seed": 3489526865,
+        "success": true,
+        "steps": 178,
+        "total_reward": 37.01000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47561481002657474
+      },
+      {
+        "run": 137,
+        "seed": 3489526866,
+        "success": false,
+        "steps": 87,
+        "total_reward": 2.1150000000000055,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.47615834457939726
+      },
+      {
+        "run": 138,
+        "seed": 3489526867,
+        "success": true,
+        "steps": 170,
+        "total_reward": 38.42000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5517357642357642
+      },
+      {
+        "run": 139,
+        "seed": 3489526868,
+        "success": true,
+        "steps": 164,
+        "total_reward": 41.980000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5885780657176538
+      },
+      {
+        "run": 140,
+        "seed": 3489526869,
+        "success": true,
+        "steps": 217,
+        "total_reward": 34.045000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42876314593937936
+      },
+      {
+        "run": 141,
+        "seed": 3489526870,
+        "success": true,
+        "steps": 131,
+        "total_reward": 38.5250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6350155245511282
+      },
+      {
+        "run": 142,
+        "seed": 3489526871,
+        "success": true,
+        "steps": 209,
+        "total_reward": 27.295000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4174295587453482
+      },
+      {
+        "run": 143,
+        "seed": 3489526872,
+        "success": true,
+        "steps": 207,
+        "total_reward": 37.1150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45523514181516916
+      },
+      {
+        "run": 144,
+        "seed": 3489526873,
+        "success": true,
+        "steps": 131,
+        "total_reward": 32.025000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6675152625152625
+      },
+      {
+        "run": 145,
+        "seed": 3489526874,
+        "success": true,
+        "steps": 179,
+        "total_reward": 34.12500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5216691619077019
+      },
+      {
+        "run": 146,
+        "seed": 3489526875,
+        "success": true,
+        "steps": 151,
+        "total_reward": 25.285000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4714682539682539
+      },
+      {
+        "run": 147,
+        "seed": 3489526876,
+        "success": true,
+        "steps": 166,
+        "total_reward": 40.02000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.557617794777574
+      },
+      {
+        "run": 148,
+        "seed": 3489526877,
+        "success": true,
+        "steps": 184,
+        "total_reward": 29.72000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4464087301587301
+      },
+      {
+        "run": 149,
+        "seed": 3489526878,
+        "success": true,
+        "steps": 189,
+        "total_reward": 38.4050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.561480463980464
+      },
+      {
+        "run": 150,
+        "seed": 3489526879,
+        "success": true,
+        "steps": 150,
+        "total_reward": 27.100000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5368181818181819
+      },
+      {
+        "run": 151,
+        "seed": 3489526880,
+        "success": true,
+        "steps": 201,
+        "total_reward": 26.835000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4385094431712079
+      },
+      {
+        "run": 152,
+        "seed": 3489526881,
+        "success": true,
+        "steps": 177,
+        "total_reward": 34.4650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4778027017258516
+      },
+      {
+        "run": 153,
+        "seed": 3489526882,
+        "success": true,
+        "steps": 172,
+        "total_reward": 33.790000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5237835454019664
+      },
+      {
+        "run": 154,
+        "seed": 3489526883,
+        "success": false,
+        "steps": 107,
+        "total_reward": 5.974999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.5047619047619047
+      },
+      {
+        "run": 155,
+        "seed": 3489526884,
+        "success": true,
+        "steps": 211,
+        "total_reward": 35.06500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42856410256410254
+      },
+      {
+        "run": 156,
+        "seed": 3489526885,
+        "success": true,
+        "steps": 151,
+        "total_reward": 29.275000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.59745670995671
+      },
+      {
+        "run": 157,
+        "seed": 3489526886,
+        "success": true,
+        "steps": 202,
+        "total_reward": 32.73000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5175324675324675
+      },
+      {
+        "run": 158,
+        "seed": 3489526887,
+        "success": true,
+        "steps": 209,
+        "total_reward": 34.32500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43134565496237603
+      },
+      {
+        "run": 159,
+        "seed": 3489526888,
+        "success": false,
+        "steps": 30,
+        "total_reward": -3.0499999999999954,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.6862745098039216
+      },
+      {
+        "run": 160,
+        "seed": 3489526889,
+        "success": true,
+        "steps": 166,
+        "total_reward": 30.180000000000103,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4369453071083506
+      },
+      {
+        "run": 161,
+        "seed": 3489526890,
+        "success": true,
+        "steps": 164,
+        "total_reward": 29.360000000000024,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5187931839402428
+      },
+      {
+        "run": 162,
+        "seed": 3489526891,
+        "success": true,
+        "steps": 160,
+        "total_reward": 38.930000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5541540102409668
+      },
+      {
+        "run": 163,
+        "seed": 3489526892,
+        "success": true,
+        "steps": 187,
+        "total_reward": 39.15500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5001718920267307
+      },
+      {
+        "run": 164,
+        "seed": 3489526893,
+        "success": true,
+        "steps": 160,
+        "total_reward": 34.88000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.525158317173023
+      },
+      {
+        "run": 165,
+        "seed": 3489526894,
+        "success": true,
+        "steps": 194,
+        "total_reward": 35.000000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46264886524611926
+      },
+      {
+        "run": 166,
+        "seed": 3489526895,
+        "success": true,
+        "steps": 170,
+        "total_reward": 38.050000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.559723544973545
+      },
+      {
+        "run": 167,
+        "seed": 3489526896,
+        "success": true,
+        "steps": 181,
+        "total_reward": 37.595000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47725757575757577
+      },
+      {
+        "run": 168,
+        "seed": 3489526897,
+        "success": true,
+        "steps": 207,
+        "total_reward": 33.09500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4910222763003299
+      },
+      {
+        "run": 169,
+        "seed": 3489526898,
+        "success": false,
+        "steps": 194,
+        "total_reward": 14.050000000000061,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4354656144183207
+      },
+      {
+        "run": 170,
+        "seed": 3489526899,
+        "success": true,
+        "steps": 170,
+        "total_reward": 23.650000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4673409923409923
+      },
+      {
+        "run": 171,
+        "seed": 3489526900,
+        "success": false,
+        "steps": 107,
+        "total_reward": -0.7050000000000018,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.259700176366843
+      },
+      {
+        "run": 172,
+        "seed": 3489526901,
+        "success": true,
+        "steps": 235,
+        "total_reward": 31.725000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42737117521098106
+      },
+      {
+        "run": 173,
+        "seed": 3489526902,
+        "success": true,
+        "steps": 148,
+        "total_reward": 26.820000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4608502827581775
+      },
+      {
+        "run": 174,
+        "seed": 3489526903,
+        "success": false,
+        "steps": 128,
+        "total_reward": 10.909999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.5026924715375527
+      },
+      {
+        "run": 175,
+        "seed": 3489526904,
+        "success": true,
+        "steps": 205,
+        "total_reward": 36.365000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47560425685425683
+      },
+      {
+        "run": 176,
+        "seed": 3489526905,
+        "success": true,
+        "steps": 182,
+        "total_reward": 31.300000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4590318745581904
+      },
+      {
+        "run": 177,
+        "seed": 3489526906,
+        "success": true,
+        "steps": 179,
+        "total_reward": 36.65500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5950450937950938
+      },
+      {
+        "run": 178,
+        "seed": 3489526907,
+        "success": true,
+        "steps": 171,
+        "total_reward": 43.845000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5700461133069828
+      },
+      {
+        "run": 179,
+        "seed": 3489526908,
+        "success": true,
+        "steps": 161,
+        "total_reward": 31.27500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5141056166056166
+      },
+      {
+        "run": 180,
+        "seed": 3489526909,
+        "success": true,
+        "steps": 215,
+        "total_reward": 41.235000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5448300653594771
+      },
+      {
+        "run": 181,
+        "seed": 3489526910,
+        "success": true,
+        "steps": 180,
+        "total_reward": 37.10000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45214646464646463
+      },
+      {
+        "run": 182,
+        "seed": 3489526911,
+        "success": false,
+        "steps": 125,
+        "total_reward": 19.90500000000005,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.6259550634550635
+      },
+      {
+        "run": 183,
+        "seed": 3489526912,
+        "success": true,
+        "steps": 189,
+        "total_reward": 29.40500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46662568330925336
+      },
+      {
+        "run": 184,
+        "seed": 3489526913,
+        "success": true,
+        "steps": 194,
+        "total_reward": 42.730000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5111817168338908
+      },
+      {
+        "run": 185,
+        "seed": 3489526914,
+        "success": true,
+        "steps": 139,
+        "total_reward": 30.235000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6279076479076479
+      },
+      {
+        "run": 186,
+        "seed": 3489526915,
+        "success": true,
+        "steps": 165,
+        "total_reward": 35.01500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5202880452880453
+      },
+      {
+        "run": 187,
+        "seed": 3489526916,
+        "success": false,
+        "steps": 10,
+        "total_reward": -7.449999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 188,
+        "seed": 3489526917,
+        "success": false,
+        "steps": 22,
+        "total_reward": -6.36,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.4444444444444444
+      },
+      {
+        "run": 189,
+        "seed": 3489526918,
+        "success": false,
+        "steps": 67,
+        "total_reward": 4.6750000000000025,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.5462962962962963
+      },
+      {
+        "run": 190,
+        "seed": 3489526919,
+        "success": true,
+        "steps": 182,
+        "total_reward": 24.400000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39014928930718407
+      },
+      {
+        "run": 191,
+        "seed": 3489526920,
+        "success": true,
+        "steps": 170,
+        "total_reward": 32.730000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5292999991232454
+      },
+      {
+        "run": 192,
+        "seed": 3489526921,
+        "success": true,
+        "steps": 176,
+        "total_reward": 31.33000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5238370982488629
+      },
+      {
+        "run": 193,
+        "seed": 3489526922,
+        "success": true,
+        "steps": 128,
+        "total_reward": 27.020000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6233287545787546
+      },
+      {
+        "run": 194,
+        "seed": 3489526923,
+        "success": true,
+        "steps": 190,
+        "total_reward": 34.58000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3939959726653275
+      },
+      {
+        "run": 195,
+        "seed": 3489526924,
+        "success": true,
+        "steps": 235,
+        "total_reward": 34.34500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45757384915279653
+      },
+      {
+        "run": 196,
+        "seed": 3489526925,
+        "success": true,
+        "steps": 172,
+        "total_reward": 34.7900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5180043386565126
+      },
+      {
+        "run": 197,
+        "seed": 3489526926,
+        "success": true,
+        "steps": 175,
+        "total_reward": 28.355000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48149799807864324
+      },
+      {
+        "run": 198,
+        "seed": 3489526927,
+        "success": true,
+        "steps": 213,
+        "total_reward": 32.43500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48536738036738036
+      },
+      {
+        "run": 199,
+        "seed": 3489526928,
+        "success": true,
+        "steps": 200,
+        "total_reward": 31.64000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4358201262961325
+      },
+      {
+        "run": 200,
+        "seed": 3489526929,
+        "success": true,
+        "steps": 169,
+        "total_reward": 36.39500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5479109292839943
+      }
+    ],
+    "avg_chemotaxis_index": 0.3373500484282572,
+    "avg_time_in_attractant": 0.6686750242141286,
+    "avg_approach_frequency": 0.43054725880998373,
+    "avg_path_efficiency": 0.06423938255471566,
+    "post_convergence_chemotaxis_index": 0.34470612315483046,
+    "post_convergence_time_in_attractant": 0.6723530615774153,
+    "post_convergence_approach_frequency": 0.433396203611853,
+    "post_convergence_path_efficiency": 0.06568954894719217,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_101745.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_101745.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_101745",
+  "timestamp": "2025-12-29T10:31:32.790748+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_101745",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.495,
+    "avg_steps": 296.85,
+    "avg_reward": 15.745250000000064,
+    "avg_foods_collected": 6.965,
+    "avg_distance_efficiency": 0.26532042411946904,
+    "completed_all_food": 99,
+    "starved": 24,
+    "max_steps_reached": 7,
+    "goal_reached": 0,
+    "predator_deaths": 70,
+    "avg_predator_encounters": 10.67,
+    "avg_successful_evasions": 10.12,
+    "converged": false,
+    "convergence_run": null,
+    "runs_to_convergence": null,
+    "post_convergence_success_rate": 0.5,
+    "post_convergence_avg_steps": 331.8,
+    "post_convergence_avg_foods": 6.5,
+    "post_convergence_variance": 0.25,
+    "post_convergence_distance_efficiency": 0.28645181673398457,
+    "composite_benchmark_score": 0.28593554502019536,
+    "learning_speed": 0.575,
+    "learning_speed_episodes": 85,
+    "stability": 0.0,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 1070406003,
+        "success": false,
+        "steps": 212,
+        "total_reward": -21.62000000000002,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.5833333333333334
+      },
+      {
+        "run": 2,
+        "seed": 1070406004,
+        "success": false,
+        "steps": 115,
+        "total_reward": -18.93500000000001,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 1070406005,
+        "success": false,
+        "steps": 46,
+        "total_reward": -6.6899999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.2857142857142857
+      },
+      {
+        "run": 4,
+        "seed": 1070406006,
+        "success": false,
+        "steps": 13,
+        "total_reward": -10.415,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 5,
+        "seed": 1070406007,
+        "success": false,
+        "steps": 240,
+        "total_reward": -8.379999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.12121212121212122
+      },
+      {
+        "run": 6,
+        "seed": 1070406008,
+        "success": false,
+        "steps": 146,
+        "total_reward": -6.149999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.2751322751322751
+      },
+      {
+        "run": 7,
+        "seed": 1070406009,
+        "success": false,
+        "steps": 309,
+        "total_reward": -0.5350000000000499,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4344649380735988
+      },
+      {
+        "run": 8,
+        "seed": 1070406010,
+        "success": false,
+        "steps": 65,
+        "total_reward": -10.625,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 9,
+        "seed": 1070406011,
+        "success": false,
+        "steps": 51,
+        "total_reward": -13.274999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 10,
+        "seed": 1070406012,
+        "success": false,
+        "steps": 240,
+        "total_reward": -18.510000000000005,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.05263157894736842
+      },
+      {
+        "run": 11,
+        "seed": 1070406013,
+        "success": false,
+        "steps": 104,
+        "total_reward": -14.61,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 12,
+        "seed": 1070406014,
+        "success": false,
+        "steps": 240,
+        "total_reward": -7.179999999999993,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.04375
+      },
+      {
+        "run": 13,
+        "seed": 1070406015,
+        "success": false,
+        "steps": 280,
+        "total_reward": -4.670000000000002,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.14422084623323012
+      },
+      {
+        "run": 14,
+        "seed": 1070406016,
+        "success": false,
+        "steps": 320,
+        "total_reward": -17.130000000000003,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.17064828175939287
+      },
+      {
+        "run": 15,
+        "seed": 1070406017,
+        "success": false,
+        "steps": 175,
+        "total_reward": -5.405000000000005,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.15175585284280935
+      },
+      {
+        "run": 16,
+        "seed": 1070406018,
+        "success": false,
+        "steps": 186,
+        "total_reward": -13.940000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.05714285714285714
+      },
+      {
+        "run": 17,
+        "seed": 1070406019,
+        "success": false,
+        "steps": 200,
+        "total_reward": -8.609999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 18,
+        "seed": 1070406020,
+        "success": false,
+        "steps": 451,
+        "total_reward": -0.08500000000006303,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.1807767920246269
+      },
+      {
+        "run": 19,
+        "seed": 1070406021,
+        "success": false,
+        "steps": 200,
+        "total_reward": -8.209999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 20,
+        "seed": 1070406022,
+        "success": false,
+        "steps": 320,
+        "total_reward": -14.829999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.08616946778711486
+      },
+      {
+        "run": 21,
+        "seed": 1070406023,
+        "success": false,
+        "steps": 240,
+        "total_reward": -10.209999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.047058823529411764
+      },
+      {
+        "run": 22,
+        "seed": 1070406024,
+        "success": false,
+        "steps": 360,
+        "total_reward": 3.319999999999924,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.08900932766353811
+      },
+      {
+        "run": 23,
+        "seed": 1070406025,
+        "success": false,
+        "steps": 232,
+        "total_reward": -4.4899999999999896,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.1875
+      },
+      {
+        "run": 24,
+        "seed": 1070406026,
+        "success": false,
+        "steps": 159,
+        "total_reward": -6.085000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.129382889200561
+      },
+      {
+        "run": 25,
+        "seed": 1070406027,
+        "success": true,
+        "steps": 484,
+        "total_reward": 33.23000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31329987962711076
+      },
+      {
+        "run": 26,
+        "seed": 1070406028,
+        "success": false,
+        "steps": 320,
+        "total_reward": -5.930000000000005,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.07929046563192904
+      },
+      {
+        "run": 27,
+        "seed": 1070406029,
+        "success": false,
+        "steps": 320,
+        "total_reward": -17.180000000000017,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.07618235700077132
+      },
+      {
+        "run": 28,
+        "seed": 1070406030,
+        "success": false,
+        "steps": 418,
+        "total_reward": 1.6299999999998853,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.2200283798006758
+      },
+      {
+        "run": 29,
+        "seed": 1070406031,
+        "success": false,
+        "steps": 143,
+        "total_reward": -12.194999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.17835595776772248
+      },
+      {
+        "run": 30,
+        "seed": 1070406032,
+        "success": false,
+        "steps": 276,
+        "total_reward": 6.349999999999952,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.23545115655513602
+      },
+      {
+        "run": 31,
+        "seed": 1070406033,
+        "success": false,
+        "steps": 72,
+        "total_reward": -9.379999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.25
+      },
+      {
+        "run": 32,
+        "seed": 1070406034,
+        "success": false,
+        "steps": 280,
+        "total_reward": 1.6299999999999386,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.10422705314009661
+      },
+      {
+        "run": 33,
+        "seed": 1070406035,
+        "success": false,
+        "steps": 414,
+        "total_reward": 13.480000000000139,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.28711737318708197
+      },
+      {
+        "run": 34,
+        "seed": 1070406036,
+        "success": true,
+        "steps": 381,
+        "total_reward": 25.055000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27844094362310684
+      },
+      {
+        "run": 35,
+        "seed": 1070406037,
+        "success": false,
+        "steps": 240,
+        "total_reward": -13.589999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.09523809523809523
+      },
+      {
+        "run": 36,
+        "seed": 1070406038,
+        "success": false,
+        "steps": 447,
+        "total_reward": 13.265000000000143,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.13995351246968554
+      },
+      {
+        "run": 37,
+        "seed": 1070406039,
+        "success": false,
+        "steps": 500,
+        "total_reward": 26.390000000000114,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.24065502338576755
+      },
+      {
+        "run": 38,
+        "seed": 1070406040,
+        "success": false,
+        "steps": 360,
+        "total_reward": 7.750000000000011,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.1993228602383532
+      },
+      {
+        "run": 39,
+        "seed": 1070406041,
+        "success": true,
+        "steps": 439,
+        "total_reward": 39.785000000000196,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22033915675303692
+      },
+      {
+        "run": 40,
+        "seed": 1070406042,
+        "success": false,
+        "steps": 225,
+        "total_reward": 11.705000000000034,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.2250548457865531
+      },
+      {
+        "run": 41,
+        "seed": 1070406043,
+        "success": false,
+        "steps": 500,
+        "total_reward": 22.790000000000152,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.20046468172380105
+      },
+      {
+        "run": 42,
+        "seed": 1070406044,
+        "success": true,
+        "steps": 318,
+        "total_reward": 23.710000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3632101433475788
+      },
+      {
+        "run": 43,
+        "seed": 1070406045,
+        "success": true,
+        "steps": 397,
+        "total_reward": 32.42500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22343373521905074
+      },
+      {
+        "run": 44,
+        "seed": 1070406046,
+        "success": false,
+        "steps": 365,
+        "total_reward": 14.325000000000042,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.2566641121786783
+      },
+      {
+        "run": 45,
+        "seed": 1070406047,
+        "success": false,
+        "steps": 221,
+        "total_reward": 0.2649999999999597,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.15285832642916322
+      },
+      {
+        "run": 46,
+        "seed": 1070406048,
+        "success": true,
+        "steps": 309,
+        "total_reward": 27.5750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22532359211933164
+      },
+      {
+        "run": 47,
+        "seed": 1070406049,
+        "success": false,
+        "steps": 328,
+        "total_reward": -8.309999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.2642142364192054
+      },
+      {
+        "run": 48,
+        "seed": 1070406050,
+        "success": true,
+        "steps": 432,
+        "total_reward": 25.060000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21040677781217107
+      },
+      {
+        "run": 49,
+        "seed": 1070406051,
+        "success": false,
+        "steps": 406,
+        "total_reward": 25.8100000000002,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.2576063172466584
+      },
+      {
+        "run": 50,
+        "seed": 1070406052,
+        "success": false,
+        "steps": 221,
+        "total_reward": -2.195000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.28106367451195036
+      },
+      {
+        "run": 51,
+        "seed": 1070406053,
+        "success": true,
+        "steps": 253,
+        "total_reward": 20.955000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3372087535341392
+      },
+      {
+        "run": 52,
+        "seed": 1070406054,
+        "success": true,
+        "steps": 363,
+        "total_reward": 32.32500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24779729439898696
+      },
+      {
+        "run": 53,
+        "seed": 1070406055,
+        "success": false,
+        "steps": 277,
+        "total_reward": 9.39500000000011,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.36592013187757866
+      },
+      {
+        "run": 54,
+        "seed": 1070406056,
+        "success": false,
+        "steps": 184,
+        "total_reward": 6.189999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3179089026915114
+      },
+      {
+        "run": 55,
+        "seed": 1070406057,
+        "success": false,
+        "steps": 500,
+        "total_reward": 15.129999999999947,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.24842113321465162
+      },
+      {
+        "run": 56,
+        "seed": 1070406058,
+        "success": true,
+        "steps": 426,
+        "total_reward": 35.34000000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2685959939369875
+      },
+      {
+        "run": 57,
+        "seed": 1070406059,
+        "success": false,
+        "steps": 15,
+        "total_reward": -9.195,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 58,
+        "seed": 1070406060,
+        "success": false,
+        "steps": 500,
+        "total_reward": 19.280000000000065,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.1840051699594984
+      },
+      {
+        "run": 59,
+        "seed": 1070406061,
+        "success": true,
+        "steps": 364,
+        "total_reward": 35.31000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33832239418488647
+      },
+      {
+        "run": 60,
+        "seed": 1070406062,
+        "success": false,
+        "steps": 48,
+        "total_reward": -8.709999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.15
+      },
+      {
+        "run": 61,
+        "seed": 1070406063,
+        "success": false,
+        "steps": 500,
+        "total_reward": 34.37000000000034,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.23437971874140429
+      },
+      {
+        "run": 62,
+        "seed": 1070406064,
+        "success": true,
+        "steps": 445,
+        "total_reward": 35.605000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25180791753520154
+      },
+      {
+        "run": 63,
+        "seed": 1070406065,
+        "success": true,
+        "steps": 238,
+        "total_reward": 29.91000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.397276588447988
+      },
+      {
+        "run": 64,
+        "seed": 1070406066,
+        "success": false,
+        "steps": 110,
+        "total_reward": 2.809999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.37825722394220845
+      },
+      {
+        "run": 65,
+        "seed": 1070406067,
+        "success": false,
+        "steps": 156,
+        "total_reward": -2.149999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.24701426024955433
+      },
+      {
+        "run": 66,
+        "seed": 1070406068,
+        "success": false,
+        "steps": 319,
+        "total_reward": 3.9649999999999856,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.25656792393547234
+      },
+      {
+        "run": 67,
+        "seed": 1070406069,
+        "success": false,
+        "steps": 192,
+        "total_reward": 0.259999999999982,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.2675026123301985
+      },
+      {
+        "run": 68,
+        "seed": 1070406070,
+        "success": false,
+        "steps": 383,
+        "total_reward": 14.94500000000026,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.2817916835474445
+      },
+      {
+        "run": 69,
+        "seed": 1070406071,
+        "success": true,
+        "steps": 475,
+        "total_reward": 20.765000000000157,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23758365355083538
+      },
+      {
+        "run": 70,
+        "seed": 1070406072,
+        "success": true,
+        "steps": 490,
+        "total_reward": 26.120000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2289770718217055
+      },
+      {
+        "run": 71,
+        "seed": 1070406073,
+        "success": true,
+        "steps": 252,
+        "total_reward": 31.290000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37632095144998373
+      },
+      {
+        "run": 72,
+        "seed": 1070406074,
+        "success": false,
+        "steps": 85,
+        "total_reward": -1.9949999999999974,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.3181818181818182
+      },
+      {
+        "run": 73,
+        "seed": 1070406075,
+        "success": true,
+        "steps": 343,
+        "total_reward": 26.79500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3472407584124002
+      },
+      {
+        "run": 74,
+        "seed": 1070406076,
+        "success": false,
+        "steps": 283,
+        "total_reward": 7.154999999999976,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.3134523176119199
+      },
+      {
+        "run": 75,
+        "seed": 1070406077,
+        "success": false,
+        "steps": 291,
+        "total_reward": 7.62499999999995,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3121846124663026
+      },
+      {
+        "run": 76,
+        "seed": 1070406078,
+        "success": true,
+        "steps": 499,
+        "total_reward": 31.31500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2830483863041538
+      },
+      {
+        "run": 77,
+        "seed": 1070406079,
+        "success": true,
+        "steps": 487,
+        "total_reward": 56.19500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.278783831430372
+      },
+      {
+        "run": 78,
+        "seed": 1070406080,
+        "success": false,
+        "steps": 95,
+        "total_reward": -2.2150000000000034,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4131379731379732
+      },
+      {
+        "run": 79,
+        "seed": 1070406081,
+        "success": true,
+        "steps": 446,
+        "total_reward": 38.73000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2649169305571056
+      },
+      {
+        "run": 80,
+        "seed": 1070406082,
+        "success": false,
+        "steps": 145,
+        "total_reward": 0.6449999999999907,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.15786191209920022
+      },
+      {
+        "run": 81,
+        "seed": 1070406083,
+        "success": true,
+        "steps": 425,
+        "total_reward": 24.665000000000177,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24298277110259098
+      },
+      {
+        "run": 82,
+        "seed": 1070406084,
+        "success": true,
+        "steps": 246,
+        "total_reward": 25.240000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2861493632566849
+      },
+      {
+        "run": 83,
+        "seed": 1070406085,
+        "success": true,
+        "steps": 394,
+        "total_reward": 37.94000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30857221384381245
+      },
+      {
+        "run": 84,
+        "seed": 1070406086,
+        "success": true,
+        "steps": 383,
+        "total_reward": 34.915000000000255,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3134543982398319
+      },
+      {
+        "run": 85,
+        "seed": 1070406087,
+        "success": true,
+        "steps": 375,
+        "total_reward": 31.55500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3017238879567255
+      },
+      {
+        "run": 86,
+        "seed": 1070406088,
+        "success": true,
+        "steps": 401,
+        "total_reward": 20.755,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2034178224749866
+      },
+      {
+        "run": 87,
+        "seed": 1070406089,
+        "success": false,
+        "steps": 316,
+        "total_reward": 13.390000000000015,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.2275584579686633
+      },
+      {
+        "run": 88,
+        "seed": 1070406090,
+        "success": true,
+        "steps": 480,
+        "total_reward": 44.86000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.262183436855972
+      },
+      {
+        "run": 89,
+        "seed": 1070406091,
+        "success": true,
+        "steps": 418,
+        "total_reward": 25.95000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38521782453361403
+      },
+      {
+        "run": 90,
+        "seed": 1070406092,
+        "success": true,
+        "steps": 361,
+        "total_reward": 27.315000000000108,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2758679094062674
+      },
+      {
+        "run": 91,
+        "seed": 1070406093,
+        "success": true,
+        "steps": 292,
+        "total_reward": 30.280000000000157,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3642278965447084
+      },
+      {
+        "run": 92,
+        "seed": 1070406094,
+        "success": true,
+        "steps": 368,
+        "total_reward": 28.88000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3149122615407019
+      },
+      {
+        "run": 93,
+        "seed": 1070406095,
+        "success": true,
+        "steps": 282,
+        "total_reward": 31.74000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32508499969410787
+      },
+      {
+        "run": 94,
+        "seed": 1070406096,
+        "success": true,
+        "steps": 289,
+        "total_reward": 29.745000000000132,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33133918886489877
+      },
+      {
+        "run": 95,
+        "seed": 1070406097,
+        "success": true,
+        "steps": 407,
+        "total_reward": 49.115000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31819013051508127
+      },
+      {
+        "run": 96,
+        "seed": 1070406098,
+        "success": false,
+        "steps": 336,
+        "total_reward": 8.830000000000066,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.1598068804337968
+      },
+      {
+        "run": 97,
+        "seed": 1070406099,
+        "success": true,
+        "steps": 397,
+        "total_reward": 35.73500000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2994450724481561
+      },
+      {
+        "run": 98,
+        "seed": 1070406100,
+        "success": false,
+        "steps": 150,
+        "total_reward": 7.159999999999986,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.241000616000616
+      },
+      {
+        "run": 99,
+        "seed": 1070406101,
+        "success": true,
+        "steps": 269,
+        "total_reward": 25.385000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4223493709020024
+      },
+      {
+        "run": 100,
+        "seed": 1070406102,
+        "success": false,
+        "steps": 500,
+        "total_reward": 19.490000000000112,
+        "termination_reason": "max_steps",
+        "foods_collected": 8,
+        "distance_efficiency": 0.16681588554801138
+      },
+      {
+        "run": 101,
+        "seed": 1070406103,
+        "success": false,
+        "steps": 252,
+        "total_reward": 1.3499999999999588,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.1822103882959146
+      },
+      {
+        "run": 102,
+        "seed": 1070406104,
+        "success": true,
+        "steps": 420,
+        "total_reward": 19.65,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26525619038709847
+      },
+      {
+        "run": 103,
+        "seed": 1070406105,
+        "success": false,
+        "steps": 176,
+        "total_reward": -0.5800000000000107,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3358406762662082
+      },
+      {
+        "run": 104,
+        "seed": 1070406106,
+        "success": true,
+        "steps": 352,
+        "total_reward": 34.44000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31074425118884763
+      },
+      {
+        "run": 105,
+        "seed": 1070406107,
+        "success": true,
+        "steps": 319,
+        "total_reward": 19.585000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3232695919385026
+      },
+      {
+        "run": 106,
+        "seed": 1070406108,
+        "success": true,
+        "steps": 307,
+        "total_reward": 28.195000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38129791373239247
+      },
+      {
+        "run": 107,
+        "seed": 1070406109,
+        "success": true,
+        "steps": 405,
+        "total_reward": 26.305000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22299533895845366
+      },
+      {
+        "run": 108,
+        "seed": 1070406110,
+        "success": true,
+        "steps": 348,
+        "total_reward": 25.62000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22705063616355634
+      },
+      {
+        "run": 109,
+        "seed": 1070406111,
+        "success": true,
+        "steps": 345,
+        "total_reward": 30.785000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35595232435448104
+      },
+      {
+        "run": 110,
+        "seed": 1070406112,
+        "success": false,
+        "steps": 27,
+        "total_reward": -11.195,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 111,
+        "seed": 1070406113,
+        "success": true,
+        "steps": 465,
+        "total_reward": 34.845000000000184,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33277181833282815
+      },
+      {
+        "run": 112,
+        "seed": 1070406114,
+        "success": true,
+        "steps": 302,
+        "total_reward": 31.800000000000157,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3799917674579713
+      },
+      {
+        "run": 113,
+        "seed": 1070406115,
+        "success": true,
+        "steps": 361,
+        "total_reward": 38.32500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3582230469024602
+      },
+      {
+        "run": 114,
+        "seed": 1070406116,
+        "success": false,
+        "steps": 236,
+        "total_reward": 14.370000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3411890356974523
+      },
+      {
+        "run": 115,
+        "seed": 1070406117,
+        "success": false,
+        "steps": 9,
+        "total_reward": -9.245,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 116,
+        "seed": 1070406118,
+        "success": true,
+        "steps": 456,
+        "total_reward": 31.100000000000158,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2052773453164527
+      },
+      {
+        "run": 117,
+        "seed": 1070406119,
+        "success": false,
+        "steps": 113,
+        "total_reward": -3.2950000000000035,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.40548340548340545
+      },
+      {
+        "run": 118,
+        "seed": 1070406120,
+        "success": true,
+        "steps": 416,
+        "total_reward": 25.870000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24612964874473825
+      },
+      {
+        "run": 119,
+        "seed": 1070406121,
+        "success": true,
+        "steps": 323,
+        "total_reward": 28.99500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2599377133995361
+      },
+      {
+        "run": 120,
+        "seed": 1070406122,
+        "success": false,
+        "steps": 64,
+        "total_reward": -2.1299999999999972,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.611111111111111
+      },
+      {
+        "run": 121,
+        "seed": 1070406123,
+        "success": false,
+        "steps": 52,
+        "total_reward": -5.380000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.3146453089244851
+      },
+      {
+        "run": 122,
+        "seed": 1070406124,
+        "success": false,
+        "steps": 439,
+        "total_reward": 13.765000000000015,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.23117340086871474
+      },
+      {
+        "run": 123,
+        "seed": 1070406125,
+        "success": true,
+        "steps": 358,
+        "total_reward": 26.60000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2818911522247186
+      },
+      {
+        "run": 124,
+        "seed": 1070406126,
+        "success": true,
+        "steps": 301,
+        "total_reward": 27.725000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3315630350964112
+      },
+      {
+        "run": 125,
+        "seed": 1070406127,
+        "success": false,
+        "steps": 230,
+        "total_reward": 5.919999999999984,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.29885321717619856
+      },
+      {
+        "run": 126,
+        "seed": 1070406128,
+        "success": false,
+        "steps": 44,
+        "total_reward": -5.989999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.5641025641025641
+      },
+      {
+        "run": 127,
+        "seed": 1070406129,
+        "success": false,
+        "steps": 344,
+        "total_reward": 16.54000000000008,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.27773883999005317
+      },
+      {
+        "run": 128,
+        "seed": 1070406130,
+        "success": true,
+        "steps": 332,
+        "total_reward": 38.2400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28133549115453127
+      },
+      {
+        "run": 129,
+        "seed": 1070406131,
+        "success": true,
+        "steps": 344,
+        "total_reward": 35.54000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3396408342667685
+      },
+      {
+        "run": 130,
+        "seed": 1070406132,
+        "success": false,
+        "steps": 409,
+        "total_reward": 13.404999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.312427045898533
+      },
+      {
+        "run": 131,
+        "seed": 1070406133,
+        "success": true,
+        "steps": 253,
+        "total_reward": 29.415000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3345360558193488
+      },
+      {
+        "run": 132,
+        "seed": 1070406134,
+        "success": false,
+        "steps": 500,
+        "total_reward": 14.789999999999896,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.19746269525681293
+      },
+      {
+        "run": 133,
+        "seed": 1070406135,
+        "success": true,
+        "steps": 308,
+        "total_reward": 25.120000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29104383347386703
+      },
+      {
+        "run": 134,
+        "seed": 1070406136,
+        "success": false,
+        "steps": 287,
+        "total_reward": 25.05500000000017,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.326363966381943
+      },
+      {
+        "run": 135,
+        "seed": 1070406137,
+        "success": false,
+        "steps": 311,
+        "total_reward": -6.125000000000023,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.1375243288401183
+      },
+      {
+        "run": 136,
+        "seed": 1070406138,
+        "success": true,
+        "steps": 367,
+        "total_reward": 31.195000000000107,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2802910503166343
+      },
+      {
+        "run": 137,
+        "seed": 1070406139,
+        "success": true,
+        "steps": 479,
+        "total_reward": 32.29500000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2491247052270782
+      },
+      {
+        "run": 138,
+        "seed": 1070406140,
+        "success": true,
+        "steps": 361,
+        "total_reward": 37.5650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26693252364717784
+      },
+      {
+        "run": 139,
+        "seed": 1070406141,
+        "success": false,
+        "steps": 118,
+        "total_reward": 5.359999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.4994212962962963
+      },
+      {
+        "run": 140,
+        "seed": 1070406142,
+        "success": false,
+        "steps": 87,
+        "total_reward": 2.1450000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.3397019647019647
+      },
+      {
+        "run": 141,
+        "seed": 1070406143,
+        "success": false,
+        "steps": 462,
+        "total_reward": 38.1099999999999,
+        "termination_reason": "starved",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3654722264410376
+      },
+      {
+        "run": 142,
+        "seed": 1070406144,
+        "success": true,
+        "steps": 263,
+        "total_reward": 30.3350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3230482947982948
+      },
+      {
+        "run": 143,
+        "seed": 1070406145,
+        "success": true,
+        "steps": 280,
+        "total_reward": 27.620000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24717115811841978
+      },
+      {
+        "run": 144,
+        "seed": 1070406146,
+        "success": false,
+        "steps": 128,
+        "total_reward": 11.270000000000035,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.3954326923076923
+      },
+      {
+        "run": 145,
+        "seed": 1070406147,
+        "success": true,
+        "steps": 339,
+        "total_reward": 24.58500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.306941810586813
+      },
+      {
+        "run": 146,
+        "seed": 1070406148,
+        "success": true,
+        "steps": 452,
+        "total_reward": 18.350000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20273269021424256
+      },
+      {
+        "run": 147,
+        "seed": 1070406149,
+        "success": true,
+        "steps": 408,
+        "total_reward": 33.46000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2974752593957867
+      },
+      {
+        "run": 148,
+        "seed": 1070406150,
+        "success": true,
+        "steps": 423,
+        "total_reward": 13.614999999999924,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23908302396630376
+      },
+      {
+        "run": 149,
+        "seed": 1070406151,
+        "success": false,
+        "steps": 61,
+        "total_reward": -0.6849999999999987,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.504585326953748
+      },
+      {
+        "run": 150,
+        "seed": 1070406152,
+        "success": true,
+        "steps": 424,
+        "total_reward": 43.540000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33704059093882477
+      },
+      {
+        "run": 151,
+        "seed": 1070406153,
+        "success": true,
+        "steps": 309,
+        "total_reward": 47.275000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4028639618409439
+      },
+      {
+        "run": 152,
+        "seed": 1070406154,
+        "success": true,
+        "steps": 328,
+        "total_reward": 21.12000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29406462217868834
+      },
+      {
+        "run": 153,
+        "seed": 1070406155,
+        "success": true,
+        "steps": 371,
+        "total_reward": 22.10500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3243377009857237
+      },
+      {
+        "run": 154,
+        "seed": 1070406156,
+        "success": true,
+        "steps": 249,
+        "total_reward": 29.915000000000138,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37722133959227533
+      },
+      {
+        "run": 155,
+        "seed": 1070406157,
+        "success": false,
+        "steps": 176,
+        "total_reward": 7.879999999999978,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.32485294117647057
+      },
+      {
+        "run": 156,
+        "seed": 1070406158,
+        "success": true,
+        "steps": 263,
+        "total_reward": 26.755000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40987575543037724
+      },
+      {
+        "run": 157,
+        "seed": 1070406159,
+        "success": true,
+        "steps": 493,
+        "total_reward": 35.23500000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21034689987171817
+      },
+      {
+        "run": 158,
+        "seed": 1070406160,
+        "success": true,
+        "steps": 338,
+        "total_reward": 28.77000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2909051038440451
+      },
+      {
+        "run": 159,
+        "seed": 1070406161,
+        "success": true,
+        "steps": 406,
+        "total_reward": 28.780000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.293939632467933
+      },
+      {
+        "run": 160,
+        "seed": 1070406162,
+        "success": false,
+        "steps": 248,
+        "total_reward": 14.940000000000115,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.24656432748538012
+      },
+      {
+        "run": 161,
+        "seed": 1070406163,
+        "success": true,
+        "steps": 358,
+        "total_reward": 23.570000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2661051760097596
+      },
+      {
+        "run": 162,
+        "seed": 1070406164,
+        "success": false,
+        "steps": 268,
+        "total_reward": 23.320000000000178,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.31382850241545895
+      },
+      {
+        "run": 163,
+        "seed": 1070406165,
+        "success": false,
+        "steps": 171,
+        "total_reward": -0.8550000000000093,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.2258522727272727
+      },
+      {
+        "run": 164,
+        "seed": 1070406166,
+        "success": true,
+        "steps": 337,
+        "total_reward": 32.255000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23240328054298645
+      },
+      {
+        "run": 165,
+        "seed": 1070406167,
+        "success": true,
+        "steps": 333,
+        "total_reward": 26.745000000000122,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26277944169120643
+      },
+      {
+        "run": 166,
+        "seed": 1070406168,
+        "success": true,
+        "steps": 300,
+        "total_reward": 30.680000000000142,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.275717631998506
+      },
+      {
+        "run": 167,
+        "seed": 1070406169,
+        "success": false,
+        "steps": 131,
+        "total_reward": 0.015000000000000568,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4293500617030029
+      },
+      {
+        "run": 168,
+        "seed": 1070406170,
+        "success": true,
+        "steps": 488,
+        "total_reward": 37.38000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21187022047871107
+      },
+      {
+        "run": 169,
+        "seed": 1070406171,
+        "success": true,
+        "steps": 315,
+        "total_reward": 30.73500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3215636340521924
+      },
+      {
+        "run": 170,
+        "seed": 1070406172,
+        "success": true,
+        "steps": 341,
+        "total_reward": 25.82499999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3161968923672665
+      },
+      {
+        "run": 171,
+        "seed": 1070406173,
+        "success": true,
+        "steps": 387,
+        "total_reward": 21.55500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23288195688180585
+      },
+      {
+        "run": 172,
+        "seed": 1070406174,
+        "success": true,
+        "steps": 407,
+        "total_reward": 30.495000000000193,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29443768015551053
+      },
+      {
+        "run": 173,
+        "seed": 1070406175,
+        "success": true,
+        "steps": 318,
+        "total_reward": 22.430000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2994092298187831
+      },
+      {
+        "run": 174,
+        "seed": 1070406176,
+        "success": false,
+        "steps": 61,
+        "total_reward": -11.555,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.2589285714285714
+      },
+      {
+        "run": 175,
+        "seed": 1070406177,
+        "success": true,
+        "steps": 274,
+        "total_reward": 25.970000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2838068070332594
+      },
+      {
+        "run": 176,
+        "seed": 1070406178,
+        "success": true,
+        "steps": 382,
+        "total_reward": 35.8000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22786480055592895
+      },
+      {
+        "run": 177,
+        "seed": 1070406179,
+        "success": false,
+        "steps": 118,
+        "total_reward": -1.0100000000000104,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3362460926399546
+      },
+      {
+        "run": 178,
+        "seed": 1070406180,
+        "success": true,
+        "steps": 316,
+        "total_reward": 26.24000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2960741682159225
+      },
+      {
+        "run": 179,
+        "seed": 1070406181,
+        "success": true,
+        "steps": 314,
+        "total_reward": 30.110000000000195,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2654881293574214
+      },
+      {
+        "run": 180,
+        "seed": 1070406182,
+        "success": false,
+        "steps": 24,
+        "total_reward": -8.22,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.5
+      },
+      {
+        "run": 181,
+        "seed": 1070406183,
+        "success": true,
+        "steps": 459,
+        "total_reward": 31.095000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2673282216841539
+      },
+      {
+        "run": 182,
+        "seed": 1070406184,
+        "success": false,
+        "steps": 209,
+        "total_reward": 16.13500000000004,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.35480777436422595
+      },
+      {
+        "run": 183,
+        "seed": 1070406185,
+        "success": true,
+        "steps": 305,
+        "total_reward": 32.335000000000186,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2790906327163934
+      },
+      {
+        "run": 184,
+        "seed": 1070406186,
+        "success": true,
+        "steps": 301,
+        "total_reward": 31.575000000000177,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38444760473396156
+      },
+      {
+        "run": 185,
+        "seed": 1070406187,
+        "success": true,
+        "steps": 371,
+        "total_reward": 22.005000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2149682731232656
+      },
+      {
+        "run": 186,
+        "seed": 1070406188,
+        "success": true,
+        "steps": 321,
+        "total_reward": 39.025000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30858219265250947
+      },
+      {
+        "run": 187,
+        "seed": 1070406189,
+        "success": false,
+        "steps": 133,
+        "total_reward": 1.6849999999999863,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.16904761904761903
+      },
+      {
+        "run": 188,
+        "seed": 1070406190,
+        "success": true,
+        "steps": 420,
+        "total_reward": 36.540000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24756346357971987
+      },
+      {
+        "run": 189,
+        "seed": 1070406191,
+        "success": true,
+        "steps": 351,
+        "total_reward": 25.61500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28000858022402764
+      },
+      {
+        "run": 190,
+        "seed": 1070406192,
+        "success": false,
+        "steps": 428,
+        "total_reward": 17.190000000000268,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.25197721372159876
+      },
+      {
+        "run": 191,
+        "seed": 1070406193,
+        "success": true,
+        "steps": 401,
+        "total_reward": 17.784999999999993,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2270322872127543
+      },
+      {
+        "run": 192,
+        "seed": 1070406194,
+        "success": true,
+        "steps": 375,
+        "total_reward": 17.57499999999998,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24594264622487577
+      },
+      {
+        "run": 193,
+        "seed": 1070406195,
+        "success": false,
+        "steps": 224,
+        "total_reward": 11.31000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.24693035143370184
+      },
+      {
+        "run": 194,
+        "seed": 1070406196,
+        "success": false,
+        "steps": 406,
+        "total_reward": 10.370000000000132,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.1660766125297494
+      },
+      {
+        "run": 195,
+        "seed": 1070406197,
+        "success": true,
+        "steps": 294,
+        "total_reward": 35.83000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3232015484515484
+      },
+      {
+        "run": 196,
+        "seed": 1070406198,
+        "success": false,
+        "steps": 23,
+        "total_reward": -5.855,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.5
+      },
+      {
+        "run": 197,
+        "seed": 1070406199,
+        "success": true,
+        "steps": 319,
+        "total_reward": 30.605000000000153,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3318390952872377
+      },
+      {
+        "run": 198,
+        "seed": 1070406200,
+        "success": false,
+        "steps": 62,
+        "total_reward": -3.979999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.6428571428571429
+      },
+      {
+        "run": 199,
+        "seed": 1070406201,
+        "success": false,
+        "steps": 41,
+        "total_reward": -2.474999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.5
+      },
+      {
+        "run": 200,
+        "seed": 1070406202,
+        "success": true,
+        "steps": 270,
+        "total_reward": 24.970000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30424350649350645
+      }
+    ],
+    "avg_chemotaxis_index": 0.30765254700532624,
+    "avg_time_in_attractant": 0.6538262735026632,
+    "avg_approach_frequency": 0.38339211693754977,
+    "avg_path_efficiency": 0.05038063205604477,
+    "post_convergence_chemotaxis_index": 0.30765254700532624,
+    "post_convergence_time_in_attractant": 0.6538262735026632,
+    "post_convergence_approach_frequency": 0.38339211693754977,
+    "post_convergence_path_efficiency": 0.05038063205604477,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_101747.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_101747.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_101747",
+  "timestamp": "2025-12-29T10:27:47.518150+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_101747",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.725,
+    "avg_steps": 225.5,
+    "avg_reward": 24.992350000000073,
+    "avg_foods_collected": 8.465,
+    "avg_distance_efficiency": 0.38606576860775904,
+    "completed_all_food": 145,
+    "starved": 10,
+    "max_steps_reached": 1,
+    "goal_reached": 0,
+    "predator_deaths": 44,
+    "avg_predator_encounters": 8.03,
+    "avg_successful_evasions": 7.56,
+    "converged": true,
+    "convergence_run": 45,
+    "runs_to_convergence": 44,
+    "post_convergence_success_rate": 0.8205128205128205,
+    "post_convergence_avg_steps": 238.4453125,
+    "post_convergence_avg_foods": 9.192307692307692,
+    "post_convergence_variance": 0.14727153188691647,
+    "post_convergence_distance_efficiency": 0.4101590543235873,
+    "composite_benchmark_score": 0.6336170785587462,
+    "learning_speed": 0.835,
+    "learning_speed_episodes": 33,
+    "stability": 0.5322928266532574,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 1150672159,
+        "success": false,
+        "steps": 240,
+        "total_reward": -8.889999999999986,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.06944444444444445
+      },
+      {
+        "run": 2,
+        "seed": 1150672160,
+        "success": false,
+        "steps": 25,
+        "total_reward": -12.185,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 1150672161,
+        "success": false,
+        "steps": 280,
+        "total_reward": -9.769999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.08847213392667938
+      },
+      {
+        "run": 4,
+        "seed": 1150672162,
+        "success": false,
+        "steps": 201,
+        "total_reward": -4.705000000000011,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.19819081754565626
+      },
+      {
+        "run": 5,
+        "seed": 1150672163,
+        "success": false,
+        "steps": 80,
+        "total_reward": -11.36,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.09433962264150944
+      },
+      {
+        "run": 6,
+        "seed": 1150672164,
+        "success": false,
+        "steps": 29,
+        "total_reward": -10.114999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 7,
+        "seed": 1150672165,
+        "success": false,
+        "steps": 240,
+        "total_reward": -5.459999999999997,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.10309278350515463
+      },
+      {
+        "run": 8,
+        "seed": 1150672166,
+        "success": false,
+        "steps": 200,
+        "total_reward": -21.46000000000003,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 9,
+        "seed": 1150672167,
+        "success": false,
+        "steps": 165,
+        "total_reward": -11.574999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.07692307692307693
+      },
+      {
+        "run": 10,
+        "seed": 1150672168,
+        "success": false,
+        "steps": 320,
+        "total_reward": -0.4800000000000484,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.10589515554054561
+      },
+      {
+        "run": 11,
+        "seed": 1150672169,
+        "success": false,
+        "steps": 200,
+        "total_reward": -11.59,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 12,
+        "seed": 1150672170,
+        "success": false,
+        "steps": 165,
+        "total_reward": 1.874999999999952,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.4777777777777778
+      },
+      {
+        "run": 13,
+        "seed": 1150672171,
+        "success": false,
+        "steps": 240,
+        "total_reward": -7.169999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.047337278106508875
+      },
+      {
+        "run": 14,
+        "seed": 1150672172,
+        "success": false,
+        "steps": 174,
+        "total_reward": -0.49000000000002153,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.1684313725490196
+      },
+      {
+        "run": 15,
+        "seed": 1150672173,
+        "success": false,
+        "steps": 173,
+        "total_reward": 7.7149999999999785,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3174583568605308
+      },
+      {
+        "run": 16,
+        "seed": 1150672174,
+        "success": false,
+        "steps": 312,
+        "total_reward": 6.539999999999964,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.23124386804022565
+      },
+      {
+        "run": 17,
+        "seed": 1150672175,
+        "success": false,
+        "steps": 454,
+        "total_reward": 13.440000000000065,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.24792240675762464
+      },
+      {
+        "run": 18,
+        "seed": 1150672176,
+        "success": false,
+        "steps": 500,
+        "total_reward": 30.800000000000185,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.20718510135943963
+      },
+      {
+        "run": 19,
+        "seed": 1150672177,
+        "success": false,
+        "steps": 316,
+        "total_reward": 20.340000000000163,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3388875322429479
+      },
+      {
+        "run": 20,
+        "seed": 1150672178,
+        "success": true,
+        "steps": 409,
+        "total_reward": 28.435000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21628786923293047
+      },
+      {
+        "run": 21,
+        "seed": 1150672179,
+        "success": true,
+        "steps": 322,
+        "total_reward": 36.860000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2967220417100667
+      },
+      {
+        "run": 22,
+        "seed": 1150672180,
+        "success": false,
+        "steps": 165,
+        "total_reward": 5.034999999999945,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4214102564102564
+      },
+      {
+        "run": 23,
+        "seed": 1150672181,
+        "success": false,
+        "steps": 273,
+        "total_reward": -1.7250000000000494,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.20935642346903932
+      },
+      {
+        "run": 24,
+        "seed": 1150672182,
+        "success": true,
+        "steps": 370,
+        "total_reward": 32.130000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3065771502842441
+      },
+      {
+        "run": 25,
+        "seed": 1150672183,
+        "success": true,
+        "steps": 432,
+        "total_reward": 36.29000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2667358840710983
+      },
+      {
+        "run": 26,
+        "seed": 1150672184,
+        "success": true,
+        "steps": 273,
+        "total_reward": 30.2350000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37345054025189384
+      },
+      {
+        "run": 27,
+        "seed": 1150672185,
+        "success": true,
+        "steps": 340,
+        "total_reward": 39.100000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37589741649721786
+      },
+      {
+        "run": 28,
+        "seed": 1150672186,
+        "success": true,
+        "steps": 267,
+        "total_reward": 29.29500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31862625401418504
+      },
+      {
+        "run": 29,
+        "seed": 1150672187,
+        "success": false,
+        "steps": 68,
+        "total_reward": -5.0,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.47393578643578643
+      },
+      {
+        "run": 30,
+        "seed": 1150672188,
+        "success": true,
+        "steps": 212,
+        "total_reward": 34.170000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4145598202119941
+      },
+      {
+        "run": 31,
+        "seed": 1150672189,
+        "success": false,
+        "steps": 77,
+        "total_reward": 4.144999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.48545454545454547
+      },
+      {
+        "run": 32,
+        "seed": 1150672190,
+        "success": true,
+        "steps": 234,
+        "total_reward": 33.61000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4101293879253829
+      },
+      {
+        "run": 33,
+        "seed": 1150672191,
+        "success": true,
+        "steps": 248,
+        "total_reward": 39.38000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4056813654459007
+      },
+      {
+        "run": 34,
+        "seed": 1150672192,
+        "success": true,
+        "steps": 297,
+        "total_reward": 30.28500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2785282021151586
+      },
+      {
+        "run": 35,
+        "seed": 1150672193,
+        "success": true,
+        "steps": 241,
+        "total_reward": 31.915000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3744169938248886
+      },
+      {
+        "run": 36,
+        "seed": 1150672194,
+        "success": true,
+        "steps": 251,
+        "total_reward": 29.615000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32737817737817737
+      },
+      {
+        "run": 37,
+        "seed": 1150672195,
+        "success": true,
+        "steps": 193,
+        "total_reward": 36.04500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48504981676465053
+      },
+      {
+        "run": 38,
+        "seed": 1150672196,
+        "success": true,
+        "steps": 215,
+        "total_reward": 30.645000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40389931296977777
+      },
+      {
+        "run": 39,
+        "seed": 1150672197,
+        "success": true,
+        "steps": 379,
+        "total_reward": 37.90500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2617471040274244
+      },
+      {
+        "run": 40,
+        "seed": 1150672198,
+        "success": false,
+        "steps": 56,
+        "total_reward": 1.309999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.5119047619047619
+      },
+      {
+        "run": 41,
+        "seed": 1150672199,
+        "success": false,
+        "steps": 86,
+        "total_reward": 6.959999999999983,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4679021082117057
+      },
+      {
+        "run": 42,
+        "seed": 1150672200,
+        "success": false,
+        "steps": 202,
+        "total_reward": 11.580000000000062,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.39435226156813735
+      },
+      {
+        "run": 43,
+        "seed": 1150672201,
+        "success": true,
+        "steps": 268,
+        "total_reward": 34.750000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3491424603612552
+      },
+      {
+        "run": 44,
+        "seed": 1150672202,
+        "success": false,
+        "steps": 251,
+        "total_reward": 9.825000000000049,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.3621164261818426
+      },
+      {
+        "run": 45,
+        "seed": 1150672203,
+        "success": true,
+        "steps": 225,
+        "total_reward": 33.345000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38853618603618606
+      },
+      {
+        "run": 46,
+        "seed": 1150672204,
+        "success": true,
+        "steps": 249,
+        "total_reward": 28.015000000000082,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41474025974025974
+      },
+      {
+        "run": 47,
+        "seed": 1150672205,
+        "success": true,
+        "steps": 246,
+        "total_reward": 33.66000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36938217579521926
+      },
+      {
+        "run": 48,
+        "seed": 1150672206,
+        "success": true,
+        "steps": 269,
+        "total_reward": 31.725000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32562866954691483
+      },
+      {
+        "run": 49,
+        "seed": 1150672207,
+        "success": true,
+        "steps": 243,
+        "total_reward": 30.695000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3675343868225595
+      },
+      {
+        "run": 50,
+        "seed": 1150672208,
+        "success": true,
+        "steps": 321,
+        "total_reward": 29.23500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3534157499917766
+      },
+      {
+        "run": 51,
+        "seed": 1150672209,
+        "success": true,
+        "steps": 290,
+        "total_reward": 32.710000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33662147106419554
+      },
+      {
+        "run": 52,
+        "seed": 1150672210,
+        "success": true,
+        "steps": 299,
+        "total_reward": 20.535,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3801180041516275
+      },
+      {
+        "run": 53,
+        "seed": 1150672211,
+        "success": true,
+        "steps": 245,
+        "total_reward": 37.23500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3826875043433069
+      },
+      {
+        "run": 54,
+        "seed": 1150672212,
+        "success": true,
+        "steps": 219,
+        "total_reward": 27.285000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37609825040859524
+      },
+      {
+        "run": 55,
+        "seed": 1150672213,
+        "success": true,
+        "steps": 353,
+        "total_reward": 28.92500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2869633951623066
+      },
+      {
+        "run": 56,
+        "seed": 1150672214,
+        "success": true,
+        "steps": 218,
+        "total_reward": 33.13000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44186232755311705
+      },
+      {
+        "run": 57,
+        "seed": 1150672215,
+        "success": true,
+        "steps": 207,
+        "total_reward": 43.64500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43765614469681796
+      },
+      {
+        "run": 58,
+        "seed": 1150672216,
+        "success": true,
+        "steps": 252,
+        "total_reward": 38.07000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4303638246050771
+      },
+      {
+        "run": 59,
+        "seed": 1150672217,
+        "success": true,
+        "steps": 252,
+        "total_reward": 28.670000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4104683145646192
+      },
+      {
+        "run": 60,
+        "seed": 1150672218,
+        "success": true,
+        "steps": 251,
+        "total_reward": 35.49500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4129677286165373
+      },
+      {
+        "run": 61,
+        "seed": 1150672219,
+        "success": true,
+        "steps": 270,
+        "total_reward": 44.33000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41616331450427557
+      },
+      {
+        "run": 62,
+        "seed": 1150672220,
+        "success": true,
+        "steps": 153,
+        "total_reward": 37.56500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6161480676186558
+      },
+      {
+        "run": 63,
+        "seed": 1150672221,
+        "success": true,
+        "steps": 264,
+        "total_reward": 42.750000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32970824035479207
+      },
+      {
+        "run": 64,
+        "seed": 1150672222,
+        "success": true,
+        "steps": 241,
+        "total_reward": 37.84500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38750287862180444
+      },
+      {
+        "run": 65,
+        "seed": 1150672223,
+        "success": true,
+        "steps": 192,
+        "total_reward": 34.03000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4616744912175947
+      },
+      {
+        "run": 66,
+        "seed": 1150672224,
+        "success": true,
+        "steps": 234,
+        "total_reward": 24.390000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37664684661743486
+      },
+      {
+        "run": 67,
+        "seed": 1150672225,
+        "success": true,
+        "steps": 210,
+        "total_reward": 32.910000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4686555318597386
+      },
+      {
+        "run": 68,
+        "seed": 1150672226,
+        "success": true,
+        "steps": 306,
+        "total_reward": 38.82000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35157022267911564
+      },
+      {
+        "run": 69,
+        "seed": 1150672227,
+        "success": true,
+        "steps": 235,
+        "total_reward": 42.005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4020995997924469
+      },
+      {
+        "run": 70,
+        "seed": 1150672228,
+        "success": true,
+        "steps": 183,
+        "total_reward": 39.56500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5308082940974312
+      },
+      {
+        "run": 71,
+        "seed": 1150672229,
+        "success": true,
+        "steps": 204,
+        "total_reward": 30.950000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46028927041310946
+      },
+      {
+        "run": 72,
+        "seed": 1150672230,
+        "success": false,
+        "steps": 181,
+        "total_reward": 22.71500000000009,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4082392756243331
+      },
+      {
+        "run": 73,
+        "seed": 1150672231,
+        "success": true,
+        "steps": 256,
+        "total_reward": 33.19000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32864582757667865
+      },
+      {
+        "run": 74,
+        "seed": 1150672232,
+        "success": true,
+        "steps": 250,
+        "total_reward": 27.920000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32817047331753213
+      },
+      {
+        "run": 75,
+        "seed": 1150672233,
+        "success": false,
+        "steps": 200,
+        "total_reward": 6.370000000000097,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3910897435897436
+      },
+      {
+        "run": 76,
+        "seed": 1150672234,
+        "success": false,
+        "steps": 249,
+        "total_reward": 17.33500000000009,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.44637539111223323
+      },
+      {
+        "run": 77,
+        "seed": 1150672235,
+        "success": true,
+        "steps": 246,
+        "total_reward": 26.780000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3756417821445452
+      },
+      {
+        "run": 78,
+        "seed": 1150672236,
+        "success": true,
+        "steps": 181,
+        "total_reward": 30.505000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4630400315996758
+      },
+      {
+        "run": 79,
+        "seed": 1150672237,
+        "success": true,
+        "steps": 282,
+        "total_reward": 39.96000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36067629699122317
+      },
+      {
+        "run": 80,
+        "seed": 1150672238,
+        "success": true,
+        "steps": 232,
+        "total_reward": 25.330000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33045887135341945
+      },
+      {
+        "run": 81,
+        "seed": 1150672239,
+        "success": true,
+        "steps": 237,
+        "total_reward": 38.51500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44919164169164166
+      },
+      {
+        "run": 82,
+        "seed": 1150672240,
+        "success": false,
+        "steps": 163,
+        "total_reward": 0.624999999999984,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.27889958800421577
+      },
+      {
+        "run": 83,
+        "seed": 1150672241,
+        "success": true,
+        "steps": 203,
+        "total_reward": 26.795000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41197728328076566
+      },
+      {
+        "run": 84,
+        "seed": 1150672242,
+        "success": true,
+        "steps": 242,
+        "total_reward": 26.150000000000098,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33184935325003234
+      },
+      {
+        "run": 85,
+        "seed": 1150672243,
+        "success": false,
+        "steps": 195,
+        "total_reward": 12.245000000000012,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.2967857609161957
+      },
+      {
+        "run": 86,
+        "seed": 1150672244,
+        "success": false,
+        "steps": 351,
+        "total_reward": 22.875000000000306,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.5350487675882224
+      },
+      {
+        "run": 87,
+        "seed": 1150672245,
+        "success": true,
+        "steps": 301,
+        "total_reward": 30.625000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3204261165764254
+      },
+      {
+        "run": 88,
+        "seed": 1150672246,
+        "success": true,
+        "steps": 179,
+        "total_reward": 28.295000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4611301674650571
+      },
+      {
+        "run": 89,
+        "seed": 1150672247,
+        "success": false,
+        "steps": 25,
+        "total_reward": -7.775,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.3
+      },
+      {
+        "run": 90,
+        "seed": 1150672248,
+        "success": true,
+        "steps": 259,
+        "total_reward": 30.04500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3894467754467755
+      },
+      {
+        "run": 91,
+        "seed": 1150672249,
+        "success": true,
+        "steps": 283,
+        "total_reward": 38.07500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34886414335520644
+      },
+      {
+        "run": 92,
+        "seed": 1150672250,
+        "success": false,
+        "steps": 165,
+        "total_reward": -3.955000000000023,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.475098814229249
+      },
+      {
+        "run": 93,
+        "seed": 1150672251,
+        "success": true,
+        "steps": 236,
+        "total_reward": 29.200000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3406694289790242
+      },
+      {
+        "run": 94,
+        "seed": 1150672252,
+        "success": true,
+        "steps": 214,
+        "total_reward": 31.480000000000103,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4405325087475189
+      },
+      {
+        "run": 95,
+        "seed": 1150672253,
+        "success": true,
+        "steps": 217,
+        "total_reward": 35.705000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43517426679012045
+      },
+      {
+        "run": 96,
+        "seed": 1150672254,
+        "success": true,
+        "steps": 195,
+        "total_reward": 35.1250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.451883979547023
+      },
+      {
+        "run": 97,
+        "seed": 1150672255,
+        "success": true,
+        "steps": 167,
+        "total_reward": 29.015000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44804430863254396
+      },
+      {
+        "run": 98,
+        "seed": 1150672256,
+        "success": true,
+        "steps": 226,
+        "total_reward": 34.89000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3790281367163097
+      },
+      {
+        "run": 99,
+        "seed": 1150672257,
+        "success": true,
+        "steps": 253,
+        "total_reward": 27.255000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31413417998790527
+      },
+      {
+        "run": 100,
+        "seed": 1150672258,
+        "success": false,
+        "steps": 121,
+        "total_reward": 7.335000000000008,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.3684635816692268
+      },
+      {
+        "run": 101,
+        "seed": 1150672259,
+        "success": false,
+        "steps": 120,
+        "total_reward": 8.200000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.45497076023391814
+      },
+      {
+        "run": 102,
+        "seed": 1150672260,
+        "success": true,
+        "steps": 266,
+        "total_reward": 38.32000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47814950234179
+      },
+      {
+        "run": 103,
+        "seed": 1150672261,
+        "success": true,
+        "steps": 209,
+        "total_reward": 28.135000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49133385766011084
+      },
+      {
+        "run": 104,
+        "seed": 1150672262,
+        "success": true,
+        "steps": 193,
+        "total_reward": 31.995000000000093,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.427744708994709
+      },
+      {
+        "run": 105,
+        "seed": 1150672263,
+        "success": false,
+        "steps": 191,
+        "total_reward": 25.085000000000093,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4199784167294427
+      },
+      {
+        "run": 106,
+        "seed": 1150672264,
+        "success": true,
+        "steps": 180,
+        "total_reward": 35.170000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47808694057920065
+      },
+      {
+        "run": 107,
+        "seed": 1150672265,
+        "success": true,
+        "steps": 171,
+        "total_reward": 37.09500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5853255292910465
+      },
+      {
+        "run": 108,
+        "seed": 1150672266,
+        "success": true,
+        "steps": 196,
+        "total_reward": 31.310000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44258169462116825
+      },
+      {
+        "run": 109,
+        "seed": 1150672267,
+        "success": true,
+        "steps": 209,
+        "total_reward": 28.51500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49331814522031914
+      },
+      {
+        "run": 110,
+        "seed": 1150672268,
+        "success": true,
+        "steps": 259,
+        "total_reward": 38.9450000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37967851726401264
+      },
+      {
+        "run": 111,
+        "seed": 1150672269,
+        "success": false,
+        "steps": 78,
+        "total_reward": 6.5699999999999825,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5256060606060606
+      },
+      {
+        "run": 112,
+        "seed": 1150672270,
+        "success": true,
+        "steps": 257,
+        "total_reward": 24.56500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3271315946925703
+      },
+      {
+        "run": 113,
+        "seed": 1150672271,
+        "success": true,
+        "steps": 234,
+        "total_reward": 34.67000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3719968944099379
+      },
+      {
+        "run": 114,
+        "seed": 1150672272,
+        "success": true,
+        "steps": 274,
+        "total_reward": 29.890000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3589297419612738
+      },
+      {
+        "run": 115,
+        "seed": 1150672273,
+        "success": true,
+        "steps": 317,
+        "total_reward": 43.385000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4068638862328225
+      },
+      {
+        "run": 116,
+        "seed": 1150672274,
+        "success": true,
+        "steps": 253,
+        "total_reward": 27.685000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4015597536994596
+      },
+      {
+        "run": 117,
+        "seed": 1150672275,
+        "success": true,
+        "steps": 369,
+        "total_reward": 30.93500000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30190923129443853
+      },
+      {
+        "run": 118,
+        "seed": 1150672276,
+        "success": false,
+        "steps": 79,
+        "total_reward": 5.154999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.545673076923077
+      },
+      {
+        "run": 119,
+        "seed": 1150672277,
+        "success": true,
+        "steps": 155,
+        "total_reward": 31.815000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5111310911310911
+      },
+      {
+        "run": 120,
+        "seed": 1150672278,
+        "success": true,
+        "steps": 258,
+        "total_reward": 27.090000000000032,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33114774114774115
+      },
+      {
+        "run": 121,
+        "seed": 1150672279,
+        "success": true,
+        "steps": 165,
+        "total_reward": 34.31500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5302162900620251
+      },
+      {
+        "run": 122,
+        "seed": 1150672280,
+        "success": true,
+        "steps": 179,
+        "total_reward": 30.73500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4878571428571428
+      },
+      {
+        "run": 123,
+        "seed": 1150672281,
+        "success": false,
+        "steps": 100,
+        "total_reward": -0.920000000000007,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.33608979823813584
+      },
+      {
+        "run": 124,
+        "seed": 1150672282,
+        "success": true,
+        "steps": 308,
+        "total_reward": 20.25000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3255031677960566
+      },
+      {
+        "run": 125,
+        "seed": 1150672283,
+        "success": true,
+        "steps": 228,
+        "total_reward": 37.99999999999998,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4130992318832609
+      },
+      {
+        "run": 126,
+        "seed": 1150672284,
+        "success": true,
+        "steps": 146,
+        "total_reward": 27.68000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5457624676664924
+      },
+      {
+        "run": 127,
+        "seed": 1150672285,
+        "success": true,
+        "steps": 208,
+        "total_reward": 34.4500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4639112137469924
+      },
+      {
+        "run": 128,
+        "seed": 1150672286,
+        "success": true,
+        "steps": 209,
+        "total_reward": 41.59500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4357143872054601
+      },
+      {
+        "run": 129,
+        "seed": 1150672287,
+        "success": false,
+        "steps": 21,
+        "total_reward": -8.255,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.5
+      },
+      {
+        "run": 130,
+        "seed": 1150672288,
+        "success": true,
+        "steps": 234,
+        "total_reward": 35.71000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40291911968281136
+      },
+      {
+        "run": 131,
+        "seed": 1150672289,
+        "success": false,
+        "steps": 186,
+        "total_reward": 24.560000000000073,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.47403499782154745
+      },
+      {
+        "run": 132,
+        "seed": 1150672290,
+        "success": false,
+        "steps": 161,
+        "total_reward": 3.724999999999982,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4749896928468357
+      },
+      {
+        "run": 133,
+        "seed": 1150672291,
+        "success": false,
+        "steps": 31,
+        "total_reward": -1.9049999999999976,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.7272727272727273
+      },
+      {
+        "run": 134,
+        "seed": 1150672292,
+        "success": true,
+        "steps": 264,
+        "total_reward": 37.73000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37987232208284843
+      },
+      {
+        "run": 135,
+        "seed": 1150672293,
+        "success": false,
+        "steps": 125,
+        "total_reward": 6.15499999999998,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.40550797241973713
+      },
+      {
+        "run": 136,
+        "seed": 1150672294,
+        "success": true,
+        "steps": 184,
+        "total_reward": 23.840000000000057,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33412995655282407
+      },
+      {
+        "run": 137,
+        "seed": 1150672295,
+        "success": true,
+        "steps": 201,
+        "total_reward": 34.23500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3925062607957345
+      },
+      {
+        "run": 138,
+        "seed": 1150672296,
+        "success": true,
+        "steps": 167,
+        "total_reward": 28.455000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5363381716322893
+      },
+      {
+        "run": 139,
+        "seed": 1150672297,
+        "success": true,
+        "steps": 346,
+        "total_reward": 30.900000000000258,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42019338203695744
+      },
+      {
+        "run": 140,
+        "seed": 1150672298,
+        "success": false,
+        "steps": 74,
+        "total_reward": 8.08999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.6476608187134504
+      },
+      {
+        "run": 141,
+        "seed": 1150672299,
+        "success": true,
+        "steps": 281,
+        "total_reward": 31.745000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32269624612297027
+      },
+      {
+        "run": 142,
+        "seed": 1150672300,
+        "success": true,
+        "steps": 309,
+        "total_reward": 31.435000000000127,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34361331931051137
+      },
+      {
+        "run": 143,
+        "seed": 1150672301,
+        "success": true,
+        "steps": 207,
+        "total_reward": 28.185000000000077,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4344754400189183
+      },
+      {
+        "run": 144,
+        "seed": 1150672302,
+        "success": true,
+        "steps": 303,
+        "total_reward": 36.96500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33314408584857
+      },
+      {
+        "run": 145,
+        "seed": 1150672303,
+        "success": true,
+        "steps": 244,
+        "total_reward": 44.82000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39411328318352745
+      },
+      {
+        "run": 146,
+        "seed": 1150672304,
+        "success": true,
+        "steps": 249,
+        "total_reward": 27.975000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37478667280116557
+      },
+      {
+        "run": 147,
+        "seed": 1150672305,
+        "success": true,
+        "steps": 186,
+        "total_reward": 27.08000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42479498068871885
+      },
+      {
+        "run": 148,
+        "seed": 1150672306,
+        "success": true,
+        "steps": 289,
+        "total_reward": 36.215000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3631789037454062
+      },
+      {
+        "run": 149,
+        "seed": 1150672307,
+        "success": true,
+        "steps": 171,
+        "total_reward": 28.55500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48425529063299966
+      },
+      {
+        "run": 150,
+        "seed": 1150672308,
+        "success": true,
+        "steps": 442,
+        "total_reward": 33.480000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.326237442084229
+      },
+      {
+        "run": 151,
+        "seed": 1150672309,
+        "success": true,
+        "steps": 210,
+        "total_reward": 32.6000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3685196942161063
+      },
+      {
+        "run": 152,
+        "seed": 1150672310,
+        "success": true,
+        "steps": 224,
+        "total_reward": 42.62000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46813825696988565
+      },
+      {
+        "run": 153,
+        "seed": 1150672311,
+        "success": false,
+        "steps": 170,
+        "total_reward": 28.830000000000112,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.5234257988323029
+      },
+      {
+        "run": 154,
+        "seed": 1150672312,
+        "success": true,
+        "steps": 203,
+        "total_reward": 36.63500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43570171057013163
+      },
+      {
+        "run": 155,
+        "seed": 1150672313,
+        "success": true,
+        "steps": 239,
+        "total_reward": 31.755000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4018279680244364
+      },
+      {
+        "run": 156,
+        "seed": 1150672314,
+        "success": false,
+        "steps": 147,
+        "total_reward": 19.185000000000056,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5198105407664231
+      },
+      {
+        "run": 157,
+        "seed": 1150672315,
+        "success": true,
+        "steps": 212,
+        "total_reward": 33.080000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3804950768186062
+      },
+      {
+        "run": 158,
+        "seed": 1150672316,
+        "success": true,
+        "steps": 205,
+        "total_reward": 31.275000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3795233032075137
+      },
+      {
+        "run": 159,
+        "seed": 1150672317,
+        "success": true,
+        "steps": 162,
+        "total_reward": 35.69000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5458817571317571
+      },
+      {
+        "run": 160,
+        "seed": 1150672318,
+        "success": true,
+        "steps": 233,
+        "total_reward": 38.50500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4472317546001756
+      },
+      {
+        "run": 161,
+        "seed": 1150672319,
+        "success": true,
+        "steps": 201,
+        "total_reward": 28.27500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4411654004204427
+      },
+      {
+        "run": 162,
+        "seed": 1150672320,
+        "success": false,
+        "steps": 106,
+        "total_reward": 3.990000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4838095238095238
+      },
+      {
+        "run": 163,
+        "seed": 1150672321,
+        "success": true,
+        "steps": 201,
+        "total_reward": 35.6150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4619249772295618
+      },
+      {
+        "run": 164,
+        "seed": 1150672322,
+        "success": true,
+        "steps": 210,
+        "total_reward": 23.700000000000028,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4444729390549824
+      },
+      {
+        "run": 165,
+        "seed": 1150672323,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.75500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4317824152530035
+      },
+      {
+        "run": 166,
+        "seed": 1150672324,
+        "success": true,
+        "steps": 247,
+        "total_reward": 36.29500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3702442339594042
+      },
+      {
+        "run": 167,
+        "seed": 1150672325,
+        "success": true,
+        "steps": 214,
+        "total_reward": 34.51000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47912953060011887
+      },
+      {
+        "run": 168,
+        "seed": 1150672326,
+        "success": true,
+        "steps": 272,
+        "total_reward": 36.46000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36291381757171226
+      },
+      {
+        "run": 169,
+        "seed": 1150672327,
+        "success": false,
+        "steps": 381,
+        "total_reward": 11.535000000000242,
+        "termination_reason": "starved",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3998437304163672
+      },
+      {
+        "run": 170,
+        "seed": 1150672328,
+        "success": true,
+        "steps": 321,
+        "total_reward": 43.18500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4502228589356109
+      },
+      {
+        "run": 171,
+        "seed": 1150672329,
+        "success": true,
+        "steps": 297,
+        "total_reward": 37.11500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4673778213400855
+      },
+      {
+        "run": 172,
+        "seed": 1150672330,
+        "success": false,
+        "steps": 188,
+        "total_reward": 15.920000000000055,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.3200303473080814
+      },
+      {
+        "run": 173,
+        "seed": 1150672331,
+        "success": true,
+        "steps": 289,
+        "total_reward": 21.335000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33274186774186776
+      },
+      {
+        "run": 174,
+        "seed": 1150672332,
+        "success": true,
+        "steps": 325,
+        "total_reward": 28.80500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27799203607062156
+      },
+      {
+        "run": 175,
+        "seed": 1150672333,
+        "success": true,
+        "steps": 213,
+        "total_reward": 31.64500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3876226577000571
+      },
+      {
+        "run": 176,
+        "seed": 1150672334,
+        "success": false,
+        "steps": 130,
+        "total_reward": 13.340000000000007,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4991324535679374
+      },
+      {
+        "run": 177,
+        "seed": 1150672335,
+        "success": true,
+        "steps": 225,
+        "total_reward": 35.60500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41719228870726877
+      },
+      {
+        "run": 178,
+        "seed": 1150672336,
+        "success": true,
+        "steps": 200,
+        "total_reward": 28.420000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4211179011179011
+      },
+      {
+        "run": 179,
+        "seed": 1150672337,
+        "success": true,
+        "steps": 164,
+        "total_reward": 33.57000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47614847968172774
+      },
+      {
+        "run": 180,
+        "seed": 1150672338,
+        "success": false,
+        "steps": 60,
+        "total_reward": 2.309999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.5111111111111111
+      },
+      {
+        "run": 181,
+        "seed": 1150672339,
+        "success": true,
+        "steps": 325,
+        "total_reward": 20.31500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4700442085262385
+      },
+      {
+        "run": 182,
+        "seed": 1150672340,
+        "success": true,
+        "steps": 203,
+        "total_reward": 34.76500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43310116354234
+      },
+      {
+        "run": 183,
+        "seed": 1150672341,
+        "success": true,
+        "steps": 216,
+        "total_reward": 32.55000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4481879702218685
+      },
+      {
+        "run": 184,
+        "seed": 1150672342,
+        "success": true,
+        "steps": 290,
+        "total_reward": 34.89000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4098247863247863
+      },
+      {
+        "run": 185,
+        "seed": 1150672343,
+        "success": true,
+        "steps": 287,
+        "total_reward": 28.105000000000043,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34303606727096614
+      },
+      {
+        "run": 186,
+        "seed": 1150672344,
+        "success": true,
+        "steps": 193,
+        "total_reward": 22.505000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39443523536857095
+      },
+      {
+        "run": 187,
+        "seed": 1150672345,
+        "success": true,
+        "steps": 303,
+        "total_reward": 24.145000000000152,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42730826978878467
+      },
+      {
+        "run": 188,
+        "seed": 1150672346,
+        "success": true,
+        "steps": 251,
+        "total_reward": 27.39500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5242489421878531
+      },
+      {
+        "run": 189,
+        "seed": 1150672347,
+        "success": true,
+        "steps": 231,
+        "total_reward": 25.955000000000048,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36850586611456176
+      },
+      {
+        "run": 190,
+        "seed": 1150672348,
+        "success": true,
+        "steps": 282,
+        "total_reward": 34.54000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2958338991059579
+      },
+      {
+        "run": 191,
+        "seed": 1150672349,
+        "success": true,
+        "steps": 218,
+        "total_reward": 33.01000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4704581220749562
+      },
+      {
+        "run": 192,
+        "seed": 1150672350,
+        "success": false,
+        "steps": 138,
+        "total_reward": 11.219999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.47998192283906566
+      },
+      {
+        "run": 193,
+        "seed": 1150672351,
+        "success": true,
+        "steps": 238,
+        "total_reward": 35.850000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4257818459191457
+      },
+      {
+        "run": 194,
+        "seed": 1150672352,
+        "success": true,
+        "steps": 231,
+        "total_reward": 37.43500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5198949135659662
+      },
+      {
+        "run": 195,
+        "seed": 1150672353,
+        "success": true,
+        "steps": 284,
+        "total_reward": 38.34000000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4424281032060918
+      },
+      {
+        "run": 196,
+        "seed": 1150672354,
+        "success": true,
+        "steps": 260,
+        "total_reward": 28.350000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32489693149710125
+      },
+      {
+        "run": 197,
+        "seed": 1150672355,
+        "success": true,
+        "steps": 247,
+        "total_reward": 38.71500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41291873654324573
+      },
+      {
+        "run": 198,
+        "seed": 1150672356,
+        "success": true,
+        "steps": 179,
+        "total_reward": 27.985000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4331116106116106
+      },
+      {
+        "run": 199,
+        "seed": 1150672357,
+        "success": true,
+        "steps": 198,
+        "total_reward": 31.670000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4472664483853742
+      },
+      {
+        "run": 200,
+        "seed": 1150672358,
+        "success": true,
+        "steps": 199,
+        "total_reward": 32.42500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37820275293622985
+      }
+    ],
+    "avg_chemotaxis_index": 0.2851008269047106,
+    "avg_time_in_attractant": 0.6425504134523553,
+    "avg_approach_frequency": 0.3935668608531444,
+    "avg_path_efficiency": 0.03599385401106045,
+    "post_convergence_chemotaxis_index": 0.3091644907878868,
+    "post_convergence_time_in_attractant": 0.6545822453939434,
+    "post_convergence_approach_frequency": 0.39507343268004597,
+    "post_convergence_path_efficiency": 0.034347508944483435,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_101750.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_101750.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_101750",
+  "timestamp": "2025-12-29T10:28:01.450470+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_101750",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.67,
+    "avg_steps": 230.205,
+    "avg_reward": 22.601825000000066,
+    "avg_foods_collected": 8.165,
+    "avg_distance_efficiency": 0.3580934619266393,
+    "completed_all_food": 134,
+    "starved": 10,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 56,
+    "avg_predator_encounters": 8.665,
+    "avg_successful_evasions": 8.135,
+    "converged": true,
+    "convergence_run": 122,
+    "runs_to_convergence": 121,
+    "post_convergence_success_rate": 0.7974683544303798,
+    "post_convergence_avg_steps": 240.87301587301587,
+    "post_convergence_avg_foods": 9.08860759493671,
+    "post_convergence_variance": 0.161512578112482,
+    "post_convergence_distance_efficiency": 0.40514556297941084,
+    "composite_benchmark_score": 0.5387747216097342,
+    "learning_speed": 0.86,
+    "learning_speed_episodes": 28,
+    "stability": 0.49604736932103033,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 642802586,
+        "success": false,
+        "steps": 200,
+        "total_reward": -13.199999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 642802587,
+        "success": false,
+        "steps": 200,
+        "total_reward": -10.339999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 642802588,
+        "success": false,
+        "steps": 206,
+        "total_reward": -8.939999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.03614457831325301
+      },
+      {
+        "run": 4,
+        "seed": 642802589,
+        "success": false,
+        "steps": 165,
+        "total_reward": -9.894999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.09705882352941177
+      },
+      {
+        "run": 5,
+        "seed": 642802590,
+        "success": false,
+        "steps": 200,
+        "total_reward": -9.389999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 6,
+        "seed": 642802591,
+        "success": false,
+        "steps": 166,
+        "total_reward": -9.049999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.20826330532212886
+      },
+      {
+        "run": 7,
+        "seed": 642802592,
+        "success": false,
+        "steps": 130,
+        "total_reward": -8.040000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 8,
+        "seed": 642802593,
+        "success": false,
+        "steps": 280,
+        "total_reward": -10.679999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.1142857142857143
+      },
+      {
+        "run": 9,
+        "seed": 642802594,
+        "success": false,
+        "steps": 28,
+        "total_reward": -9.32,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 10,
+        "seed": 642802595,
+        "success": false,
+        "steps": 280,
+        "total_reward": -5.390000000000015,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.07953394123606888
+      },
+      {
+        "run": 11,
+        "seed": 642802596,
+        "success": false,
+        "steps": 320,
+        "total_reward": 4.7199999999999385,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.19556913674560736
+      },
+      {
+        "run": 12,
+        "seed": 642802597,
+        "success": false,
+        "steps": 36,
+        "total_reward": -14.55,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 13,
+        "seed": 642802598,
+        "success": false,
+        "steps": 280,
+        "total_reward": -3.2700000000000458,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.14835164835164835
+      },
+      {
+        "run": 14,
+        "seed": 642802599,
+        "success": false,
+        "steps": 261,
+        "total_reward": 7.785000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.2717692338403801
+      },
+      {
+        "run": 15,
+        "seed": 642802600,
+        "success": false,
+        "steps": 100,
+        "total_reward": -10.189999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.22857142857142856
+      },
+      {
+        "run": 16,
+        "seed": 642802601,
+        "success": false,
+        "steps": 38,
+        "total_reward": -9.190000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 17,
+        "seed": 642802602,
+        "success": false,
+        "steps": 412,
+        "total_reward": -1.4500000000000544,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.1855994575627344
+      },
+      {
+        "run": 18,
+        "seed": 642802603,
+        "success": false,
+        "steps": 97,
+        "total_reward": -8.494999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.38461538461538464
+      },
+      {
+        "run": 19,
+        "seed": 642802604,
+        "success": false,
+        "steps": 240,
+        "total_reward": -4.309999999999992,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.03977272727272727
+      },
+      {
+        "run": 20,
+        "seed": 642802605,
+        "success": true,
+        "steps": 290,
+        "total_reward": 26.710000000000047,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3507879919470308
+      },
+      {
+        "run": 21,
+        "seed": 642802606,
+        "success": true,
+        "steps": 364,
+        "total_reward": 26.140000000000132,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2649628831820613
+      },
+      {
+        "run": 22,
+        "seed": 642802607,
+        "success": true,
+        "steps": 486,
+        "total_reward": 34.750000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23635638418639893
+      },
+      {
+        "run": 23,
+        "seed": 642802608,
+        "success": false,
+        "steps": 433,
+        "total_reward": 9.874999999999964,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.2573080734963703
+      },
+      {
+        "run": 24,
+        "seed": 642802609,
+        "success": true,
+        "steps": 350,
+        "total_reward": 31.6900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2855974919135521
+      },
+      {
+        "run": 25,
+        "seed": 642802610,
+        "success": true,
+        "steps": 361,
+        "total_reward": 32.825000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21214757985703395
+      },
+      {
+        "run": 26,
+        "seed": 642802611,
+        "success": true,
+        "steps": 268,
+        "total_reward": 31.640000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41631168348559655
+      },
+      {
+        "run": 27,
+        "seed": 642802612,
+        "success": true,
+        "steps": 306,
+        "total_reward": 26.460000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30418198231820526
+      },
+      {
+        "run": 28,
+        "seed": 642802613,
+        "success": true,
+        "steps": 386,
+        "total_reward": 28.720000000000127,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2753606666238245
+      },
+      {
+        "run": 29,
+        "seed": 642802614,
+        "success": true,
+        "steps": 236,
+        "total_reward": 25.900000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34989546738678357
+      },
+      {
+        "run": 30,
+        "seed": 642802615,
+        "success": true,
+        "steps": 237,
+        "total_reward": 28.905000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3279932492332407
+      },
+      {
+        "run": 31,
+        "seed": 642802616,
+        "success": true,
+        "steps": 344,
+        "total_reward": 31.090000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29881376842294133
+      },
+      {
+        "run": 32,
+        "seed": 642802617,
+        "success": false,
+        "steps": 311,
+        "total_reward": 23.695000000000213,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.361367148678976
+      },
+      {
+        "run": 33,
+        "seed": 642802618,
+        "success": false,
+        "steps": 214,
+        "total_reward": 20.280000000000108,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.3903607019476113
+      },
+      {
+        "run": 34,
+        "seed": 642802619,
+        "success": true,
+        "steps": 269,
+        "total_reward": 30.16500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34593589913442857
+      },
+      {
+        "run": 35,
+        "seed": 642802620,
+        "success": false,
+        "steps": 80,
+        "total_reward": 0.6800000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4778121775025799
+      },
+      {
+        "run": 36,
+        "seed": 642802621,
+        "success": true,
+        "steps": 297,
+        "total_reward": 24.78500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3150728407658622
+      },
+      {
+        "run": 37,
+        "seed": 642802622,
+        "success": false,
+        "steps": 325,
+        "total_reward": 6.215000000000103,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.2857773386034256
+      },
+      {
+        "run": 38,
+        "seed": 642802623,
+        "success": true,
+        "steps": 202,
+        "total_reward": 29.520000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43101232277908846
+      },
+      {
+        "run": 39,
+        "seed": 642802624,
+        "success": false,
+        "steps": 160,
+        "total_reward": 14.220000000000013,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.44041213416213415
+      },
+      {
+        "run": 40,
+        "seed": 642802625,
+        "success": true,
+        "steps": 324,
+        "total_reward": 31.220000000000173,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36035892024303656
+      },
+      {
+        "run": 41,
+        "seed": 642802626,
+        "success": false,
+        "steps": 103,
+        "total_reward": 4.194999999999979,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3893939393939394
+      },
+      {
+        "run": 42,
+        "seed": 642802627,
+        "success": true,
+        "steps": 259,
+        "total_reward": 30.545000000000112,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2996955578760964
+      },
+      {
+        "run": 43,
+        "seed": 642802628,
+        "success": true,
+        "steps": 370,
+        "total_reward": 40.25000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36862329309989406
+      },
+      {
+        "run": 44,
+        "seed": 642802629,
+        "success": true,
+        "steps": 309,
+        "total_reward": 39.05500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32284736295248695
+      },
+      {
+        "run": 45,
+        "seed": 642802630,
+        "success": true,
+        "steps": 239,
+        "total_reward": 23.765000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33606626233185294
+      },
+      {
+        "run": 46,
+        "seed": 642802631,
+        "success": false,
+        "steps": 139,
+        "total_reward": 3.1949999999999825,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.32784033400809715
+      },
+      {
+        "run": 47,
+        "seed": 642802632,
+        "success": true,
+        "steps": 464,
+        "total_reward": 27.6000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.221551472055756
+      },
+      {
+        "run": 48,
+        "seed": 642802633,
+        "success": false,
+        "steps": 53,
+        "total_reward": -4.994999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.34007936507936504
+      },
+      {
+        "run": 49,
+        "seed": 642802634,
+        "success": true,
+        "steps": 191,
+        "total_reward": 23.06500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4869028194028194
+      },
+      {
+        "run": 50,
+        "seed": 642802635,
+        "success": true,
+        "steps": 231,
+        "total_reward": 24.525000000000038,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3115182494402443
+      },
+      {
+        "run": 51,
+        "seed": 642802636,
+        "success": true,
+        "steps": 235,
+        "total_reward": 33.4050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39261906841418115
+      },
+      {
+        "run": 52,
+        "seed": 642802637,
+        "success": true,
+        "steps": 200,
+        "total_reward": 26.32000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3686460826754944
+      },
+      {
+        "run": 53,
+        "seed": 642802638,
+        "success": true,
+        "steps": 297,
+        "total_reward": 31.60500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31715591798545706
+      },
+      {
+        "run": 54,
+        "seed": 642802639,
+        "success": true,
+        "steps": 158,
+        "total_reward": 27.510000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5148258157612997
+      },
+      {
+        "run": 55,
+        "seed": 642802640,
+        "success": true,
+        "steps": 322,
+        "total_reward": 19.349999999999977,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27970956684757675
+      },
+      {
+        "run": 56,
+        "seed": 642802641,
+        "success": true,
+        "steps": 379,
+        "total_reward": 42.77500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3728981054124365
+      },
+      {
+        "run": 57,
+        "seed": 642802642,
+        "success": false,
+        "steps": 133,
+        "total_reward": 6.034999999999993,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3372727272727273
+      },
+      {
+        "run": 58,
+        "seed": 642802643,
+        "success": false,
+        "steps": 260,
+        "total_reward": 14.880000000000127,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.5146210931925218
+      },
+      {
+        "run": 59,
+        "seed": 642802644,
+        "success": true,
+        "steps": 262,
+        "total_reward": 30.220000000000137,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37808337627025057
+      },
+      {
+        "run": 60,
+        "seed": 642802645,
+        "success": true,
+        "steps": 282,
+        "total_reward": 42.43000000000024,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41831634890559377
+      },
+      {
+        "run": 61,
+        "seed": 642802646,
+        "success": false,
+        "steps": 104,
+        "total_reward": 1.9399999999999906,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.4411706349206349
+      },
+      {
+        "run": 62,
+        "seed": 642802647,
+        "success": false,
+        "steps": 119,
+        "total_reward": 10.785000000000007,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.47012108262108265
+      },
+      {
+        "run": 63,
+        "seed": 642802648,
+        "success": true,
+        "steps": 263,
+        "total_reward": 32.51500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3403071365047935
+      },
+      {
+        "run": 64,
+        "seed": 642802649,
+        "success": false,
+        "steps": 48,
+        "total_reward": -2.299999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.3205128205128205
+      },
+      {
+        "run": 65,
+        "seed": 642802650,
+        "success": true,
+        "steps": 410,
+        "total_reward": 46.130000000000294,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37947650817951
+      },
+      {
+        "run": 66,
+        "seed": 642802651,
+        "success": true,
+        "steps": 185,
+        "total_reward": 30.965000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48986928104575167
+      },
+      {
+        "run": 67,
+        "seed": 642802652,
+        "success": true,
+        "steps": 252,
+        "total_reward": 24.150000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3776102224239074
+      },
+      {
+        "run": 68,
+        "seed": 642802653,
+        "success": true,
+        "steps": 228,
+        "total_reward": 36.59000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4077131987882495
+      },
+      {
+        "run": 69,
+        "seed": 642802654,
+        "success": true,
+        "steps": 321,
+        "total_reward": 26.81500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33989157646090373
+      },
+      {
+        "run": 70,
+        "seed": 642802655,
+        "success": false,
+        "steps": 272,
+        "total_reward": 17.680000000000096,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.29122240124119825
+      },
+      {
+        "run": 71,
+        "seed": 642802656,
+        "success": true,
+        "steps": 198,
+        "total_reward": 33.53000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3956111054408268
+      },
+      {
+        "run": 72,
+        "seed": 642802657,
+        "success": true,
+        "steps": 227,
+        "total_reward": 37.995000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4295887360933718
+      },
+      {
+        "run": 73,
+        "seed": 642802658,
+        "success": true,
+        "steps": 272,
+        "total_reward": 33.90000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32584415159840885
+      },
+      {
+        "run": 74,
+        "seed": 642802659,
+        "success": true,
+        "steps": 292,
+        "total_reward": 28.63000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2964535874426446
+      },
+      {
+        "run": 75,
+        "seed": 642802660,
+        "success": true,
+        "steps": 237,
+        "total_reward": 33.67500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3865614129057525
+      },
+      {
+        "run": 76,
+        "seed": 642802661,
+        "success": true,
+        "steps": 254,
+        "total_reward": 33.02000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3535613241062059
+      },
+      {
+        "run": 77,
+        "seed": 642802662,
+        "success": true,
+        "steps": 191,
+        "total_reward": 23.695000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3613005396676796
+      },
+      {
+        "run": 78,
+        "seed": 642802663,
+        "success": true,
+        "steps": 193,
+        "total_reward": 35.135000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4449147173489279
+      },
+      {
+        "run": 79,
+        "seed": 642802664,
+        "success": false,
+        "steps": 151,
+        "total_reward": -4.5450000000000035,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.5238095238095238
+      },
+      {
+        "run": 80,
+        "seed": 642802665,
+        "success": true,
+        "steps": 302,
+        "total_reward": 39.33000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35474782114437287
+      },
+      {
+        "run": 81,
+        "seed": 642802666,
+        "success": false,
+        "steps": 64,
+        "total_reward": -1.1199999999999992,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.43333333333333335
+      },
+      {
+        "run": 82,
+        "seed": 642802667,
+        "success": true,
+        "steps": 209,
+        "total_reward": 27.615000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41841794090370943
+      },
+      {
+        "run": 83,
+        "seed": 642802668,
+        "success": true,
+        "steps": 223,
+        "total_reward": 29.385000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42302909267528205
+      },
+      {
+        "run": 84,
+        "seed": 642802669,
+        "success": false,
+        "steps": 218,
+        "total_reward": 22.610000000000063,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.42584347827243535
+      },
+      {
+        "run": 85,
+        "seed": 642802670,
+        "success": false,
+        "steps": 216,
+        "total_reward": 13.840000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.3459989698711503
+      },
+      {
+        "run": 86,
+        "seed": 642802671,
+        "success": false,
+        "steps": 69,
+        "total_reward": -5.975,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.375
+      },
+      {
+        "run": 87,
+        "seed": 642802672,
+        "success": true,
+        "steps": 299,
+        "total_reward": 29.29500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32814703718176375
+      },
+      {
+        "run": 88,
+        "seed": 642802673,
+        "success": true,
+        "steps": 265,
+        "total_reward": 25.745000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2809749006321587
+      },
+      {
+        "run": 89,
+        "seed": 642802674,
+        "success": false,
+        "steps": 187,
+        "total_reward": 12.925000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.38173593761829056
+      },
+      {
+        "run": 90,
+        "seed": 642802675,
+        "success": true,
+        "steps": 319,
+        "total_reward": 37.865000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30677651816171736
+      },
+      {
+        "run": 91,
+        "seed": 642802676,
+        "success": true,
+        "steps": 227,
+        "total_reward": 29.85500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3825744843391902
+      },
+      {
+        "run": 92,
+        "seed": 642802677,
+        "success": true,
+        "steps": 231,
+        "total_reward": 31.54500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4345806010002723
+      },
+      {
+        "run": 93,
+        "seed": 642802678,
+        "success": true,
+        "steps": 306,
+        "total_reward": 44.9400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48582206953174695
+      },
+      {
+        "run": 94,
+        "seed": 642802679,
+        "success": true,
+        "steps": 291,
+        "total_reward": 28.40500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33406710299025766
+      },
+      {
+        "run": 95,
+        "seed": 642802680,
+        "success": true,
+        "steps": 163,
+        "total_reward": 29.325000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46865800865800866
+      },
+      {
+        "run": 96,
+        "seed": 642802681,
+        "success": true,
+        "steps": 226,
+        "total_reward": 25.470000000000038,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46687396557431315
+      },
+      {
+        "run": 97,
+        "seed": 642802682,
+        "success": true,
+        "steps": 243,
+        "total_reward": 24.335000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32860523529287833
+      },
+      {
+        "run": 98,
+        "seed": 642802683,
+        "success": true,
+        "steps": 309,
+        "total_reward": 35.49500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33639439074221683
+      },
+      {
+        "run": 99,
+        "seed": 642802684,
+        "success": false,
+        "steps": 87,
+        "total_reward": 5.194999999999986,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.48643543956043955
+      },
+      {
+        "run": 100,
+        "seed": 642802685,
+        "success": true,
+        "steps": 286,
+        "total_reward": 34.3900000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38725773273816316
+      },
+      {
+        "run": 101,
+        "seed": 642802686,
+        "success": true,
+        "steps": 240,
+        "total_reward": 30.830000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37600557590370687
+      },
+      {
+        "run": 102,
+        "seed": 642802687,
+        "success": true,
+        "steps": 199,
+        "total_reward": 32.65500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3894900128607025
+      },
+      {
+        "run": 103,
+        "seed": 642802688,
+        "success": true,
+        "steps": 195,
+        "total_reward": 31.405000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46335590178644265
+      },
+      {
+        "run": 104,
+        "seed": 642802689,
+        "success": true,
+        "steps": 227,
+        "total_reward": 30.41500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3862807884547015
+      },
+      {
+        "run": 105,
+        "seed": 642802690,
+        "success": false,
+        "steps": 301,
+        "total_reward": 21.76500000000014,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.31345899470899474
+      },
+      {
+        "run": 106,
+        "seed": 642802691,
+        "success": true,
+        "steps": 301,
+        "total_reward": 32.055000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31425589465613946
+      },
+      {
+        "run": 107,
+        "seed": 642802692,
+        "success": false,
+        "steps": 124,
+        "total_reward": -6.9799999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.3024936868686869
+      },
+      {
+        "run": 108,
+        "seed": 642802693,
+        "success": false,
+        "steps": 133,
+        "total_reward": 7.25500000000001,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.43333050391873923
+      },
+      {
+        "run": 109,
+        "seed": 642802694,
+        "success": true,
+        "steps": 305,
+        "total_reward": 39.18500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40434978179715025
+      },
+      {
+        "run": 110,
+        "seed": 642802695,
+        "success": true,
+        "steps": 347,
+        "total_reward": 26.775000000000098,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32652597277567685
+      },
+      {
+        "run": 111,
+        "seed": 642802696,
+        "success": true,
+        "steps": 361,
+        "total_reward": 33.67500000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3101747023468335
+      },
+      {
+        "run": 112,
+        "seed": 642802697,
+        "success": true,
+        "steps": 293,
+        "total_reward": 40.45500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35170324039889256
+      },
+      {
+        "run": 113,
+        "seed": 642802698,
+        "success": false,
+        "steps": 146,
+        "total_reward": 14.250000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4361152557705372
+      },
+      {
+        "run": 114,
+        "seed": 642802699,
+        "success": false,
+        "steps": 255,
+        "total_reward": 16.225000000000044,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3593145683468264
+      },
+      {
+        "run": 115,
+        "seed": 642802700,
+        "success": false,
+        "steps": 176,
+        "total_reward": 8.980000000000022,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.3285568772963731
+      },
+      {
+        "run": 116,
+        "seed": 642802701,
+        "success": true,
+        "steps": 214,
+        "total_reward": 31.930000000000078,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3815549022191673
+      },
+      {
+        "run": 117,
+        "seed": 642802702,
+        "success": true,
+        "steps": 259,
+        "total_reward": 27.395000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3667927094987462
+      },
+      {
+        "run": 118,
+        "seed": 642802703,
+        "success": false,
+        "steps": 42,
+        "total_reward": -5.679999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.36363636363636365
+      },
+      {
+        "run": 119,
+        "seed": 642802704,
+        "success": false,
+        "steps": 173,
+        "total_reward": 21.105000000000114,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.6063805052537447
+      },
+      {
+        "run": 120,
+        "seed": 642802705,
+        "success": true,
+        "steps": 280,
+        "total_reward": 27.050000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39252194503715804
+      },
+      {
+        "run": 121,
+        "seed": 642802706,
+        "success": false,
+        "steps": 238,
+        "total_reward": 18.18000000000005,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.32871077607312166
+      },
+      {
+        "run": 122,
+        "seed": 642802707,
+        "success": true,
+        "steps": 282,
+        "total_reward": 26.809999999999985,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37996256547527385
+      },
+      {
+        "run": 123,
+        "seed": 642802708,
+        "success": true,
+        "steps": 277,
+        "total_reward": 36.66500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4192230008472496
+      },
+      {
+        "run": 124,
+        "seed": 642802709,
+        "success": true,
+        "steps": 185,
+        "total_reward": 34.2250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4302970539744587
+      },
+      {
+        "run": 125,
+        "seed": 642802710,
+        "success": true,
+        "steps": 175,
+        "total_reward": 21.215000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4256092527183858
+      },
+      {
+        "run": 126,
+        "seed": 642802711,
+        "success": true,
+        "steps": 344,
+        "total_reward": 24.639999999999997,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3698338804198657
+      },
+      {
+        "run": 127,
+        "seed": 642802712,
+        "success": true,
+        "steps": 243,
+        "total_reward": 36.59500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41662477307638596
+      },
+      {
+        "run": 128,
+        "seed": 642802713,
+        "success": true,
+        "steps": 285,
+        "total_reward": 33.96500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3303666637060346
+      },
+      {
+        "run": 129,
+        "seed": 642802714,
+        "success": true,
+        "steps": 219,
+        "total_reward": 25.70500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3972091844868028
+      },
+      {
+        "run": 130,
+        "seed": 642802715,
+        "success": true,
+        "steps": 216,
+        "total_reward": 37.94000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4995529765742532
+      },
+      {
+        "run": 131,
+        "seed": 642802716,
+        "success": true,
+        "steps": 225,
+        "total_reward": 30.995000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44025619117724385
+      },
+      {
+        "run": 132,
+        "seed": 642802717,
+        "success": true,
+        "steps": 261,
+        "total_reward": 33.125000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38683329869862376
+      },
+      {
+        "run": 133,
+        "seed": 642802718,
+        "success": true,
+        "steps": 231,
+        "total_reward": 29.185000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3861051146920712
+      },
+      {
+        "run": 134,
+        "seed": 642802719,
+        "success": false,
+        "steps": 191,
+        "total_reward": 19.035000000000093,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.4303420235416847
+      },
+      {
+        "run": 135,
+        "seed": 642802720,
+        "success": false,
+        "steps": 167,
+        "total_reward": 10.60499999999999,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.3866447012417407
+      },
+      {
+        "run": 136,
+        "seed": 642802721,
+        "success": true,
+        "steps": 214,
+        "total_reward": 24.94000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3395117465380623
+      },
+      {
+        "run": 137,
+        "seed": 642802722,
+        "success": true,
+        "steps": 232,
+        "total_reward": 38.05000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37876998001998
+      },
+      {
+        "run": 138,
+        "seed": 642802723,
+        "success": true,
+        "steps": 178,
+        "total_reward": 31.68000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48170485752064696
+      },
+      {
+        "run": 139,
+        "seed": 642802724,
+        "success": true,
+        "steps": 279,
+        "total_reward": 31.975000000000122,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34874701447977313
+      },
+      {
+        "run": 140,
+        "seed": 642802725,
+        "success": true,
+        "steps": 181,
+        "total_reward": 35.20500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4710926212590299
+      },
+      {
+        "run": 141,
+        "seed": 642802726,
+        "success": true,
+        "steps": 319,
+        "total_reward": 36.2550000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3273023551679508
+      },
+      {
+        "run": 142,
+        "seed": 642802727,
+        "success": false,
+        "steps": 225,
+        "total_reward": 7.715000000000007,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.31640852881454384
+      },
+      {
+        "run": 143,
+        "seed": 642802728,
+        "success": true,
+        "steps": 285,
+        "total_reward": 37.08500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3448657772672236
+      },
+      {
+        "run": 144,
+        "seed": 642802729,
+        "success": true,
+        "steps": 246,
+        "total_reward": 29.640000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3910907929873447
+      },
+      {
+        "run": 145,
+        "seed": 642802730,
+        "success": true,
+        "steps": 249,
+        "total_reward": 25.77500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47467448643856336
+      },
+      {
+        "run": 146,
+        "seed": 642802731,
+        "success": true,
+        "steps": 250,
+        "total_reward": 33.17000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4142941176470588
+      },
+      {
+        "run": 147,
+        "seed": 642802732,
+        "success": true,
+        "steps": 179,
+        "total_reward": 23.20500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45117435368209363
+      },
+      {
+        "run": 148,
+        "seed": 642802733,
+        "success": true,
+        "steps": 289,
+        "total_reward": 49.97500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3934823923121796
+      },
+      {
+        "run": 149,
+        "seed": 642802734,
+        "success": false,
+        "steps": 131,
+        "total_reward": 2.7650000000000023,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.26604489713185364
+      },
+      {
+        "run": 150,
+        "seed": 642802735,
+        "success": true,
+        "steps": 230,
+        "total_reward": 28.560000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39749694749694753
+      },
+      {
+        "run": 151,
+        "seed": 642802736,
+        "success": true,
+        "steps": 195,
+        "total_reward": 24.70500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4344514472455649
+      },
+      {
+        "run": 152,
+        "seed": 642802737,
+        "success": false,
+        "steps": 119,
+        "total_reward": 0.6049999999999898,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.26415619709525084
+      },
+      {
+        "run": 153,
+        "seed": 642802738,
+        "success": true,
+        "steps": 278,
+        "total_reward": 34.630000000000194,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31814622380891666
+      },
+      {
+        "run": 154,
+        "seed": 642802739,
+        "success": true,
+        "steps": 209,
+        "total_reward": 37.655000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40729702532401263
+      },
+      {
+        "run": 155,
+        "seed": 642802740,
+        "success": true,
+        "steps": 279,
+        "total_reward": 32.415000000000205,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32974327551533433
+      },
+      {
+        "run": 156,
+        "seed": 642802741,
+        "success": true,
+        "steps": 205,
+        "total_reward": 31.785000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.456528749028749
+      },
+      {
+        "run": 157,
+        "seed": 642802742,
+        "success": false,
+        "steps": 112,
+        "total_reward": 12.980000000000018,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5482295482295482
+      },
+      {
+        "run": 158,
+        "seed": 642802743,
+        "success": true,
+        "steps": 254,
+        "total_reward": 41.65000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42797480237213953
+      },
+      {
+        "run": 159,
+        "seed": 642802744,
+        "success": false,
+        "steps": 245,
+        "total_reward": 19.18500000000012,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.37903890490097386
+      },
+      {
+        "run": 160,
+        "seed": 642802745,
+        "success": false,
+        "steps": 130,
+        "total_reward": 7.829999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3547513788893099
+      },
+      {
+        "run": 161,
+        "seed": 642802746,
+        "success": true,
+        "steps": 247,
+        "total_reward": 31.865000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42114037922861447
+      },
+      {
+        "run": 162,
+        "seed": 642802747,
+        "success": false,
+        "steps": 149,
+        "total_reward": 0.5049999999999759,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.30378086419753086
+      },
+      {
+        "run": 163,
+        "seed": 642802748,
+        "success": false,
+        "steps": 53,
+        "total_reward": -3.7850000000000037,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.6238095238095238
+      },
+      {
+        "run": 164,
+        "seed": 642802749,
+        "success": true,
+        "steps": 172,
+        "total_reward": 27.110000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4530055954863257
+      },
+      {
+        "run": 165,
+        "seed": 642802750,
+        "success": false,
+        "steps": 123,
+        "total_reward": 1.374999999999993,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.33865079365079365
+      },
+      {
+        "run": 166,
+        "seed": 642802751,
+        "success": true,
+        "steps": 202,
+        "total_reward": 34.7600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5288507262176597
+      },
+      {
+        "run": 167,
+        "seed": 642802752,
+        "success": true,
+        "steps": 271,
+        "total_reward": 28.93500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3992737242716747
+      },
+      {
+        "run": 168,
+        "seed": 642802753,
+        "success": true,
+        "steps": 286,
+        "total_reward": 33.04000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37555124167733256
+      },
+      {
+        "run": 169,
+        "seed": 642802754,
+        "success": true,
+        "steps": 333,
+        "total_reward": 30.155000000000108,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3445002712341422
+      },
+      {
+        "run": 170,
+        "seed": 642802755,
+        "success": true,
+        "steps": 228,
+        "total_reward": 35.820000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39754736268229524
+      },
+      {
+        "run": 171,
+        "seed": 642802756,
+        "success": true,
+        "steps": 214,
+        "total_reward": 25.940000000000072,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3851116244866245
+      },
+      {
+        "run": 172,
+        "seed": 642802757,
+        "success": false,
+        "steps": 186,
+        "total_reward": 13.130000000000042,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.4578912559175717
+      },
+      {
+        "run": 173,
+        "seed": 642802758,
+        "success": true,
+        "steps": 204,
+        "total_reward": 32.7700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4219304812834225
+      },
+      {
+        "run": 174,
+        "seed": 642802759,
+        "success": true,
+        "steps": 248,
+        "total_reward": 28.640000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3556664781297134
+      },
+      {
+        "run": 175,
+        "seed": 642802760,
+        "success": true,
+        "steps": 234,
+        "total_reward": 26.870000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32152173913043475
+      },
+      {
+        "run": 176,
+        "seed": 642802761,
+        "success": true,
+        "steps": 222,
+        "total_reward": 42.180000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4648489215227933
+      },
+      {
+        "run": 177,
+        "seed": 642802762,
+        "success": true,
+        "steps": 240,
+        "total_reward": 35.740000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3842524142524143
+      },
+      {
+        "run": 178,
+        "seed": 642802763,
+        "success": true,
+        "steps": 328,
+        "total_reward": 38.780000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32039129457581106
+      },
+      {
+        "run": 179,
+        "seed": 642802764,
+        "success": true,
+        "steps": 313,
+        "total_reward": 29.955000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3276136830524876
+      },
+      {
+        "run": 180,
+        "seed": 642802765,
+        "success": false,
+        "steps": 125,
+        "total_reward": 16.95500000000004,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.473109243697479
+      },
+      {
+        "run": 181,
+        "seed": 642802766,
+        "success": true,
+        "steps": 228,
+        "total_reward": 35.40000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3922915428797782
+      },
+      {
+        "run": 182,
+        "seed": 642802767,
+        "success": true,
+        "steps": 161,
+        "total_reward": 32.755000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5066107316107316
+      },
+      {
+        "run": 183,
+        "seed": 642802768,
+        "success": false,
+        "steps": 221,
+        "total_reward": 12.865000000000013,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.33427928164770265
+      },
+      {
+        "run": 184,
+        "seed": 642802769,
+        "success": true,
+        "steps": 197,
+        "total_reward": 32.18500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43486693789566566
+      },
+      {
+        "run": 185,
+        "seed": 642802770,
+        "success": true,
+        "steps": 231,
+        "total_reward": 30.365000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38530679200195395
+      },
+      {
+        "run": 186,
+        "seed": 642802771,
+        "success": true,
+        "steps": 172,
+        "total_reward": 29.10000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4473400210900211
+      },
+      {
+        "run": 187,
+        "seed": 642802772,
+        "success": true,
+        "steps": 252,
+        "total_reward": 32.400000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4404859962878539
+      },
+      {
+        "run": 188,
+        "seed": 642802773,
+        "success": true,
+        "steps": 238,
+        "total_reward": 33.44000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3788198532534556
+      },
+      {
+        "run": 189,
+        "seed": 642802774,
+        "success": true,
+        "steps": 223,
+        "total_reward": 40.67500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4567455918065674
+      },
+      {
+        "run": 190,
+        "seed": 642802775,
+        "success": true,
+        "steps": 267,
+        "total_reward": 39.115000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37146955957356786
+      },
+      {
+        "run": 191,
+        "seed": 642802776,
+        "success": true,
+        "steps": 277,
+        "total_reward": 40.36500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41688897124380997
+      },
+      {
+        "run": 192,
+        "seed": 642802777,
+        "success": true,
+        "steps": 257,
+        "total_reward": 30.555000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4011277878849134
+      },
+      {
+        "run": 193,
+        "seed": 642802778,
+        "success": true,
+        "steps": 180,
+        "total_reward": 25.260000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4132142857142857
+      },
+      {
+        "run": 194,
+        "seed": 642802779,
+        "success": false,
+        "steps": 50,
+        "total_reward": -3.42,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.38124723573639985
+      },
+      {
+        "run": 195,
+        "seed": 642802780,
+        "success": false,
+        "steps": 105,
+        "total_reward": -7.305000000000013,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.4642857142857143
+      },
+      {
+        "run": 196,
+        "seed": 642802781,
+        "success": true,
+        "steps": 203,
+        "total_reward": 37.44500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49618367296780175
+      },
+      {
+        "run": 197,
+        "seed": 642802782,
+        "success": true,
+        "steps": 302,
+        "total_reward": 34.66000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3742737122293171
+      },
+      {
+        "run": 198,
+        "seed": 642802783,
+        "success": true,
+        "steps": 313,
+        "total_reward": 36.8250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4066652051652052
+      },
+      {
+        "run": 199,
+        "seed": 642802784,
+        "success": true,
+        "steps": 212,
+        "total_reward": 28.850000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.382365003417635
+      },
+      {
+        "run": 200,
+        "seed": 642802785,
+        "success": true,
+        "steps": 226,
+        "total_reward": 40.23000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4480859434903553
+      }
+    ],
+    "avg_chemotaxis_index": 0.2877214994907588,
+    "avg_time_in_attractant": 0.6438607497453794,
+    "avg_approach_frequency": 0.38645350167712805,
+    "avg_path_efficiency": 0.061657413415888714,
+    "post_convergence_chemotaxis_index": 0.32701313837079765,
+    "post_convergence_time_in_attractant": 0.6635065691853987,
+    "post_convergence_approach_frequency": 0.38883201174152154,
+    "post_convergence_path_efficiency": 0.05859249761912076,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_103141.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_103141.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_103141",
+  "timestamp": "2025-12-29T10:41:50.896886+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_103141",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.78,
+    "avg_steps": 228.21,
+    "avg_reward": 25.16890000000007,
+    "avg_foods_collected": 8.555,
+    "avg_distance_efficiency": 0.35651846100556805,
+    "completed_all_food": 156,
+    "starved": 8,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 36,
+    "avg_predator_encounters": 8.475,
+    "avg_successful_evasions": 8.05,
+    "converged": true,
+    "convergence_run": 42,
+    "runs_to_convergence": 41,
+    "post_convergence_success_rate": 0.8805031446540881,
+    "post_convergence_avg_steps": 239.60714285714286,
+    "post_convergence_avg_foods": 9.415094339622641,
+    "post_convergence_variance": 0.10521735690835016,
+    "post_convergence_distance_efficiency": 0.3946865233586635,
+    "composite_benchmark_score": 0.6769985364150592,
+    "learning_speed": 0.855,
+    "learning_speed_episodes": 29,
+    "stability": 0.6316058011934964,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 827597606,
+        "success": false,
+        "steps": 240,
+        "total_reward": -4.970000000000009,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.056
+      },
+      {
+        "run": 2,
+        "seed": 827597607,
+        "success": false,
+        "steps": 200,
+        "total_reward": -13.309999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 827597608,
+        "success": false,
+        "steps": 200,
+        "total_reward": -19.19000000000002,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 827597609,
+        "success": false,
+        "steps": 24,
+        "total_reward": -11.629999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 5,
+        "seed": 827597610,
+        "success": false,
+        "steps": 71,
+        "total_reward": -9.184999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 6,
+        "seed": 827597611,
+        "success": false,
+        "steps": 35,
+        "total_reward": -9.975,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 7,
+        "seed": 827597612,
+        "success": false,
+        "steps": 131,
+        "total_reward": -8.115,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 8,
+        "seed": 827597613,
+        "success": false,
+        "steps": 39,
+        "total_reward": -11.655000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 9,
+        "seed": 827597614,
+        "success": false,
+        "steps": 87,
+        "total_reward": -10.514999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 10,
+        "seed": 827597615,
+        "success": false,
+        "steps": 360,
+        "total_reward": 1.4899999999998954,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.1397200048978735
+      },
+      {
+        "run": 11,
+        "seed": 827597616,
+        "success": false,
+        "steps": 41,
+        "total_reward": -11.174999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 12,
+        "seed": 827597617,
+        "success": false,
+        "steps": 200,
+        "total_reward": -15.879999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 13,
+        "seed": 827597618,
+        "success": false,
+        "steps": 135,
+        "total_reward": -5.455000000000009,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.24949832775919734
+      },
+      {
+        "run": 14,
+        "seed": 827597619,
+        "success": false,
+        "steps": 320,
+        "total_reward": -0.38000000000006295,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.17198498964803313
+      },
+      {
+        "run": 15,
+        "seed": 827597620,
+        "success": false,
+        "steps": 154,
+        "total_reward": -20.320000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 16,
+        "seed": 827597621,
+        "success": false,
+        "steps": 320,
+        "total_reward": 4.809999999999924,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.1640076188320934
+      },
+      {
+        "run": 17,
+        "seed": 827597622,
+        "success": true,
+        "steps": 495,
+        "total_reward": 26.915000000000177,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22727903335063146
+      },
+      {
+        "run": 18,
+        "seed": 827597623,
+        "success": false,
+        "steps": 192,
+        "total_reward": -0.7999999999999918,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.27380952380952384
+      },
+      {
+        "run": 19,
+        "seed": 827597624,
+        "success": false,
+        "steps": 67,
+        "total_reward": -5.894999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3841269841269841
+      },
+      {
+        "run": 20,
+        "seed": 827597625,
+        "success": true,
+        "steps": 399,
+        "total_reward": 21.15499999999999,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2104248563985406
+      },
+      {
+        "run": 21,
+        "seed": 827597626,
+        "success": true,
+        "steps": 373,
+        "total_reward": 29.505000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24107596275492288
+      },
+      {
+        "run": 22,
+        "seed": 827597627,
+        "success": true,
+        "steps": 281,
+        "total_reward": 22.474999999999987,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36321950767696054
+      },
+      {
+        "run": 23,
+        "seed": 827597628,
+        "success": true,
+        "steps": 338,
+        "total_reward": 30.690000000000218,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3093798937332825
+      },
+      {
+        "run": 24,
+        "seed": 827597629,
+        "success": false,
+        "steps": 231,
+        "total_reward": 5.704999999999993,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.2613563654019398
+      },
+      {
+        "run": 25,
+        "seed": 827597630,
+        "success": false,
+        "steps": 225,
+        "total_reward": 13.015000000000022,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.24076365718636178
+      },
+      {
+        "run": 26,
+        "seed": 827597631,
+        "success": true,
+        "steps": 408,
+        "total_reward": 33.67000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.22487535659135016
+      },
+      {
+        "run": 27,
+        "seed": 827597632,
+        "success": true,
+        "steps": 257,
+        "total_reward": 33.09500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3436244872490195
+      },
+      {
+        "run": 28,
+        "seed": 827597633,
+        "success": true,
+        "steps": 338,
+        "total_reward": 26.860000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28082760678746077
+      },
+      {
+        "run": 29,
+        "seed": 827597634,
+        "success": true,
+        "steps": 287,
+        "total_reward": 24.335000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2963578528895835
+      },
+      {
+        "run": 30,
+        "seed": 827597635,
+        "success": false,
+        "steps": 225,
+        "total_reward": 9.925000000000022,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.3593255814782723
+      },
+      {
+        "run": 31,
+        "seed": 827597636,
+        "success": true,
+        "steps": 235,
+        "total_reward": 34.47500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4323929086193237
+      },
+      {
+        "run": 32,
+        "seed": 827597637,
+        "success": false,
+        "steps": 176,
+        "total_reward": 4.7499999999999805,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.24000797724750278
+      },
+      {
+        "run": 33,
+        "seed": 827597638,
+        "success": true,
+        "steps": 268,
+        "total_reward": 38.45000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3277726738053981
+      },
+      {
+        "run": 34,
+        "seed": 827597639,
+        "success": true,
+        "steps": 305,
+        "total_reward": 31.98500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33154952919658803
+      },
+      {
+        "run": 35,
+        "seed": 827597640,
+        "success": true,
+        "steps": 362,
+        "total_reward": 27.98000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23951347000912815
+      },
+      {
+        "run": 36,
+        "seed": 827597641,
+        "success": false,
+        "steps": 241,
+        "total_reward": 14.535000000000057,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.39367242648731987
+      },
+      {
+        "run": 37,
+        "seed": 827597642,
+        "success": true,
+        "steps": 278,
+        "total_reward": 30.90000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3167308931211974
+      },
+      {
+        "run": 38,
+        "seed": 827597643,
+        "success": true,
+        "steps": 298,
+        "total_reward": 32.61000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33547891771252425
+      },
+      {
+        "run": 39,
+        "seed": 827597644,
+        "success": true,
+        "steps": 334,
+        "total_reward": 25.290000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3110889056518843
+      },
+      {
+        "run": 40,
+        "seed": 827597645,
+        "success": false,
+        "steps": 130,
+        "total_reward": 1.9099999999999824,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.3357142857142857
+      },
+      {
+        "run": 41,
+        "seed": 827597646,
+        "success": false,
+        "steps": 58,
+        "total_reward": -3.790000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.43045112781954886
+      },
+      {
+        "run": 42,
+        "seed": 827597647,
+        "success": true,
+        "steps": 230,
+        "total_reward": 33.560000000000116,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4021406644666407
+      },
+      {
+        "run": 43,
+        "seed": 827597648,
+        "success": true,
+        "steps": 282,
+        "total_reward": 36.68000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3875924889646694
+      },
+      {
+        "run": 44,
+        "seed": 827597649,
+        "success": true,
+        "steps": 228,
+        "total_reward": 22.709999999999987,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34808767420491743
+      },
+      {
+        "run": 45,
+        "seed": 827597650,
+        "success": true,
+        "steps": 264,
+        "total_reward": 27.72000000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3545684666210982
+      },
+      {
+        "run": 46,
+        "seed": 827597651,
+        "success": true,
+        "steps": 312,
+        "total_reward": 37.27000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32441265145511694
+      },
+      {
+        "run": 47,
+        "seed": 827597652,
+        "success": true,
+        "steps": 344,
+        "total_reward": 23.980000000000032,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31175591615554976
+      },
+      {
+        "run": 48,
+        "seed": 827597653,
+        "success": true,
+        "steps": 194,
+        "total_reward": 37.360000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45789075892161446
+      },
+      {
+        "run": 49,
+        "seed": 827597654,
+        "success": true,
+        "steps": 218,
+        "total_reward": 21.429999999999996,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31698389914179387
+      },
+      {
+        "run": 50,
+        "seed": 827597655,
+        "success": true,
+        "steps": 144,
+        "total_reward": 32.65000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5434411670201145
+      },
+      {
+        "run": 51,
+        "seed": 827597656,
+        "success": true,
+        "steps": 215,
+        "total_reward": 35.34500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.421472362986756
+      },
+      {
+        "run": 52,
+        "seed": 827597657,
+        "success": true,
+        "steps": 208,
+        "total_reward": 35.37000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4708547008547009
+      },
+      {
+        "run": 53,
+        "seed": 827597658,
+        "success": true,
+        "steps": 336,
+        "total_reward": 27.04000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.296252941465597
+      },
+      {
+        "run": 54,
+        "seed": 827597659,
+        "success": true,
+        "steps": 348,
+        "total_reward": 20.58000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24862179949195787
+      },
+      {
+        "run": 55,
+        "seed": 827597660,
+        "success": true,
+        "steps": 236,
+        "total_reward": 32.830000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43127433591854725
+      },
+      {
+        "run": 56,
+        "seed": 827597661,
+        "success": true,
+        "steps": 256,
+        "total_reward": 32.71000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3772530958532906
+      },
+      {
+        "run": 57,
+        "seed": 827597662,
+        "success": true,
+        "steps": 300,
+        "total_reward": 44.89000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4350720591937282
+      },
+      {
+        "run": 58,
+        "seed": 827597663,
+        "success": true,
+        "steps": 255,
+        "total_reward": 27.574999999999996,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3737049424005946
+      },
+      {
+        "run": 59,
+        "seed": 827597664,
+        "success": true,
+        "steps": 301,
+        "total_reward": 40.795000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43059592430516347
+      },
+      {
+        "run": 60,
+        "seed": 827597665,
+        "success": false,
+        "steps": 64,
+        "total_reward": -10.689999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.2834008097165992
+      },
+      {
+        "run": 61,
+        "seed": 827597666,
+        "success": true,
+        "steps": 217,
+        "total_reward": 33.2750000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44587866230868256
+      },
+      {
+        "run": 62,
+        "seed": 827597667,
+        "success": true,
+        "steps": 294,
+        "total_reward": 38.870000000000225,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36632028789923526
+      },
+      {
+        "run": 63,
+        "seed": 827597668,
+        "success": false,
+        "steps": 105,
+        "total_reward": 7.164999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.35042735042735046
+      },
+      {
+        "run": 64,
+        "seed": 827597669,
+        "success": true,
+        "steps": 198,
+        "total_reward": 28.370000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4196123680241327
+      },
+      {
+        "run": 65,
+        "seed": 827597670,
+        "success": true,
+        "steps": 173,
+        "total_reward": 26.77500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4870756302521008
+      },
+      {
+        "run": 66,
+        "seed": 827597671,
+        "success": true,
+        "steps": 168,
+        "total_reward": 25.580000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4966906325284716
+      },
+      {
+        "run": 67,
+        "seed": 827597672,
+        "success": true,
+        "steps": 229,
+        "total_reward": 27.775000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.365414392860045
+      },
+      {
+        "run": 68,
+        "seed": 827597673,
+        "success": true,
+        "steps": 213,
+        "total_reward": 25.10500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3492721928148129
+      },
+      {
+        "run": 69,
+        "seed": 827597674,
+        "success": true,
+        "steps": 172,
+        "total_reward": 25.620000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4332421306763412
+      },
+      {
+        "run": 70,
+        "seed": 827597675,
+        "success": true,
+        "steps": 377,
+        "total_reward": 39.485000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2839712474867483
+      },
+      {
+        "run": 71,
+        "seed": 827597676,
+        "success": true,
+        "steps": 250,
+        "total_reward": 42.1000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3862333935289718
+      },
+      {
+        "run": 72,
+        "seed": 827597677,
+        "success": true,
+        "steps": 244,
+        "total_reward": 34.5300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40374823472769183
+      },
+      {
+        "run": 73,
+        "seed": 827597678,
+        "success": true,
+        "steps": 267,
+        "total_reward": 43.29500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4213586351295097
+      },
+      {
+        "run": 74,
+        "seed": 827597679,
+        "success": true,
+        "steps": 256,
+        "total_reward": 32.47000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3614790650580417
+      },
+      {
+        "run": 75,
+        "seed": 827597680,
+        "success": true,
+        "steps": 233,
+        "total_reward": 35.76500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3665310671129637
+      },
+      {
+        "run": 76,
+        "seed": 827597681,
+        "success": true,
+        "steps": 238,
+        "total_reward": 32.32000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34611150361454796
+      },
+      {
+        "run": 77,
+        "seed": 827597682,
+        "success": true,
+        "steps": 192,
+        "total_reward": 26.640000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41499115435647943
+      },
+      {
+        "run": 78,
+        "seed": 827597683,
+        "success": true,
+        "steps": 184,
+        "total_reward": 38.91000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46933486019913395
+      },
+      {
+        "run": 79,
+        "seed": 827597684,
+        "success": true,
+        "steps": 214,
+        "total_reward": 29.750000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41896170482167117
+      },
+      {
+        "run": 80,
+        "seed": 827597685,
+        "success": true,
+        "steps": 255,
+        "total_reward": 36.47500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3259688749247573
+      },
+      {
+        "run": 81,
+        "seed": 827597686,
+        "success": true,
+        "steps": 267,
+        "total_reward": 39.21500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38825066178305667
+      },
+      {
+        "run": 82,
+        "seed": 827597687,
+        "success": true,
+        "steps": 185,
+        "total_reward": 29.415000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43253388988272706
+      },
+      {
+        "run": 83,
+        "seed": 827597688,
+        "success": true,
+        "steps": 248,
+        "total_reward": 37.64000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3451973182988925
+      },
+      {
+        "run": 84,
+        "seed": 827597689,
+        "success": true,
+        "steps": 338,
+        "total_reward": 44.01000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.408655642824957
+      },
+      {
+        "run": 85,
+        "seed": 827597690,
+        "success": true,
+        "steps": 210,
+        "total_reward": 32.8300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36054410014936333
+      },
+      {
+        "run": 86,
+        "seed": 827597691,
+        "success": true,
+        "steps": 184,
+        "total_reward": 24.820000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36863506059158235
+      },
+      {
+        "run": 87,
+        "seed": 827597692,
+        "success": true,
+        "steps": 240,
+        "total_reward": 27.300000000000033,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.370532655590972
+      },
+      {
+        "run": 88,
+        "seed": 827597693,
+        "success": true,
+        "steps": 234,
+        "total_reward": 24.890000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36208399787347156
+      },
+      {
+        "run": 89,
+        "seed": 827597694,
+        "success": true,
+        "steps": 389,
+        "total_reward": 33.54500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33857939391218494
+      },
+      {
+        "run": 90,
+        "seed": 827597695,
+        "success": false,
+        "steps": 208,
+        "total_reward": 12.600000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.3576577773157933
+      },
+      {
+        "run": 91,
+        "seed": 827597696,
+        "success": true,
+        "steps": 181,
+        "total_reward": 22.995000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4762572375944469
+      },
+      {
+        "run": 92,
+        "seed": 827597697,
+        "success": true,
+        "steps": 220,
+        "total_reward": 33.760000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45848036758563077
+      },
+      {
+        "run": 93,
+        "seed": 827597698,
+        "success": true,
+        "steps": 244,
+        "total_reward": 29.51000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3020048932548932
+      },
+      {
+        "run": 94,
+        "seed": 827597699,
+        "success": true,
+        "steps": 222,
+        "total_reward": 46.98000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5103711012624425
+      },
+      {
+        "run": 95,
+        "seed": 827597700,
+        "success": true,
+        "steps": 236,
+        "total_reward": 39.550000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42704033468899194
+      },
+      {
+        "run": 96,
+        "seed": 827597701,
+        "success": true,
+        "steps": 236,
+        "total_reward": 41.50000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4350405640111522
+      },
+      {
+        "run": 97,
+        "seed": 827597702,
+        "success": true,
+        "steps": 165,
+        "total_reward": 26.46500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4107640206620283
+      },
+      {
+        "run": 98,
+        "seed": 827597703,
+        "success": true,
+        "steps": 247,
+        "total_reward": 21.175000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3403415809340956
+      },
+      {
+        "run": 99,
+        "seed": 827597704,
+        "success": true,
+        "steps": 230,
+        "total_reward": 32.9700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3892230179836086
+      },
+      {
+        "run": 100,
+        "seed": 827597705,
+        "success": true,
+        "steps": 270,
+        "total_reward": 35.95000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38373061837703915
+      },
+      {
+        "run": 101,
+        "seed": 827597706,
+        "success": true,
+        "steps": 263,
+        "total_reward": 36.545000000000186,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3439977614977615
+      },
+      {
+        "run": 102,
+        "seed": 827597707,
+        "success": false,
+        "steps": 45,
+        "total_reward": -1.8749999999999982,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.6217948717948718
+      },
+      {
+        "run": 103,
+        "seed": 827597708,
+        "success": true,
+        "steps": 298,
+        "total_reward": 28.270000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4045016274048532
+      },
+      {
+        "run": 104,
+        "seed": 827597709,
+        "success": false,
+        "steps": 209,
+        "total_reward": 2.445000000000057,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.45641081309774323
+      },
+      {
+        "run": 105,
+        "seed": 827597710,
+        "success": true,
+        "steps": 208,
+        "total_reward": 35.32000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4636596725339118
+      },
+      {
+        "run": 106,
+        "seed": 827597711,
+        "success": true,
+        "steps": 202,
+        "total_reward": 22.450000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3691679957469431
+      },
+      {
+        "run": 107,
+        "seed": 827597712,
+        "success": true,
+        "steps": 209,
+        "total_reward": 36.545000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4133265373001721
+      },
+      {
+        "run": 108,
+        "seed": 827597713,
+        "success": true,
+        "steps": 263,
+        "total_reward": 32.99500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3737523309961857
+      },
+      {
+        "run": 109,
+        "seed": 827597714,
+        "success": false,
+        "steps": 72,
+        "total_reward": 4.2699999999999925,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.49903846153846154
+      },
+      {
+        "run": 110,
+        "seed": 827597715,
+        "success": false,
+        "steps": 122,
+        "total_reward": 11.160000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4326678951678951
+      },
+      {
+        "run": 111,
+        "seed": 827597716,
+        "success": true,
+        "steps": 210,
+        "total_reward": 30.94000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4284431040805409
+      },
+      {
+        "run": 112,
+        "seed": 827597717,
+        "success": true,
+        "steps": 189,
+        "total_reward": 29.595000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39365024505291213
+      },
+      {
+        "run": 113,
+        "seed": 827597718,
+        "success": true,
+        "steps": 299,
+        "total_reward": 36.97500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42553266607390317
+      },
+      {
+        "run": 114,
+        "seed": 827597719,
+        "success": false,
+        "steps": 147,
+        "total_reward": 13.99500000000008,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4390166028097062
+      },
+      {
+        "run": 115,
+        "seed": 827597720,
+        "success": true,
+        "steps": 215,
+        "total_reward": 27.005000000000038,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4435842286368602
+      },
+      {
+        "run": 116,
+        "seed": 827597721,
+        "success": true,
+        "steps": 296,
+        "total_reward": 29.220000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3589811424970935
+      },
+      {
+        "run": 117,
+        "seed": 827597722,
+        "success": true,
+        "steps": 353,
+        "total_reward": 35.125000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3359322330994129
+      },
+      {
+        "run": 118,
+        "seed": 827597723,
+        "success": false,
+        "steps": 59,
+        "total_reward": -2.4349999999999987,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.30995475113122173
+      },
+      {
+        "run": 119,
+        "seed": 827597724,
+        "success": true,
+        "steps": 209,
+        "total_reward": 24.35500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3908696791151152
+      },
+      {
+        "run": 120,
+        "seed": 827597725,
+        "success": true,
+        "steps": 275,
+        "total_reward": 27.83500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31698567397343247
+      },
+      {
+        "run": 121,
+        "seed": 827597726,
+        "success": true,
+        "steps": 231,
+        "total_reward": 28.725000000000108,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3540238583471666
+      },
+      {
+        "run": 122,
+        "seed": 827597727,
+        "success": true,
+        "steps": 174,
+        "total_reward": 32.60000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5071679567884502
+      },
+      {
+        "run": 123,
+        "seed": 827597728,
+        "success": true,
+        "steps": 226,
+        "total_reward": 27.660000000000103,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35342020671144714
+      },
+      {
+        "run": 124,
+        "seed": 827597729,
+        "success": true,
+        "steps": 257,
+        "total_reward": 26.38500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3390858383280717
+      },
+      {
+        "run": 125,
+        "seed": 827597730,
+        "success": true,
+        "steps": 247,
+        "total_reward": 41.06500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42513645691113283
+      },
+      {
+        "run": 126,
+        "seed": 827597731,
+        "success": true,
+        "steps": 298,
+        "total_reward": 30.990000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.352389001176772
+      },
+      {
+        "run": 127,
+        "seed": 827597732,
+        "success": false,
+        "steps": 173,
+        "total_reward": -0.4450000000000127,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.2940991548134405
+      },
+      {
+        "run": 128,
+        "seed": 827597733,
+        "success": true,
+        "steps": 184,
+        "total_reward": 34.370000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.526
+      },
+      {
+        "run": 129,
+        "seed": 827597734,
+        "success": true,
+        "steps": 301,
+        "total_reward": 28.585000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29304036731970845
+      },
+      {
+        "run": 130,
+        "seed": 827597735,
+        "success": true,
+        "steps": 193,
+        "total_reward": 31.415000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3667083336560081
+      },
+      {
+        "run": 131,
+        "seed": 827597736,
+        "success": true,
+        "steps": 302,
+        "total_reward": 32.310000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32236286650410473
+      },
+      {
+        "run": 132,
+        "seed": 827597737,
+        "success": true,
+        "steps": 216,
+        "total_reward": 29.040000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3754281391123496
+      },
+      {
+        "run": 133,
+        "seed": 827597738,
+        "success": true,
+        "steps": 266,
+        "total_reward": 25.04000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30268061843379446
+      },
+      {
+        "run": 134,
+        "seed": 827597739,
+        "success": true,
+        "steps": 284,
+        "total_reward": 26.90000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3120891130727196
+      },
+      {
+        "run": 135,
+        "seed": 827597740,
+        "success": true,
+        "steps": 194,
+        "total_reward": 37.20000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43993522249276723
+      },
+      {
+        "run": 136,
+        "seed": 827597741,
+        "success": true,
+        "steps": 204,
+        "total_reward": 29.920000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37281175658669263
+      },
+      {
+        "run": 137,
+        "seed": 827597742,
+        "success": true,
+        "steps": 188,
+        "total_reward": 34.540000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.48634209359052816
+      },
+      {
+        "run": 138,
+        "seed": 827597743,
+        "success": true,
+        "steps": 214,
+        "total_reward": 34.480000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39241449079491353
+      },
+      {
+        "run": 139,
+        "seed": 827597744,
+        "success": true,
+        "steps": 248,
+        "total_reward": 42.180000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4103009263303381
+      },
+      {
+        "run": 140,
+        "seed": 827597745,
+        "success": true,
+        "steps": 230,
+        "total_reward": 33.6400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.382594793480125
+      },
+      {
+        "run": 141,
+        "seed": 827597746,
+        "success": true,
+        "steps": 313,
+        "total_reward": 38.81500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34221261190501606
+      },
+      {
+        "run": 142,
+        "seed": 827597747,
+        "success": true,
+        "steps": 182,
+        "total_reward": 26.640000000000047,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4629507964802082
+      },
+      {
+        "run": 143,
+        "seed": 827597748,
+        "success": true,
+        "steps": 257,
+        "total_reward": 26.925000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33829230344441
+      },
+      {
+        "run": 144,
+        "seed": 827597749,
+        "success": true,
+        "steps": 209,
+        "total_reward": 38.03500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4759303854916575
+      },
+      {
+        "run": 145,
+        "seed": 827597750,
+        "success": true,
+        "steps": 211,
+        "total_reward": 29.645000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43056058492591004
+      },
+      {
+        "run": 146,
+        "seed": 827597751,
+        "success": true,
+        "steps": 204,
+        "total_reward": 32.03000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40258618218801284
+      },
+      {
+        "run": 147,
+        "seed": 827597752,
+        "success": true,
+        "steps": 265,
+        "total_reward": 33.85500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3935133355861204
+      },
+      {
+        "run": 148,
+        "seed": 827597753,
+        "success": true,
+        "steps": 213,
+        "total_reward": 39.075000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43368293211004205
+      },
+      {
+        "run": 149,
+        "seed": 827597754,
+        "success": true,
+        "steps": 256,
+        "total_reward": 39.880000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4269015404876614
+      },
+      {
+        "run": 150,
+        "seed": 827597755,
+        "success": true,
+        "steps": 254,
+        "total_reward": 40.82000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35176714915301577
+      },
+      {
+        "run": 151,
+        "seed": 827597756,
+        "success": true,
+        "steps": 232,
+        "total_reward": 42.96000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4496807255790922
+      },
+      {
+        "run": 152,
+        "seed": 827597757,
+        "success": false,
+        "steps": 180,
+        "total_reward": 22.31000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.45086754643206256
+      },
+      {
+        "run": 153,
+        "seed": 827597758,
+        "success": true,
+        "steps": 270,
+        "total_reward": 38.610000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.312650272943381
+      },
+      {
+        "run": 154,
+        "seed": 827597759,
+        "success": true,
+        "steps": 200,
+        "total_reward": 34.45000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43371311348199215
+      },
+      {
+        "run": 155,
+        "seed": 827597760,
+        "success": false,
+        "steps": 75,
+        "total_reward": -0.5650000000000013,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.42097902097902096
+      },
+      {
+        "run": 156,
+        "seed": 827597761,
+        "success": true,
+        "steps": 252,
+        "total_reward": 42.01000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37429076358424185
+      },
+      {
+        "run": 157,
+        "seed": 827597762,
+        "success": false,
+        "steps": 161,
+        "total_reward": 3.0949999999999633,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.34416475972540045
+      },
+      {
+        "run": 158,
+        "seed": 827597763,
+        "success": true,
+        "steps": 223,
+        "total_reward": 28.85500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33959396914446
+      },
+      {
+        "run": 159,
+        "seed": 827597764,
+        "success": false,
+        "steps": 340,
+        "total_reward": 5.540000000000189,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.422490253411306
+      },
+      {
+        "run": 160,
+        "seed": 827597765,
+        "success": false,
+        "steps": 230,
+        "total_reward": 17.310000000000084,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.32843966069772523
+      },
+      {
+        "run": 161,
+        "seed": 827597766,
+        "success": true,
+        "steps": 221,
+        "total_reward": 25.73500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35742746052767166
+      },
+      {
+        "run": 162,
+        "seed": 827597767,
+        "success": true,
+        "steps": 214,
+        "total_reward": 31.60000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38072452297424486
+      },
+      {
+        "run": 163,
+        "seed": 827597768,
+        "success": true,
+        "steps": 287,
+        "total_reward": 31.01500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38315515897486063
+      },
+      {
+        "run": 164,
+        "seed": 827597769,
+        "success": true,
+        "steps": 314,
+        "total_reward": 27.480000000000118,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2834438924676278
+      },
+      {
+        "run": 165,
+        "seed": 827597770,
+        "success": true,
+        "steps": 191,
+        "total_reward": 27.11500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41843043317191925
+      },
+      {
+        "run": 166,
+        "seed": 827597771,
+        "success": true,
+        "steps": 227,
+        "total_reward": 29.715000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4184490262575369
+      },
+      {
+        "run": 167,
+        "seed": 827597772,
+        "success": true,
+        "steps": 229,
+        "total_reward": 26.01500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33745778481833827
+      },
+      {
+        "run": 168,
+        "seed": 827597773,
+        "success": true,
+        "steps": 287,
+        "total_reward": 31.395000000000124,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44489404022304846
+      },
+      {
+        "run": 169,
+        "seed": 827597774,
+        "success": true,
+        "steps": 213,
+        "total_reward": 27.555000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4205901116427432
+      },
+      {
+        "run": 170,
+        "seed": 827597775,
+        "success": true,
+        "steps": 232,
+        "total_reward": 35.32000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40418019201300937
+      },
+      {
+        "run": 171,
+        "seed": 827597776,
+        "success": true,
+        "steps": 217,
+        "total_reward": 33.055000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3699844283813428
+      },
+      {
+        "run": 172,
+        "seed": 827597777,
+        "success": true,
+        "steps": 216,
+        "total_reward": 41.79000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5110989887305677
+      },
+      {
+        "run": 173,
+        "seed": 827597778,
+        "success": true,
+        "steps": 165,
+        "total_reward": 28.145000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4601932002951655
+      },
+      {
+        "run": 174,
+        "seed": 827597779,
+        "success": true,
+        "steps": 235,
+        "total_reward": 23.88500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3692113133289604
+      },
+      {
+        "run": 175,
+        "seed": 827597780,
+        "success": false,
+        "steps": 142,
+        "total_reward": 10.749999999999996,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.35870927318295737
+      },
+      {
+        "run": 176,
+        "seed": 827597781,
+        "success": true,
+        "steps": 244,
+        "total_reward": 38.49000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4067906637017697
+      },
+      {
+        "run": 177,
+        "seed": 827597782,
+        "success": false,
+        "steps": 66,
+        "total_reward": 2.5,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.458139834881321
+      },
+      {
+        "run": 178,
+        "seed": 827597783,
+        "success": true,
+        "steps": 295,
+        "total_reward": 38.12500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3328683115989618
+      },
+      {
+        "run": 179,
+        "seed": 827597784,
+        "success": true,
+        "steps": 223,
+        "total_reward": 34.08500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4634731850406066
+      },
+      {
+        "run": 180,
+        "seed": 827597785,
+        "success": true,
+        "steps": 198,
+        "total_reward": 19.28000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37667052292567166
+      },
+      {
+        "run": 181,
+        "seed": 827597786,
+        "success": true,
+        "steps": 205,
+        "total_reward": 36.54500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4707870114519051
+      },
+      {
+        "run": 182,
+        "seed": 827597787,
+        "success": true,
+        "steps": 225,
+        "total_reward": 20.67500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38179086211837204
+      },
+      {
+        "run": 183,
+        "seed": 827597788,
+        "success": true,
+        "steps": 294,
+        "total_reward": 42.110000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37036541061672346
+      },
+      {
+        "run": 184,
+        "seed": 827597789,
+        "success": true,
+        "steps": 286,
+        "total_reward": 31.93000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34571685141708025
+      },
+      {
+        "run": 185,
+        "seed": 827597790,
+        "success": false,
+        "steps": 222,
+        "total_reward": 5.749999999999972,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.327414426689789
+      },
+      {
+        "run": 186,
+        "seed": 827597791,
+        "success": true,
+        "steps": 155,
+        "total_reward": 31.445000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4581479500891266
+      },
+      {
+        "run": 187,
+        "seed": 827597792,
+        "success": true,
+        "steps": 208,
+        "total_reward": 24.95000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45450241438540734
+      },
+      {
+        "run": 188,
+        "seed": 827597793,
+        "success": true,
+        "steps": 191,
+        "total_reward": 35.805000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43992257742257745
+      },
+      {
+        "run": 189,
+        "seed": 827597794,
+        "success": true,
+        "steps": 326,
+        "total_reward": 43.45000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3062644993894994
+      },
+      {
+        "run": 190,
+        "seed": 827597795,
+        "success": true,
+        "steps": 211,
+        "total_reward": 30.225000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35154052025569055
+      },
+      {
+        "run": 191,
+        "seed": 827597796,
+        "success": true,
+        "steps": 262,
+        "total_reward": 32.35000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4114444096351991
+      },
+      {
+        "run": 192,
+        "seed": 827597797,
+        "success": true,
+        "steps": 217,
+        "total_reward": 36.045000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33965179608832863
+      },
+      {
+        "run": 193,
+        "seed": 827597798,
+        "success": true,
+        "steps": 275,
+        "total_reward": 38.79500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4641948206281534
+      },
+      {
+        "run": 194,
+        "seed": 827597799,
+        "success": true,
+        "steps": 206,
+        "total_reward": 34.700000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40902165467382856
+      },
+      {
+        "run": 195,
+        "seed": 827597800,
+        "success": true,
+        "steps": 168,
+        "total_reward": 30.930000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.417241452991453
+      },
+      {
+        "run": 196,
+        "seed": 827597801,
+        "success": true,
+        "steps": 224,
+        "total_reward": 45.69000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5288533922463944
+      },
+      {
+        "run": 197,
+        "seed": 827597802,
+        "success": true,
+        "steps": 249,
+        "total_reward": 34.8250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42113191873485994
+      },
+      {
+        "run": 198,
+        "seed": 827597803,
+        "success": false,
+        "steps": 119,
+        "total_reward": 9.46500000000001,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.39987494113130784
+      },
+      {
+        "run": 199,
+        "seed": 827597804,
+        "success": true,
+        "steps": 263,
+        "total_reward": 34.68500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39161638592870346
+      },
+      {
+        "run": 200,
+        "seed": 827597805,
+        "success": true,
+        "steps": 294,
+        "total_reward": 31.24000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4077941559064123
+      }
+    ],
+    "avg_chemotaxis_index": 0.29467748505401575,
+    "avg_time_in_attractant": 0.6473387425270078,
+    "avg_approach_frequency": 0.38247717744549903,
+    "avg_path_efficiency": 0.03666305825275692,
+    "post_convergence_chemotaxis_index": 0.3294882991735457,
+    "post_convergence_time_in_attractant": 0.6647441495867729,
+    "post_convergence_approach_frequency": 0.38690955713092795,
+    "post_convergence_path_efficiency": 0.025760459822757455,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_103144.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_103144.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_103144",
+  "timestamp": "2025-12-29T10:40:33.592360+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_103144",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.805,
+    "avg_steps": 192.58,
+    "avg_reward": 27.35255000000008,
+    "avg_foods_collected": 8.875,
+    "avg_distance_efficiency": 0.4357839413679913,
+    "completed_all_food": 161,
+    "starved": 5,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 34,
+    "avg_predator_encounters": 6.83,
+    "avg_successful_evasions": 6.415,
+    "converged": true,
+    "convergence_run": 44,
+    "runs_to_convergence": 43,
+    "post_convergence_success_rate": 0.8726114649681529,
+    "post_convergence_avg_steps": 195.66423357664235,
+    "post_convergence_avg_foods": 9.305732484076433,
+    "post_convergence_variance": 0.11116069617428702,
+    "post_convergence_distance_efficiency": 0.4712220973357878,
+    "composite_benchmark_score": 0.6918308671008541,
+    "learning_speed": 0.88,
+    "learning_speed_episodes": 24,
+    "stability": 0.6179196400495649,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 3089410929,
+        "success": false,
+        "steps": 36,
+        "total_reward": -10.13,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 2,
+        "seed": 3089410930,
+        "success": false,
+        "steps": 177,
+        "total_reward": -20.994999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 3089410931,
+        "success": false,
+        "steps": 320,
+        "total_reward": -7.0600000000000005,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.11826136944302502
+      },
+      {
+        "run": 4,
+        "seed": 3089410932,
+        "success": false,
+        "steps": 46,
+        "total_reward": -13.530000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 5,
+        "seed": 3089410933,
+        "success": false,
+        "steps": 400,
+        "total_reward": 6.349999999999934,
+        "termination_reason": "starved",
+        "foods_collected": 5,
+        "distance_efficiency": 0.308356913789851
+      },
+      {
+        "run": 6,
+        "seed": 3089410934,
+        "success": false,
+        "steps": 53,
+        "total_reward": -14.215000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 7,
+        "seed": 3089410935,
+        "success": false,
+        "steps": 400,
+        "total_reward": -3.6099999999999994,
+        "termination_reason": "starved",
+        "foods_collected": 5,
+        "distance_efficiency": 0.15410935243374058
+      },
+      {
+        "run": 8,
+        "seed": 3089410936,
+        "success": false,
+        "steps": 193,
+        "total_reward": -18.754999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 9,
+        "seed": 3089410937,
+        "success": false,
+        "steps": 320,
+        "total_reward": 0.32999999999989527,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.10629960317460317
+      },
+      {
+        "run": 10,
+        "seed": 3089410938,
+        "success": false,
+        "steps": 112,
+        "total_reward": 2.339999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5077635327635328
+      },
+      {
+        "run": 11,
+        "seed": 3089410939,
+        "success": true,
+        "steps": 458,
+        "total_reward": 34.440000000000204,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21371844191269637
+      },
+      {
+        "run": 12,
+        "seed": 3089410940,
+        "success": true,
+        "steps": 431,
+        "total_reward": 27.845000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21601916981571234
+      },
+      {
+        "run": 13,
+        "seed": 3089410941,
+        "success": true,
+        "steps": 418,
+        "total_reward": 26.940000000000122,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28354688072534534
+      },
+      {
+        "run": 14,
+        "seed": 3089410942,
+        "success": false,
+        "steps": 392,
+        "total_reward": 15.550000000000097,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.30025306773427074
+      },
+      {
+        "run": 15,
+        "seed": 3089410943,
+        "success": false,
+        "steps": 356,
+        "total_reward": 19.15000000000018,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3299872517735118
+      },
+      {
+        "run": 16,
+        "seed": 3089410944,
+        "success": true,
+        "steps": 322,
+        "total_reward": 28.630000000000138,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2886313835656764
+      },
+      {
+        "run": 17,
+        "seed": 3089410945,
+        "success": true,
+        "steps": 388,
+        "total_reward": 29.820000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3356769336614538
+      },
+      {
+        "run": 18,
+        "seed": 3089410946,
+        "success": false,
+        "steps": 101,
+        "total_reward": 1.5049999999999972,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.32453671123621863
+      },
+      {
+        "run": 19,
+        "seed": 3089410947,
+        "success": true,
+        "steps": 248,
+        "total_reward": 35.47000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3719212203545129
+      },
+      {
+        "run": 20,
+        "seed": 3089410948,
+        "success": true,
+        "steps": 250,
+        "total_reward": 35.83000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3493762506398622
+      },
+      {
+        "run": 21,
+        "seed": 3089410949,
+        "success": true,
+        "steps": 202,
+        "total_reward": 27.990000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3355960713368945
+      },
+      {
+        "run": 22,
+        "seed": 3089410950,
+        "success": true,
+        "steps": 197,
+        "total_reward": 28.075000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47319255288322226
+      },
+      {
+        "run": 23,
+        "seed": 3089410951,
+        "success": true,
+        "steps": 260,
+        "total_reward": 27.080000000000123,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3627353934922084
+      },
+      {
+        "run": 24,
+        "seed": 3089410952,
+        "success": true,
+        "steps": 236,
+        "total_reward": 27.83000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3789599344862503
+      },
+      {
+        "run": 25,
+        "seed": 3089410953,
+        "success": true,
+        "steps": 251,
+        "total_reward": 32.495000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4470148303984208
+      },
+      {
+        "run": 26,
+        "seed": 3089410954,
+        "success": true,
+        "steps": 182,
+        "total_reward": 36.20000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5216557734204793
+      },
+      {
+        "run": 27,
+        "seed": 3089410955,
+        "success": true,
+        "steps": 271,
+        "total_reward": 37.1450000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3930167735085981
+      },
+      {
+        "run": 28,
+        "seed": 3089410956,
+        "success": false,
+        "steps": 187,
+        "total_reward": 16.96500000000009,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.46139256224001984
+      },
+      {
+        "run": 29,
+        "seed": 3089410957,
+        "success": true,
+        "steps": 179,
+        "total_reward": 27.23500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4139535379369139
+      },
+      {
+        "run": 30,
+        "seed": 3089410958,
+        "success": false,
+        "steps": 159,
+        "total_reward": 9.805,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.47149725274725274
+      },
+      {
+        "run": 31,
+        "seed": 3089410959,
+        "success": true,
+        "steps": 163,
+        "total_reward": 34.435000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5912875369397108
+      },
+      {
+        "run": 32,
+        "seed": 3089410960,
+        "success": false,
+        "steps": 13,
+        "total_reward": -6.965,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 33,
+        "seed": 3089410961,
+        "success": true,
+        "steps": 231,
+        "total_reward": 38.54500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45158370063088754
+      },
+      {
+        "run": 34,
+        "seed": 3089410962,
+        "success": true,
+        "steps": 162,
+        "total_reward": 26.890000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5116282243493637
+      },
+      {
+        "run": 35,
+        "seed": 3089410963,
+        "success": true,
+        "steps": 215,
+        "total_reward": 27.55500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41544308228660787
+      },
+      {
+        "run": 36,
+        "seed": 3089410964,
+        "success": true,
+        "steps": 210,
+        "total_reward": 28.340000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4234398229185798
+      },
+      {
+        "run": 37,
+        "seed": 3089410965,
+        "success": false,
+        "steps": 76,
+        "total_reward": 4.869999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5586580086580086
+      },
+      {
+        "run": 38,
+        "seed": 3089410966,
+        "success": true,
+        "steps": 205,
+        "total_reward": 24.545000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45562495639895023
+      },
+      {
+        "run": 39,
+        "seed": 3089410967,
+        "success": true,
+        "steps": 209,
+        "total_reward": 33.5050000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40059627114380936
+      },
+      {
+        "run": 40,
+        "seed": 3089410968,
+        "success": true,
+        "steps": 200,
+        "total_reward": 33.760000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45040032455494083
+      },
+      {
+        "run": 41,
+        "seed": 3089410969,
+        "success": true,
+        "steps": 229,
+        "total_reward": 33.69500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38284962705127623
+      },
+      {
+        "run": 42,
+        "seed": 3089410970,
+        "success": false,
+        "steps": 267,
+        "total_reward": 30.29500000000015,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.3682251722691488
+      },
+      {
+        "run": 43,
+        "seed": 3089410971,
+        "success": false,
+        "steps": 139,
+        "total_reward": 19.11500000000005,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5569775132275132
+      },
+      {
+        "run": 44,
+        "seed": 3089410972,
+        "success": true,
+        "steps": 256,
+        "total_reward": 34.91000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39092624051350466
+      },
+      {
+        "run": 45,
+        "seed": 3089410973,
+        "success": true,
+        "steps": 165,
+        "total_reward": 34.16500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5067148262813898
+      },
+      {
+        "run": 46,
+        "seed": 3089410974,
+        "success": true,
+        "steps": 184,
+        "total_reward": 34.14000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4574902385196503
+      },
+      {
+        "run": 47,
+        "seed": 3089410975,
+        "success": true,
+        "steps": 157,
+        "total_reward": 24.345000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4756051954581366
+      },
+      {
+        "run": 48,
+        "seed": 3089410976,
+        "success": true,
+        "steps": 208,
+        "total_reward": 43.330000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4330300396020477
+      },
+      {
+        "run": 49,
+        "seed": 3089410977,
+        "success": true,
+        "steps": 175,
+        "total_reward": 34.475000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5240128503286398
+      },
+      {
+        "run": 50,
+        "seed": 3089410978,
+        "success": true,
+        "steps": 271,
+        "total_reward": 27.77500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3855890055966121
+      },
+      {
+        "run": 51,
+        "seed": 3089410979,
+        "success": true,
+        "steps": 224,
+        "total_reward": 42.76000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44583818142641674
+      },
+      {
+        "run": 52,
+        "seed": 3089410980,
+        "success": true,
+        "steps": 190,
+        "total_reward": 35.08000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4739223644230063
+      },
+      {
+        "run": 53,
+        "seed": 3089410981,
+        "success": true,
+        "steps": 214,
+        "total_reward": 35.46000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4566868024762762
+      },
+      {
+        "run": 54,
+        "seed": 3089410982,
+        "success": true,
+        "steps": 196,
+        "total_reward": 28.810000000000045,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49049493234552655
+      },
+      {
+        "run": 55,
+        "seed": 3089410983,
+        "success": true,
+        "steps": 165,
+        "total_reward": 25.37500000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5319337606837606
+      },
+      {
+        "run": 56,
+        "seed": 3089410984,
+        "success": true,
+        "steps": 173,
+        "total_reward": 33.695000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4707867816294362
+      },
+      {
+        "run": 57,
+        "seed": 3089410985,
+        "success": false,
+        "steps": 180,
+        "total_reward": 7.900000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.28050027680404027
+      },
+      {
+        "run": 58,
+        "seed": 3089410986,
+        "success": true,
+        "steps": 144,
+        "total_reward": 28.86000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5615728827416133
+      },
+      {
+        "run": 59,
+        "seed": 3089410987,
+        "success": true,
+        "steps": 171,
+        "total_reward": 29.7250000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45492895992895993
+      },
+      {
+        "run": 60,
+        "seed": 3089410988,
+        "success": false,
+        "steps": 123,
+        "total_reward": 17.135000000000044,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.45108024691358023
+      },
+      {
+        "run": 61,
+        "seed": 3089410989,
+        "success": true,
+        "steps": 218,
+        "total_reward": 36.540000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4127055034574216
+      },
+      {
+        "run": 62,
+        "seed": 3089410990,
+        "success": true,
+        "steps": 333,
+        "total_reward": 40.34500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.381182408036628
+      },
+      {
+        "run": 63,
+        "seed": 3089410991,
+        "success": false,
+        "steps": 52,
+        "total_reward": 1.2399999999999984,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5597222222222222
+      },
+      {
+        "run": 64,
+        "seed": 3089410992,
+        "success": true,
+        "steps": 192,
+        "total_reward": 28.97000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41932957570696383
+      },
+      {
+        "run": 65,
+        "seed": 3089410993,
+        "success": false,
+        "steps": 32,
+        "total_reward": -2.959999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.49318181818181817
+      },
+      {
+        "run": 66,
+        "seed": 3089410994,
+        "success": true,
+        "steps": 199,
+        "total_reward": 39.63500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5005788944719151
+      },
+      {
+        "run": 67,
+        "seed": 3089410995,
+        "success": true,
+        "steps": 211,
+        "total_reward": 25.79500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.373689998149288
+      },
+      {
+        "run": 68,
+        "seed": 3089410996,
+        "success": true,
+        "steps": 169,
+        "total_reward": 36.15500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5400932400932401
+      },
+      {
+        "run": 69,
+        "seed": 3089410997,
+        "success": true,
+        "steps": 226,
+        "total_reward": 37.75000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4142298461224293
+      },
+      {
+        "run": 70,
+        "seed": 3089410998,
+        "success": true,
+        "steps": 221,
+        "total_reward": 35.72500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5036246364574538
+      },
+      {
+        "run": 71,
+        "seed": 3089410999,
+        "success": true,
+        "steps": 143,
+        "total_reward": 35.73500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6137821827295512
+      },
+      {
+        "run": 72,
+        "seed": 3089411000,
+        "success": false,
+        "steps": 60,
+        "total_reward": -2.0000000000000036,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.471182412358883
+      },
+      {
+        "run": 73,
+        "seed": 3089411001,
+        "success": true,
+        "steps": 147,
+        "total_reward": 27.115000000000048,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47923877292298345
+      },
+      {
+        "run": 74,
+        "seed": 3089411002,
+        "success": true,
+        "steps": 231,
+        "total_reward": 38.37500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42636402726960004
+      },
+      {
+        "run": 75,
+        "seed": 3089411003,
+        "success": true,
+        "steps": 299,
+        "total_reward": 39.135000000000176,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3124289026802155
+      },
+      {
+        "run": 76,
+        "seed": 3089411004,
+        "success": true,
+        "steps": 236,
+        "total_reward": 30.050000000000132,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4485190999476714
+      },
+      {
+        "run": 77,
+        "seed": 3089411005,
+        "success": true,
+        "steps": 147,
+        "total_reward": 28.24500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6061302521008403
+      },
+      {
+        "run": 78,
+        "seed": 3089411006,
+        "success": true,
+        "steps": 239,
+        "total_reward": 29.05500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3980890637140637
+      },
+      {
+        "run": 79,
+        "seed": 3089411007,
+        "success": true,
+        "steps": 170,
+        "total_reward": 36.71000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5044887751137751
+      },
+      {
+        "run": 80,
+        "seed": 3089411008,
+        "success": true,
+        "steps": 185,
+        "total_reward": 39.72500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5500519106497367
+      },
+      {
+        "run": 81,
+        "seed": 3089411009,
+        "success": true,
+        "steps": 244,
+        "total_reward": 37.440000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4517748660563002
+      },
+      {
+        "run": 82,
+        "seed": 3089411010,
+        "success": true,
+        "steps": 230,
+        "total_reward": 41.26000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4417063581413426
+      },
+      {
+        "run": 83,
+        "seed": 3089411011,
+        "success": true,
+        "steps": 139,
+        "total_reward": 28.905000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5451129785247433
+      },
+      {
+        "run": 84,
+        "seed": 3089411012,
+        "success": true,
+        "steps": 198,
+        "total_reward": 39.89000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5114625595840018
+      },
+      {
+        "run": 85,
+        "seed": 3089411013,
+        "success": true,
+        "steps": 256,
+        "total_reward": 36.35000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3763759790750156
+      },
+      {
+        "run": 86,
+        "seed": 3089411014,
+        "success": true,
+        "steps": 210,
+        "total_reward": 29.61000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41167730767355304
+      },
+      {
+        "run": 87,
+        "seed": 3089411015,
+        "success": true,
+        "steps": 241,
+        "total_reward": 32.75500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.521720853858785
+      },
+      {
+        "run": 88,
+        "seed": 3089411016,
+        "success": true,
+        "steps": 326,
+        "total_reward": 27.57000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3364173927326902
+      },
+      {
+        "run": 89,
+        "seed": 3089411017,
+        "success": false,
+        "steps": 72,
+        "total_reward": 5.289999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5064484126984127
+      },
+      {
+        "run": 90,
+        "seed": 3089411018,
+        "success": true,
+        "steps": 159,
+        "total_reward": 28.355000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4741168261562998
+      },
+      {
+        "run": 91,
+        "seed": 3089411019,
+        "success": false,
+        "steps": 98,
+        "total_reward": 0.5400000000000045,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.394871023713129
+      },
+      {
+        "run": 92,
+        "seed": 3089411020,
+        "success": true,
+        "steps": 220,
+        "total_reward": 42.28000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4547395104895105
+      },
+      {
+        "run": 93,
+        "seed": 3089411021,
+        "success": true,
+        "steps": 187,
+        "total_reward": 32.01500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4957716196846632
+      },
+      {
+        "run": 94,
+        "seed": 3089411022,
+        "success": true,
+        "steps": 175,
+        "total_reward": 23.805000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46069260254042865
+      },
+      {
+        "run": 95,
+        "seed": 3089411023,
+        "success": true,
+        "steps": 162,
+        "total_reward": 23.790000000000035,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4360141492494433
+      },
+      {
+        "run": 96,
+        "seed": 3089411024,
+        "success": true,
+        "steps": 175,
+        "total_reward": 43.09500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5947382640999662
+      },
+      {
+        "run": 97,
+        "seed": 3089411025,
+        "success": true,
+        "steps": 175,
+        "total_reward": 32.87500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42456938308920406
+      },
+      {
+        "run": 98,
+        "seed": 3089411026,
+        "success": true,
+        "steps": 248,
+        "total_reward": 37.84000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3904589598997494
+      },
+      {
+        "run": 99,
+        "seed": 3089411027,
+        "success": true,
+        "steps": 140,
+        "total_reward": 27.680000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5454700577200577
+      },
+      {
+        "run": 100,
+        "seed": 3089411028,
+        "success": true,
+        "steps": 156,
+        "total_reward": 32.88000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5788256022415614
+      },
+      {
+        "run": 101,
+        "seed": 3089411029,
+        "success": true,
+        "steps": 220,
+        "total_reward": 26.330000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3393350930115636
+      },
+      {
+        "run": 102,
+        "seed": 3089411030,
+        "success": true,
+        "steps": 173,
+        "total_reward": 38.78500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5721768917209026
+      },
+      {
+        "run": 103,
+        "seed": 3089411031,
+        "success": true,
+        "steps": 176,
+        "total_reward": 42.42000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5537296037296037
+      },
+      {
+        "run": 104,
+        "seed": 3089411032,
+        "success": true,
+        "steps": 176,
+        "total_reward": 31.120000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4962538533734186
+      },
+      {
+        "run": 105,
+        "seed": 3089411033,
+        "success": true,
+        "steps": 197,
+        "total_reward": 38.06500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.463314510620931
+      },
+      {
+        "run": 106,
+        "seed": 3089411034,
+        "success": true,
+        "steps": 208,
+        "total_reward": 38.99000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5273009768009768
+      },
+      {
+        "run": 107,
+        "seed": 3089411035,
+        "success": true,
+        "steps": 245,
+        "total_reward": 35.08500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43730137982711514
+      },
+      {
+        "run": 108,
+        "seed": 3089411036,
+        "success": true,
+        "steps": 180,
+        "total_reward": 25.230000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40052196595674855
+      },
+      {
+        "run": 109,
+        "seed": 3089411037,
+        "success": true,
+        "steps": 195,
+        "total_reward": 34.135000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46302156692636565
+      },
+      {
+        "run": 110,
+        "seed": 3089411038,
+        "success": true,
+        "steps": 172,
+        "total_reward": 32.75000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5277890257890258
+      },
+      {
+        "run": 111,
+        "seed": 3089411039,
+        "success": false,
+        "steps": 95,
+        "total_reward": 6.974999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.47639531521110473
+      },
+      {
+        "run": 112,
+        "seed": 3089411040,
+        "success": true,
+        "steps": 220,
+        "total_reward": 42.30000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45729344602653593
+      },
+      {
+        "run": 113,
+        "seed": 3089411041,
+        "success": true,
+        "steps": 150,
+        "total_reward": 33.68000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5311044154503907
+      },
+      {
+        "run": 114,
+        "seed": 3089411042,
+        "success": true,
+        "steps": 182,
+        "total_reward": 29.420000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5083157365510307
+      },
+      {
+        "run": 115,
+        "seed": 3089411043,
+        "success": true,
+        "steps": 201,
+        "total_reward": 27.555000000000053,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45447332461851514
+      },
+      {
+        "run": 116,
+        "seed": 3089411044,
+        "success": false,
+        "steps": 39,
+        "total_reward": -6.845,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.21875
+      },
+      {
+        "run": 117,
+        "seed": 3089411045,
+        "success": true,
+        "steps": 152,
+        "total_reward": 32.74000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5179407795506867
+      },
+      {
+        "run": 118,
+        "seed": 3089411046,
+        "success": true,
+        "steps": 155,
+        "total_reward": 24.784999999999997,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47399513712981206
+      },
+      {
+        "run": 119,
+        "seed": 3089411047,
+        "success": true,
+        "steps": 228,
+        "total_reward": 41.85000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4445710306728613
+      },
+      {
+        "run": 120,
+        "seed": 3089411048,
+        "success": true,
+        "steps": 189,
+        "total_reward": 33.8850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4739369310220344
+      },
+      {
+        "run": 121,
+        "seed": 3089411049,
+        "success": true,
+        "steps": 205,
+        "total_reward": 37.735000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4735749886078834
+      },
+      {
+        "run": 122,
+        "seed": 3089411050,
+        "success": true,
+        "steps": 272,
+        "total_reward": 41.330000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4005752479556956
+      },
+      {
+        "run": 123,
+        "seed": 3089411051,
+        "success": true,
+        "steps": 166,
+        "total_reward": 28.7000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5051753296284189
+      },
+      {
+        "run": 124,
+        "seed": 3089411052,
+        "success": true,
+        "steps": 140,
+        "total_reward": 24.20000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5464336147434304
+      },
+      {
+        "run": 125,
+        "seed": 3089411053,
+        "success": true,
+        "steps": 197,
+        "total_reward": 35.565000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46496764143822966
+      },
+      {
+        "run": 126,
+        "seed": 3089411054,
+        "success": true,
+        "steps": 211,
+        "total_reward": 41.62500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5005884041559886
+      },
+      {
+        "run": 127,
+        "seed": 3089411055,
+        "success": true,
+        "steps": 213,
+        "total_reward": 44.89500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46069823069823074
+      },
+      {
+        "run": 128,
+        "seed": 3089411056,
+        "success": true,
+        "steps": 205,
+        "total_reward": 26.37500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46267319636884857
+      },
+      {
+        "run": 129,
+        "seed": 3089411057,
+        "success": true,
+        "steps": 183,
+        "total_reward": 30.645000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4544347698492035
+      },
+      {
+        "run": 130,
+        "seed": 3089411058,
+        "success": true,
+        "steps": 220,
+        "total_reward": 28.460000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45214646464646463
+      },
+      {
+        "run": 131,
+        "seed": 3089411059,
+        "success": true,
+        "steps": 160,
+        "total_reward": 31.4300000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5203373835598899
+      },
+      {
+        "run": 132,
+        "seed": 3089411060,
+        "success": true,
+        "steps": 201,
+        "total_reward": 34.20500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4902450980392157
+      },
+      {
+        "run": 133,
+        "seed": 3089411061,
+        "success": true,
+        "steps": 180,
+        "total_reward": 28.8600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38893620414673047
+      },
+      {
+        "run": 134,
+        "seed": 3089411062,
+        "success": true,
+        "steps": 160,
+        "total_reward": 40.40000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5741629489884639
+      },
+      {
+        "run": 135,
+        "seed": 3089411063,
+        "success": true,
+        "steps": 198,
+        "total_reward": 35.220000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.497525236250653
+      },
+      {
+        "run": 136,
+        "seed": 3089411064,
+        "success": true,
+        "steps": 258,
+        "total_reward": 39.880000000000166,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4924064733658707
+      },
+      {
+        "run": 137,
+        "seed": 3089411065,
+        "success": true,
+        "steps": 218,
+        "total_reward": 42.71000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5205438764134416
+      },
+      {
+        "run": 138,
+        "seed": 3089411066,
+        "success": true,
+        "steps": 208,
+        "total_reward": 26.1600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43997561987758066
+      },
+      {
+        "run": 139,
+        "seed": 3089411067,
+        "success": true,
+        "steps": 217,
+        "total_reward": 42.55500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5118562616434132
+      },
+      {
+        "run": 140,
+        "seed": 3089411068,
+        "success": false,
+        "steps": 184,
+        "total_reward": 9.22999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.3526496669353812
+      },
+      {
+        "run": 141,
+        "seed": 3089411069,
+        "success": true,
+        "steps": 233,
+        "total_reward": 37.035000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43625365507083186
+      },
+      {
+        "run": 142,
+        "seed": 3089411070,
+        "success": true,
+        "steps": 228,
+        "total_reward": 25.080000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4175350494915713
+      },
+      {
+        "run": 143,
+        "seed": 3089411071,
+        "success": true,
+        "steps": 197,
+        "total_reward": 44.935000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.510597733820217
+      },
+      {
+        "run": 144,
+        "seed": 3089411072,
+        "success": true,
+        "steps": 129,
+        "total_reward": 26.605000000000047,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5025000000000001
+      },
+      {
+        "run": 145,
+        "seed": 3089411073,
+        "success": false,
+        "steps": 86,
+        "total_reward": 6.219999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4801782531194296
+      },
+      {
+        "run": 146,
+        "seed": 3089411074,
+        "success": true,
+        "steps": 193,
+        "total_reward": 39.085000000000186,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5583775235846847
+      },
+      {
+        "run": 147,
+        "seed": 3089411075,
+        "success": true,
+        "steps": 162,
+        "total_reward": 37.97000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5483066688213747
+      },
+      {
+        "run": 148,
+        "seed": 3089411076,
+        "success": true,
+        "steps": 231,
+        "total_reward": 35.23500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42741826786527576
+      },
+      {
+        "run": 149,
+        "seed": 3089411077,
+        "success": false,
+        "steps": 195,
+        "total_reward": 15.185000000000024,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.477922753774147
+      },
+      {
+        "run": 150,
+        "seed": 3089411078,
+        "success": true,
+        "steps": 179,
+        "total_reward": 33.80500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4603436801902275
+      },
+      {
+        "run": 151,
+        "seed": 3089411079,
+        "success": false,
+        "steps": 91,
+        "total_reward": 8.745000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.5385665990534145
+      },
+      {
+        "run": 152,
+        "seed": 3089411080,
+        "success": true,
+        "steps": 152,
+        "total_reward": 36.60000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6235263347763348
+      },
+      {
+        "run": 153,
+        "seed": 3089411081,
+        "success": false,
+        "steps": 51,
+        "total_reward": -2.1549999999999994,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.47348484848484845
+      },
+      {
+        "run": 154,
+        "seed": 3089411082,
+        "success": true,
+        "steps": 166,
+        "total_reward": 35.59000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5336376927166401
+      },
+      {
+        "run": 155,
+        "seed": 3089411083,
+        "success": false,
+        "steps": 112,
+        "total_reward": 6.589999999999993,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.44090616671261834
+      },
+      {
+        "run": 156,
+        "seed": 3089411084,
+        "success": true,
+        "steps": 169,
+        "total_reward": 35.15500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46963691537220953
+      },
+      {
+        "run": 157,
+        "seed": 3089411085,
+        "success": true,
+        "steps": 210,
+        "total_reward": 40.600000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4911401537059431
+      },
+      {
+        "run": 158,
+        "seed": 3089411086,
+        "success": true,
+        "steps": 182,
+        "total_reward": 34.94000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47414622414622415
+      },
+      {
+        "run": 159,
+        "seed": 3089411087,
+        "success": true,
+        "steps": 213,
+        "total_reward": 27.225000000000126,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3616699182460052
+      },
+      {
+        "run": 160,
+        "seed": 3089411088,
+        "success": true,
+        "steps": 148,
+        "total_reward": 29.990000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5107963875205255
+      },
+      {
+        "run": 161,
+        "seed": 3089411089,
+        "success": true,
+        "steps": 186,
+        "total_reward": 39.44000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45949051712571637
+      },
+      {
+        "run": 162,
+        "seed": 3089411090,
+        "success": false,
+        "steps": 126,
+        "total_reward": 3.0900000000000016,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.38837944664031615
+      },
+      {
+        "run": 163,
+        "seed": 3089411091,
+        "success": true,
+        "steps": 165,
+        "total_reward": 31.825000000000113,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4892446633825944
+      },
+      {
+        "run": 164,
+        "seed": 3089411092,
+        "success": true,
+        "steps": 148,
+        "total_reward": 29.690000000000083,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.479023569023569
+      },
+      {
+        "run": 165,
+        "seed": 3089411093,
+        "success": true,
+        "steps": 206,
+        "total_reward": 31.000000000000107,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3783616982146394
+      },
+      {
+        "run": 166,
+        "seed": 3089411094,
+        "success": false,
+        "steps": 58,
+        "total_reward": 0.21000000000000085,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.4000777000777001
+      },
+      {
+        "run": 167,
+        "seed": 3089411095,
+        "success": true,
+        "steps": 199,
+        "total_reward": 36.08500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4474688453377299
+      },
+      {
+        "run": 168,
+        "seed": 3089411096,
+        "success": true,
+        "steps": 187,
+        "total_reward": 29.415000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4121291719975931
+      },
+      {
+        "run": 169,
+        "seed": 3089411097,
+        "success": false,
+        "steps": 9,
+        "total_reward": -9.445,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 170,
+        "seed": 3089411098,
+        "success": true,
+        "steps": 152,
+        "total_reward": 29.44000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5081058415268942
+      },
+      {
+        "run": 171,
+        "seed": 3089411099,
+        "success": true,
+        "steps": 280,
+        "total_reward": 38.62000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3618154002897387
+      },
+      {
+        "run": 172,
+        "seed": 3089411100,
+        "success": true,
+        "steps": 168,
+        "total_reward": 30.860000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4342335115864528
+      },
+      {
+        "run": 173,
+        "seed": 3089411101,
+        "success": true,
+        "steps": 184,
+        "total_reward": 32.44000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41900444369871614
+      },
+      {
+        "run": 174,
+        "seed": 3089411102,
+        "success": true,
+        "steps": 173,
+        "total_reward": 26.845000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39736901986901985
+      },
+      {
+        "run": 175,
+        "seed": 3089411103,
+        "success": true,
+        "steps": 164,
+        "total_reward": 30.960000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5147287157287157
+      },
+      {
+        "run": 176,
+        "seed": 3089411104,
+        "success": true,
+        "steps": 201,
+        "total_reward": 32.79500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4553708804687993
+      },
+      {
+        "run": 177,
+        "seed": 3089411105,
+        "success": true,
+        "steps": 193,
+        "total_reward": 33.54500000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47441743685164733
+      },
+      {
+        "run": 178,
+        "seed": 3089411106,
+        "success": true,
+        "steps": 218,
+        "total_reward": 34.62000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3847802963320205
+      },
+      {
+        "run": 179,
+        "seed": 3089411107,
+        "success": true,
+        "steps": 181,
+        "total_reward": 33.84500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4133902804074684
+      },
+      {
+        "run": 180,
+        "seed": 3089411108,
+        "success": true,
+        "steps": 191,
+        "total_reward": 27.075000000000113,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37195709432733026
+      },
+      {
+        "run": 181,
+        "seed": 3089411109,
+        "success": true,
+        "steps": 199,
+        "total_reward": 38.60500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5410531323918051
+      },
+      {
+        "run": 182,
+        "seed": 3089411110,
+        "success": true,
+        "steps": 223,
+        "total_reward": 31.715000000000074,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4538831200986337
+      },
+      {
+        "run": 183,
+        "seed": 3089411111,
+        "success": false,
+        "steps": 51,
+        "total_reward": 0.5950000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.6543209876543209
+      },
+      {
+        "run": 184,
+        "seed": 3089411112,
+        "success": true,
+        "steps": 238,
+        "total_reward": 33.550000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4836565841773009
+      },
+      {
+        "run": 185,
+        "seed": 3089411113,
+        "success": true,
+        "steps": 195,
+        "total_reward": 32.175000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46869898479782945
+      },
+      {
+        "run": 186,
+        "seed": 3089411114,
+        "success": true,
+        "steps": 209,
+        "total_reward": 32.415000000000106,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4134734734734734
+      },
+      {
+        "run": 187,
+        "seed": 3089411115,
+        "success": true,
+        "steps": 159,
+        "total_reward": 29.96500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5551587301587302
+      },
+      {
+        "run": 188,
+        "seed": 3089411116,
+        "success": true,
+        "steps": 152,
+        "total_reward": 27.640000000000043,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5454563156142103
+      },
+      {
+        "run": 189,
+        "seed": 3089411117,
+        "success": true,
+        "steps": 205,
+        "total_reward": 34.665000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41173120248926703
+      },
+      {
+        "run": 190,
+        "seed": 3089411118,
+        "success": true,
+        "steps": 190,
+        "total_reward": 37.07000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46103498800050524
+      },
+      {
+        "run": 191,
+        "seed": 3089411119,
+        "success": true,
+        "steps": 180,
+        "total_reward": 33.30000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42027635166155086
+      },
+      {
+        "run": 192,
+        "seed": 3089411120,
+        "success": false,
+        "steps": 132,
+        "total_reward": 11.490000000000023,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5065557821369017
+      },
+      {
+        "run": 193,
+        "seed": 3089411121,
+        "success": true,
+        "steps": 142,
+        "total_reward": 31.590000000000057,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.521510989010989
+      },
+      {
+        "run": 194,
+        "seed": 3089411122,
+        "success": true,
+        "steps": 120,
+        "total_reward": 32.10000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.6235403485403486
+      },
+      {
+        "run": 195,
+        "seed": 3089411123,
+        "success": true,
+        "steps": 172,
+        "total_reward": 29.120000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4516369995748109
+      },
+      {
+        "run": 196,
+        "seed": 3089411124,
+        "success": true,
+        "steps": 339,
+        "total_reward": 42.05500000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3818407891241399
+      },
+      {
+        "run": 197,
+        "seed": 3089411125,
+        "success": true,
+        "steps": 146,
+        "total_reward": 29.98000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5550156606678346
+      },
+      {
+        "run": 198,
+        "seed": 3089411126,
+        "success": true,
+        "steps": 254,
+        "total_reward": 43.02000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38844607346484694
+      },
+      {
+        "run": 199,
+        "seed": 3089411127,
+        "success": true,
+        "steps": 159,
+        "total_reward": 30.05500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4927920227920228
+      },
+      {
+        "run": 200,
+        "seed": 3089411128,
+        "success": true,
+        "steps": 205,
+        "total_reward": 34.36500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46610589591567847
+      }
+    ],
+    "avg_chemotaxis_index": 0.32695703277335164,
+    "avg_time_in_attractant": 0.6634785163866758,
+    "avg_approach_frequency": 0.43536376283030476,
+    "avg_path_efficiency": 0.04423663902332756,
+    "post_convergence_chemotaxis_index": 0.3551943858210383,
+    "post_convergence_time_in_attractant": 0.6775971929105191,
+    "post_convergence_approach_frequency": 0.43878079370534184,
+    "post_convergence_path_efficiency": 0.038786457684212565,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_103146.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_103146.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_103146",
+  "timestamp": "2025-12-29T10:41:53.228098+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_103146",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.755,
+    "avg_steps": 226.72,
+    "avg_reward": 24.82065000000008,
+    "avg_foods_collected": 8.63,
+    "avg_distance_efficiency": 0.3820967506015504,
+    "completed_all_food": 151,
+    "starved": 11,
+    "max_steps_reached": 0,
+    "goal_reached": 0,
+    "predator_deaths": 38,
+    "avg_predator_encounters": 8.215,
+    "avg_successful_evasions": 7.815,
+    "converged": true,
+    "convergence_run": 24,
+    "runs_to_convergence": 23,
+    "post_convergence_success_rate": 0.8305084745762712,
+    "post_convergence_avg_steps": 236.05442176870747,
+    "post_convergence_avg_foods": 9.163841807909604,
+    "post_convergence_variance": 0.14076414823326633,
+    "post_convergence_distance_efficiency": 0.40155013356956665,
+    "composite_benchmark_score": 0.6592863557847454,
+    "learning_speed": 0.865,
+    "learning_speed_episodes": 27,
+    "stability": 0.5482460485473744,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 1670133920,
+        "success": false,
+        "steps": 240,
+        "total_reward": -2.6999999999999895,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.061224489795918366
+      },
+      {
+        "run": 2,
+        "seed": 1670133921,
+        "success": false,
+        "steps": 83,
+        "total_reward": -12.145,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 1670133922,
+        "success": false,
+        "steps": 142,
+        "total_reward": -10.65,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 1670133923,
+        "success": false,
+        "steps": 200,
+        "total_reward": -16.39,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 5,
+        "seed": 1670133924,
+        "success": false,
+        "steps": 201,
+        "total_reward": -1.0650000000000386,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.2524073688833414
+      },
+      {
+        "run": 6,
+        "seed": 1670133925,
+        "success": false,
+        "steps": 57,
+        "total_reward": -8.245,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 7,
+        "seed": 1670133926,
+        "success": false,
+        "steps": 131,
+        "total_reward": -4.175000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.2867647058823529
+      },
+      {
+        "run": 8,
+        "seed": 1670133927,
+        "success": false,
+        "steps": 240,
+        "total_reward": -13.369999999999996,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.07368421052631578
+      },
+      {
+        "run": 9,
+        "seed": 1670133928,
+        "success": false,
+        "steps": 219,
+        "total_reward": -5.735000000000003,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.42105263157894735
+      },
+      {
+        "run": 10,
+        "seed": 1670133929,
+        "success": false,
+        "steps": 373,
+        "total_reward": 12.625000000000131,
+        "termination_reason": "starved",
+        "foods_collected": 5,
+        "distance_efficiency": 0.16813730621328518
+      },
+      {
+        "run": 11,
+        "seed": 1670133930,
+        "success": false,
+        "steps": 396,
+        "total_reward": 11.770000000000135,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.25025859328184913
+      },
+      {
+        "run": 12,
+        "seed": 1670133931,
+        "success": false,
+        "steps": 331,
+        "total_reward": 4.244999999999967,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.2606215242669363
+      },
+      {
+        "run": 13,
+        "seed": 1670133932,
+        "success": false,
+        "steps": 320,
+        "total_reward": -14.649999999999983,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.11551829607385163
+      },
+      {
+        "run": 14,
+        "seed": 1670133933,
+        "success": false,
+        "steps": 273,
+        "total_reward": 7.654999999999983,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.15031131001882087
+      },
+      {
+        "run": 15,
+        "seed": 1670133934,
+        "success": false,
+        "steps": 437,
+        "total_reward": 3.1949999999999186,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.25297074254096286
+      },
+      {
+        "run": 16,
+        "seed": 1670133935,
+        "success": false,
+        "steps": 329,
+        "total_reward": 6.864999999999977,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.35992659692967643
+      },
+      {
+        "run": 17,
+        "seed": 1670133936,
+        "success": false,
+        "steps": 440,
+        "total_reward": 16.440000000000293,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.19843410469268397
+      },
+      {
+        "run": 18,
+        "seed": 1670133937,
+        "success": true,
+        "steps": 333,
+        "total_reward": 31.515000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25535929883864805
+      },
+      {
+        "run": 19,
+        "seed": 1670133938,
+        "success": false,
+        "steps": 327,
+        "total_reward": 20.03500000000017,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.2379537401596225
+      },
+      {
+        "run": 20,
+        "seed": 1670133939,
+        "success": true,
+        "steps": 451,
+        "total_reward": 29.065000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2705327415488262
+      },
+      {
+        "run": 21,
+        "seed": 1670133940,
+        "success": true,
+        "steps": 220,
+        "total_reward": 34.52000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37792178409825467
+      },
+      {
+        "run": 22,
+        "seed": 1670133941,
+        "success": true,
+        "steps": 260,
+        "total_reward": 37.980000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4700714320074493
+      },
+      {
+        "run": 23,
+        "seed": 1670133942,
+        "success": false,
+        "steps": 269,
+        "total_reward": -2.5350000000000525,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.26172979084228376
+      },
+      {
+        "run": 24,
+        "seed": 1670133943,
+        "success": true,
+        "steps": 448,
+        "total_reward": 38.5600000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2203866978041506
+      },
+      {
+        "run": 25,
+        "seed": 1670133944,
+        "success": true,
+        "steps": 309,
+        "total_reward": 25.425000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3263118736038392
+      },
+      {
+        "run": 26,
+        "seed": 1670133945,
+        "success": true,
+        "steps": 286,
+        "total_reward": 36.25000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3314540272768727
+      },
+      {
+        "run": 27,
+        "seed": 1670133946,
+        "success": true,
+        "steps": 416,
+        "total_reward": 32.980000000000246,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36664637649931764
+      },
+      {
+        "run": 28,
+        "seed": 1670133947,
+        "success": true,
+        "steps": 249,
+        "total_reward": 33.595000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3315295615764916
+      },
+      {
+        "run": 29,
+        "seed": 1670133948,
+        "success": true,
+        "steps": 210,
+        "total_reward": 26.81000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3890014137908875
+      },
+      {
+        "run": 30,
+        "seed": 1670133949,
+        "success": true,
+        "steps": 191,
+        "total_reward": 29.665000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4354608238219065
+      },
+      {
+        "run": 31,
+        "seed": 1670133950,
+        "success": true,
+        "steps": 262,
+        "total_reward": 24.530000000000054,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2940443944381391
+      },
+      {
+        "run": 32,
+        "seed": 1670133951,
+        "success": true,
+        "steps": 335,
+        "total_reward": 27.59500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3283301871473227
+      },
+      {
+        "run": 33,
+        "seed": 1670133952,
+        "success": true,
+        "steps": 259,
+        "total_reward": 25.4150000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35250835234825384
+      },
+      {
+        "run": 34,
+        "seed": 1670133953,
+        "success": true,
+        "steps": 224,
+        "total_reward": 35.42000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38868642207210424
+      },
+      {
+        "run": 35,
+        "seed": 1670133954,
+        "success": true,
+        "steps": 276,
+        "total_reward": 20.04000000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3087577295068971
+      },
+      {
+        "run": 36,
+        "seed": 1670133955,
+        "success": true,
+        "steps": 233,
+        "total_reward": 33.035000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41779551366507894
+      },
+      {
+        "run": 37,
+        "seed": 1670133956,
+        "success": true,
+        "steps": 176,
+        "total_reward": 26.330000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4185987623487623
+      },
+      {
+        "run": 38,
+        "seed": 1670133957,
+        "success": true,
+        "steps": 234,
+        "total_reward": 29.640000000000157,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.353877693188038
+      },
+      {
+        "run": 39,
+        "seed": 1670133958,
+        "success": true,
+        "steps": 360,
+        "total_reward": 24.06000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2792554186848319
+      },
+      {
+        "run": 40,
+        "seed": 1670133959,
+        "success": false,
+        "steps": 178,
+        "total_reward": 2.9199999999999644,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.37648221343873517
+      },
+      {
+        "run": 41,
+        "seed": 1670133960,
+        "success": false,
+        "steps": 228,
+        "total_reward": 24.66000000000016,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.379353418481533
+      },
+      {
+        "run": 42,
+        "seed": 1670133961,
+        "success": true,
+        "steps": 218,
+        "total_reward": 38.570000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4503198862540968
+      },
+      {
+        "run": 43,
+        "seed": 1670133962,
+        "success": true,
+        "steps": 185,
+        "total_reward": 20.48500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39015222579518066
+      },
+      {
+        "run": 44,
+        "seed": 1670133963,
+        "success": true,
+        "steps": 163,
+        "total_reward": 23.795000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41925194001045396
+      },
+      {
+        "run": 45,
+        "seed": 1670133964,
+        "success": true,
+        "steps": 207,
+        "total_reward": 24.755000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40955183027837483
+      },
+      {
+        "run": 46,
+        "seed": 1670133965,
+        "success": true,
+        "steps": 220,
+        "total_reward": 30.640000000000096,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3725774178736962
+      },
+      {
+        "run": 47,
+        "seed": 1670133966,
+        "success": true,
+        "steps": 216,
+        "total_reward": 20.440000000000044,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3825145442792502
+      },
+      {
+        "run": 48,
+        "seed": 1670133967,
+        "success": true,
+        "steps": 285,
+        "total_reward": 33.22500000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40663885882052886
+      },
+      {
+        "run": 49,
+        "seed": 1670133968,
+        "success": true,
+        "steps": 256,
+        "total_reward": 36.61000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42405445624195626
+      },
+      {
+        "run": 50,
+        "seed": 1670133969,
+        "success": true,
+        "steps": 228,
+        "total_reward": 34.71000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4686809846629581
+      },
+      {
+        "run": 51,
+        "seed": 1670133970,
+        "success": true,
+        "steps": 233,
+        "total_reward": 36.705000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4168598281513883
+      },
+      {
+        "run": 52,
+        "seed": 1670133971,
+        "success": true,
+        "steps": 202,
+        "total_reward": 36.52000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4547506042627994
+      },
+      {
+        "run": 53,
+        "seed": 1670133972,
+        "success": true,
+        "steps": 193,
+        "total_reward": 28.345000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4148429879665751
+      },
+      {
+        "run": 54,
+        "seed": 1670133973,
+        "success": true,
+        "steps": 205,
+        "total_reward": 30.035000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4219526511302827
+      },
+      {
+        "run": 55,
+        "seed": 1670133974,
+        "success": false,
+        "steps": 211,
+        "total_reward": 14.145000000000042,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4556503826145321
+      },
+      {
+        "run": 56,
+        "seed": 1670133975,
+        "success": false,
+        "steps": 41,
+        "total_reward": -5.975,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.2857142857142857
+      },
+      {
+        "run": 57,
+        "seed": 1670133976,
+        "success": true,
+        "steps": 311,
+        "total_reward": 29.505000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30568878036149155
+      },
+      {
+        "run": 58,
+        "seed": 1670133977,
+        "success": true,
+        "steps": 250,
+        "total_reward": 37.520000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4028288430383625
+      },
+      {
+        "run": 59,
+        "seed": 1670133978,
+        "success": true,
+        "steps": 189,
+        "total_reward": 30.145000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41703081232493
+      },
+      {
+        "run": 60,
+        "seed": 1670133979,
+        "success": true,
+        "steps": 259,
+        "total_reward": 36.405000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4010655669866196
+      },
+      {
+        "run": 61,
+        "seed": 1670133980,
+        "success": false,
+        "steps": 18,
+        "total_reward": -6.339999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.7777777777777778
+      },
+      {
+        "run": 62,
+        "seed": 1670133981,
+        "success": true,
+        "steps": 198,
+        "total_reward": 38.2800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44809218559218555
+      },
+      {
+        "run": 63,
+        "seed": 1670133982,
+        "success": true,
+        "steps": 295,
+        "total_reward": 32.195000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42903997131659305
+      },
+      {
+        "run": 64,
+        "seed": 1670133983,
+        "success": true,
+        "steps": 247,
+        "total_reward": 32.44500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3934936489284315
+      },
+      {
+        "run": 65,
+        "seed": 1670133984,
+        "success": false,
+        "steps": 379,
+        "total_reward": 10.10500000000031,
+        "termination_reason": "starved",
+        "foods_collected": 7,
+        "distance_efficiency": 0.3680268089702052
+      },
+      {
+        "run": 66,
+        "seed": 1670133985,
+        "success": true,
+        "steps": 219,
+        "total_reward": 25.87500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40005117286424
+      },
+      {
+        "run": 67,
+        "seed": 1670133986,
+        "success": true,
+        "steps": 193,
+        "total_reward": 28.375000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41745060443706816
+      },
+      {
+        "run": 68,
+        "seed": 1670133987,
+        "success": false,
+        "steps": 250,
+        "total_reward": 11.760000000000094,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.29789161488668875
+      },
+      {
+        "run": 69,
+        "seed": 1670133988,
+        "success": true,
+        "steps": 311,
+        "total_reward": 33.925000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4032046659894696
+      },
+      {
+        "run": 70,
+        "seed": 1670133989,
+        "success": true,
+        "steps": 285,
+        "total_reward": 29.52500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.327045349009367
+      },
+      {
+        "run": 71,
+        "seed": 1670133990,
+        "success": false,
+        "steps": 153,
+        "total_reward": 20.365000000000094,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4466666666666666
+      },
+      {
+        "run": 72,
+        "seed": 1670133991,
+        "success": true,
+        "steps": 226,
+        "total_reward": 35.82000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3958953481574118
+      },
+      {
+        "run": 73,
+        "seed": 1670133992,
+        "success": true,
+        "steps": 263,
+        "total_reward": 29.095000000000038,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33962206800513256
+      },
+      {
+        "run": 74,
+        "seed": 1670133993,
+        "success": true,
+        "steps": 243,
+        "total_reward": 26.77500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34563748915626286
+      },
+      {
+        "run": 75,
+        "seed": 1670133994,
+        "success": true,
+        "steps": 254,
+        "total_reward": 35.70000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4111115355233002
+      },
+      {
+        "run": 76,
+        "seed": 1670133995,
+        "success": true,
+        "steps": 188,
+        "total_reward": 25.930000000000046,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4523835129379594
+      },
+      {
+        "run": 77,
+        "seed": 1670133996,
+        "success": true,
+        "steps": 299,
+        "total_reward": 36.55500000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30737558370240076
+      },
+      {
+        "run": 78,
+        "seed": 1670133997,
+        "success": true,
+        "steps": 176,
+        "total_reward": 25.39000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4514785704491587
+      },
+      {
+        "run": 79,
+        "seed": 1670133998,
+        "success": true,
+        "steps": 241,
+        "total_reward": 29.455000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3767298921422798
+      },
+      {
+        "run": 80,
+        "seed": 1670133999,
+        "success": true,
+        "steps": 224,
+        "total_reward": 35.4700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5094380846580985
+      },
+      {
+        "run": 81,
+        "seed": 1670134000,
+        "success": true,
+        "steps": 175,
+        "total_reward": 28.405000000000097,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4754245164771481
+      },
+      {
+        "run": 82,
+        "seed": 1670134001,
+        "success": true,
+        "steps": 203,
+        "total_reward": 39.2950000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45019855885487886
+      },
+      {
+        "run": 83,
+        "seed": 1670134002,
+        "success": true,
+        "steps": 214,
+        "total_reward": 31.16000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.461959040959041
+      },
+      {
+        "run": 84,
+        "seed": 1670134003,
+        "success": true,
+        "steps": 263,
+        "total_reward": 35.115000000000194,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36223835441157803
+      },
+      {
+        "run": 85,
+        "seed": 1670134004,
+        "success": true,
+        "steps": 186,
+        "total_reward": 35.68000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.511050405306435
+      },
+      {
+        "run": 86,
+        "seed": 1670134005,
+        "success": true,
+        "steps": 250,
+        "total_reward": 37.15000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38454400148640794
+      },
+      {
+        "run": 87,
+        "seed": 1670134006,
+        "success": true,
+        "steps": 203,
+        "total_reward": 33.2850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5156691896966497
+      },
+      {
+        "run": 88,
+        "seed": 1670134007,
+        "success": true,
+        "steps": 238,
+        "total_reward": 44.400000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4310839935852724
+      },
+      {
+        "run": 89,
+        "seed": 1670134008,
+        "success": false,
+        "steps": 76,
+        "total_reward": 2.2000000000000046,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.7802579365079365
+      },
+      {
+        "run": 90,
+        "seed": 1670134009,
+        "success": false,
+        "steps": 166,
+        "total_reward": 8.04999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.39790329762134274
+      },
+      {
+        "run": 91,
+        "seed": 1670134010,
+        "success": true,
+        "steps": 186,
+        "total_reward": 34.500000000000064,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.486013554728725
+      },
+      {
+        "run": 92,
+        "seed": 1670134011,
+        "success": true,
+        "steps": 240,
+        "total_reward": 36.05000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42389332282455267
+      },
+      {
+        "run": 93,
+        "seed": 1670134012,
+        "success": true,
+        "steps": 248,
+        "total_reward": 35.38000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.365429408850125
+      },
+      {
+        "run": 94,
+        "seed": 1670134013,
+        "success": true,
+        "steps": 292,
+        "total_reward": 31.85000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30831162464985995
+      },
+      {
+        "run": 95,
+        "seed": 1670134014,
+        "success": true,
+        "steps": 244,
+        "total_reward": 25.470000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32660280769199174
+      },
+      {
+        "run": 96,
+        "seed": 1670134015,
+        "success": true,
+        "steps": 196,
+        "total_reward": 30.600000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4475809566250743
+      },
+      {
+        "run": 97,
+        "seed": 1670134016,
+        "success": true,
+        "steps": 241,
+        "total_reward": 33.77500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3692561628757075
+      },
+      {
+        "run": 98,
+        "seed": 1670134017,
+        "success": true,
+        "steps": 260,
+        "total_reward": 33.68000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3555446205646945
+      },
+      {
+        "run": 99,
+        "seed": 1670134018,
+        "success": true,
+        "steps": 231,
+        "total_reward": 31.135000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4847518082340653
+      },
+      {
+        "run": 100,
+        "seed": 1670134019,
+        "success": true,
+        "steps": 183,
+        "total_reward": 21.185,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.42841534781008467
+      },
+      {
+        "run": 101,
+        "seed": 1670134020,
+        "success": true,
+        "steps": 191,
+        "total_reward": 34.795000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.47240889207586123
+      },
+      {
+        "run": 102,
+        "seed": 1670134021,
+        "success": true,
+        "steps": 214,
+        "total_reward": 36.470000000000034,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4096372416795108
+      },
+      {
+        "run": 103,
+        "seed": 1670134022,
+        "success": true,
+        "steps": 157,
+        "total_reward": 32.80500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.507177315438185
+      },
+      {
+        "run": 104,
+        "seed": 1670134023,
+        "success": true,
+        "steps": 239,
+        "total_reward": 32.30500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3532887120740894
+      },
+      {
+        "run": 105,
+        "seed": 1670134024,
+        "success": true,
+        "steps": 221,
+        "total_reward": 43.975000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4558081124557155
+      },
+      {
+        "run": 106,
+        "seed": 1670134025,
+        "success": true,
+        "steps": 262,
+        "total_reward": 34.270000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4118128114367815
+      },
+      {
+        "run": 107,
+        "seed": 1670134026,
+        "success": true,
+        "steps": 191,
+        "total_reward": 29.525000000000055,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5411107313738893
+      },
+      {
+        "run": 108,
+        "seed": 1670134027,
+        "success": true,
+        "steps": 168,
+        "total_reward": 25.85000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46923533363188535
+      },
+      {
+        "run": 109,
+        "seed": 1670134028,
+        "success": true,
+        "steps": 208,
+        "total_reward": 31.07000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41555041449778296
+      },
+      {
+        "run": 110,
+        "seed": 1670134029,
+        "success": false,
+        "steps": 216,
+        "total_reward": 21.980000000000096,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.38584928840599186
+      },
+      {
+        "run": 111,
+        "seed": 1670134030,
+        "success": false,
+        "steps": 19,
+        "total_reward": -8.094999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.3888888888888889
+      },
+      {
+        "run": 112,
+        "seed": 1670134031,
+        "success": true,
+        "steps": 235,
+        "total_reward": 30.705000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36529856569750185
+      },
+      {
+        "run": 113,
+        "seed": 1670134032,
+        "success": true,
+        "steps": 226,
+        "total_reward": 31.120000000000108,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4004795704795705
+      },
+      {
+        "run": 114,
+        "seed": 1670134033,
+        "success": true,
+        "steps": 219,
+        "total_reward": 24.835000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.377008547008547
+      },
+      {
+        "run": 115,
+        "seed": 1670134034,
+        "success": true,
+        "steps": 222,
+        "total_reward": 28.120000000000065,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3894009037557425
+      },
+      {
+        "run": 116,
+        "seed": 1670134035,
+        "success": true,
+        "steps": 339,
+        "total_reward": 16.69499999999996,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3959704977831566
+      },
+      {
+        "run": 117,
+        "seed": 1670134036,
+        "success": false,
+        "steps": 184,
+        "total_reward": 25.730000000000153,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.5131938317251451
+      },
+      {
+        "run": 118,
+        "seed": 1670134037,
+        "success": false,
+        "steps": 48,
+        "total_reward": -5.509999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.4037433155080214
+      },
+      {
+        "run": 119,
+        "seed": 1670134038,
+        "success": true,
+        "steps": 197,
+        "total_reward": 27.17500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44252590747872517
+      },
+      {
+        "run": 120,
+        "seed": 1670134039,
+        "success": true,
+        "steps": 305,
+        "total_reward": 29.83500000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38513482397635324
+      },
+      {
+        "run": 121,
+        "seed": 1670134040,
+        "success": true,
+        "steps": 242,
+        "total_reward": 29.02000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4017455351665878
+      },
+      {
+        "run": 122,
+        "seed": 1670134041,
+        "success": true,
+        "steps": 266,
+        "total_reward": 19.240000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32760736645264776
+      },
+      {
+        "run": 123,
+        "seed": 1670134042,
+        "success": true,
+        "steps": 211,
+        "total_reward": 35.585000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41492213804713807
+      },
+      {
+        "run": 124,
+        "seed": 1670134043,
+        "success": false,
+        "steps": 15,
+        "total_reward": -9.245,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 125,
+        "seed": 1670134044,
+        "success": true,
+        "steps": 277,
+        "total_reward": 24.435000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27824839464170525
+      },
+      {
+        "run": 126,
+        "seed": 1670134045,
+        "success": true,
+        "steps": 251,
+        "total_reward": 29.73500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32844973991525717
+      },
+      {
+        "run": 127,
+        "seed": 1670134046,
+        "success": true,
+        "steps": 273,
+        "total_reward": 26.595000000000038,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5112823658215406
+      },
+      {
+        "run": 128,
+        "seed": 1670134047,
+        "success": true,
+        "steps": 205,
+        "total_reward": 28.095000000000088,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4766365785514721
+      },
+      {
+        "run": 129,
+        "seed": 1670134048,
+        "success": false,
+        "steps": 241,
+        "total_reward": -8.585000000000027,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.35875
+      },
+      {
+        "run": 130,
+        "seed": 1670134049,
+        "success": true,
+        "steps": 326,
+        "total_reward": 39.170000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30577346198123834
+      },
+      {
+        "run": 131,
+        "seed": 1670134050,
+        "success": true,
+        "steps": 189,
+        "total_reward": 27.02500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.49256597332207086
+      },
+      {
+        "run": 132,
+        "seed": 1670134051,
+        "success": true,
+        "steps": 222,
+        "total_reward": 34.03000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4232297469479673
+      },
+      {
+        "run": 133,
+        "seed": 1670134052,
+        "success": true,
+        "steps": 265,
+        "total_reward": 34.26500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.377548897834939
+      },
+      {
+        "run": 134,
+        "seed": 1670134053,
+        "success": true,
+        "steps": 195,
+        "total_reward": 30.8650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4122144522144522
+      },
+      {
+        "run": 135,
+        "seed": 1670134054,
+        "success": true,
+        "steps": 198,
+        "total_reward": 31.130000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4214463267474997
+      },
+      {
+        "run": 136,
+        "seed": 1670134055,
+        "success": true,
+        "steps": 205,
+        "total_reward": 28.265000000000047,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5014866200739131
+      },
+      {
+        "run": 137,
+        "seed": 1670134056,
+        "success": true,
+        "steps": 256,
+        "total_reward": 35.500000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3858220678562293
+      },
+      {
+        "run": 138,
+        "seed": 1670134057,
+        "success": true,
+        "steps": 237,
+        "total_reward": 36.72500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.387004862004862
+      },
+      {
+        "run": 139,
+        "seed": 1670134058,
+        "success": true,
+        "steps": 192,
+        "total_reward": 33.79000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4246029796029796
+      },
+      {
+        "run": 140,
+        "seed": 1670134059,
+        "success": true,
+        "steps": 207,
+        "total_reward": 39.1850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3860595753282825
+      },
+      {
+        "run": 141,
+        "seed": 1670134060,
+        "success": true,
+        "steps": 208,
+        "total_reward": 30.630000000000102,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44945858662613986
+      },
+      {
+        "run": 142,
+        "seed": 1670134061,
+        "success": true,
+        "steps": 275,
+        "total_reward": 32.96500000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.44093965853784417
+      },
+      {
+        "run": 143,
+        "seed": 1670134062,
+        "success": true,
+        "steps": 208,
+        "total_reward": 37.870000000000076,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3963830049261084
+      },
+      {
+        "run": 144,
+        "seed": 1670134063,
+        "success": true,
+        "steps": 248,
+        "total_reward": 30.5700000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3730573960353372
+      },
+      {
+        "run": 145,
+        "seed": 1670134064,
+        "success": true,
+        "steps": 252,
+        "total_reward": 38.52000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4025160875160875
+      },
+      {
+        "run": 146,
+        "seed": 1670134065,
+        "success": true,
+        "steps": 257,
+        "total_reward": 28.045000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.35824880968266926
+      },
+      {
+        "run": 147,
+        "seed": 1670134066,
+        "success": true,
+        "steps": 194,
+        "total_reward": 30.060000000000052,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4149821193299454
+      },
+      {
+        "run": 148,
+        "seed": 1670134067,
+        "success": true,
+        "steps": 238,
+        "total_reward": 32.69000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40098981900452485
+      },
+      {
+        "run": 149,
+        "seed": 1670134068,
+        "success": true,
+        "steps": 214,
+        "total_reward": 30.370000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40922278380848354
+      },
+      {
+        "run": 150,
+        "seed": 1670134069,
+        "success": true,
+        "steps": 193,
+        "total_reward": 36.2650000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45096489188560795
+      },
+      {
+        "run": 151,
+        "seed": 1670134070,
+        "success": true,
+        "steps": 162,
+        "total_reward": 30.79000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5013220551378446
+      },
+      {
+        "run": 152,
+        "seed": 1670134071,
+        "success": true,
+        "steps": 219,
+        "total_reward": 32.99500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36272993314972324
+      },
+      {
+        "run": 153,
+        "seed": 1670134072,
+        "success": true,
+        "steps": 277,
+        "total_reward": 28.695000000000114,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3542601091237602
+      },
+      {
+        "run": 154,
+        "seed": 1670134073,
+        "success": true,
+        "steps": 193,
+        "total_reward": 12.844999999999976,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30814200539742337
+      },
+      {
+        "run": 155,
+        "seed": 1670134074,
+        "success": true,
+        "steps": 273,
+        "total_reward": 38.4850000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33704216717053687
+      },
+      {
+        "run": 156,
+        "seed": 1670134075,
+        "success": true,
+        "steps": 195,
+        "total_reward": 28.345000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38910774410774407
+      },
+      {
+        "run": 157,
+        "seed": 1670134076,
+        "success": false,
+        "steps": 158,
+        "total_reward": 19.470000000000084,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.42833754894147813
+      },
+      {
+        "run": 158,
+        "seed": 1670134077,
+        "success": true,
+        "steps": 279,
+        "total_reward": 34.105000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3246463378371273
+      },
+      {
+        "run": 159,
+        "seed": 1670134078,
+        "success": false,
+        "steps": 136,
+        "total_reward": 5.630000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.6757575757575758
+      },
+      {
+        "run": 160,
+        "seed": 1670134079,
+        "success": true,
+        "steps": 337,
+        "total_reward": 30.125000000000174,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3968879551820728
+      },
+      {
+        "run": 161,
+        "seed": 1670134080,
+        "success": false,
+        "steps": 185,
+        "total_reward": 14.725000000000037,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.4388563140831743
+      },
+      {
+        "run": 162,
+        "seed": 1670134081,
+        "success": false,
+        "steps": 111,
+        "total_reward": 10.995000000000008,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4679411249854125
+      },
+      {
+        "run": 163,
+        "seed": 1670134082,
+        "success": true,
+        "steps": 194,
+        "total_reward": 31.870000000000086,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4718859467509353
+      },
+      {
+        "run": 164,
+        "seed": 1670134083,
+        "success": true,
+        "steps": 169,
+        "total_reward": 23.585000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4381749232335704
+      },
+      {
+        "run": 165,
+        "seed": 1670134084,
+        "success": true,
+        "steps": 185,
+        "total_reward": 26.24500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41852570087864205
+      },
+      {
+        "run": 166,
+        "seed": 1670134085,
+        "success": true,
+        "steps": 359,
+        "total_reward": 29.885000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3441769163644164
+      },
+      {
+        "run": 167,
+        "seed": 1670134086,
+        "success": true,
+        "steps": 212,
+        "total_reward": 28.550000000000104,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37688503790670974
+      },
+      {
+        "run": 168,
+        "seed": 1670134087,
+        "success": true,
+        "steps": 187,
+        "total_reward": 26.415000000000056,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4533277591973244
+      },
+      {
+        "run": 169,
+        "seed": 1670134088,
+        "success": true,
+        "steps": 164,
+        "total_reward": 24.310000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4435406227166663
+      },
+      {
+        "run": 170,
+        "seed": 1670134089,
+        "success": true,
+        "steps": 285,
+        "total_reward": 30.135000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2841387271732099
+      },
+      {
+        "run": 171,
+        "seed": 1670134090,
+        "success": false,
+        "steps": 89,
+        "total_reward": 1.3650000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.376984126984127
+      },
+      {
+        "run": 172,
+        "seed": 1670134091,
+        "success": true,
+        "steps": 252,
+        "total_reward": 30.540000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3075883838383838
+      },
+      {
+        "run": 173,
+        "seed": 1670134092,
+        "success": true,
+        "steps": 284,
+        "total_reward": 28.27000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36786339735256146
+      },
+      {
+        "run": 174,
+        "seed": 1670134093,
+        "success": true,
+        "steps": 243,
+        "total_reward": 37.52500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.412994944465136
+      },
+      {
+        "run": 175,
+        "seed": 1670134094,
+        "success": true,
+        "steps": 203,
+        "total_reward": 29.235000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4581354593119299
+      },
+      {
+        "run": 176,
+        "seed": 1670134095,
+        "success": true,
+        "steps": 316,
+        "total_reward": 42.720000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3705851957896581
+      },
+      {
+        "run": 177,
+        "seed": 1670134096,
+        "success": true,
+        "steps": 212,
+        "total_reward": 43.430000000000085,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5204596410581364
+      },
+      {
+        "run": 178,
+        "seed": 1670134097,
+        "success": false,
+        "steps": 172,
+        "total_reward": 16.280000000000037,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4624744173763782
+      },
+      {
+        "run": 179,
+        "seed": 1670134098,
+        "success": false,
+        "steps": 137,
+        "total_reward": 9.365000000000023,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.3734848484848485
+      },
+      {
+        "run": 180,
+        "seed": 1670134099,
+        "success": true,
+        "steps": 219,
+        "total_reward": 29.08500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3898436210936211
+      },
+      {
+        "run": 181,
+        "seed": 1670134100,
+        "success": true,
+        "steps": 225,
+        "total_reward": 35.81500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.411843108720568
+      },
+      {
+        "run": 182,
+        "seed": 1670134101,
+        "success": true,
+        "steps": 273,
+        "total_reward": 40.735000000000156,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.41380477896190193
+      },
+      {
+        "run": 183,
+        "seed": 1670134102,
+        "success": true,
+        "steps": 303,
+        "total_reward": 44.10500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36620432296420524
+      },
+      {
+        "run": 184,
+        "seed": 1670134103,
+        "success": true,
+        "steps": 258,
+        "total_reward": 28.84000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4047600732600733
+      },
+      {
+        "run": 185,
+        "seed": 1670134104,
+        "success": false,
+        "steps": 142,
+        "total_reward": -0.13999999999999702,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.31843040743779055
+      },
+      {
+        "run": 186,
+        "seed": 1670134105,
+        "success": true,
+        "steps": 167,
+        "total_reward": 34.87500000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5084148458921598
+      },
+      {
+        "run": 187,
+        "seed": 1670134106,
+        "success": false,
+        "steps": 156,
+        "total_reward": 14.080000000000016,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4148148148148148
+      },
+      {
+        "run": 188,
+        "seed": 1670134107,
+        "success": true,
+        "steps": 190,
+        "total_reward": 32.580000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46151545037027064
+      },
+      {
+        "run": 189,
+        "seed": 1670134108,
+        "success": true,
+        "steps": 314,
+        "total_reward": 45.3000000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3673857302620514
+      },
+      {
+        "run": 190,
+        "seed": 1670134109,
+        "success": false,
+        "steps": 147,
+        "total_reward": 5.004999999999967,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.42652613087395697
+      },
+      {
+        "run": 191,
+        "seed": 1670134110,
+        "success": true,
+        "steps": 151,
+        "total_reward": 26.54500000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45455677655677657
+      },
+      {
+        "run": 192,
+        "seed": 1670134111,
+        "success": false,
+        "steps": 107,
+        "total_reward": 6.324999999999996,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.3242424242424242
+      },
+      {
+        "run": 193,
+        "seed": 1670134112,
+        "success": true,
+        "steps": 189,
+        "total_reward": 26.605000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3880667120603182
+      },
+      {
+        "run": 194,
+        "seed": 1670134113,
+        "success": false,
+        "steps": 108,
+        "total_reward": 4.059999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3632116690192915
+      },
+      {
+        "run": 195,
+        "seed": 1670134114,
+        "success": false,
+        "steps": 235,
+        "total_reward": 19.21500000000011,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.4558493724789609
+      },
+      {
+        "run": 196,
+        "seed": 1670134115,
+        "success": true,
+        "steps": 255,
+        "total_reward": 35.31500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36681782562217347
+      },
+      {
+        "run": 197,
+        "seed": 1670134116,
+        "success": true,
+        "steps": 217,
+        "total_reward": 28.935000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.40273475544063775
+      },
+      {
+        "run": 198,
+        "seed": 1670134117,
+        "success": false,
+        "steps": 66,
+        "total_reward": 1.4700000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.5235393147157853
+      },
+      {
+        "run": 199,
+        "seed": 1670134118,
+        "success": true,
+        "steps": 179,
+        "total_reward": 33.275000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.45684747270273585
+      },
+      {
+        "run": 200,
+        "seed": 1670134119,
+        "success": true,
+        "steps": 259,
+        "total_reward": 25.885000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34996975225496896
+      }
+    ],
+    "avg_chemotaxis_index": 0.3234178459090497,
+    "avg_time_in_attractant": 0.6617089229545249,
+    "avg_approach_frequency": 0.3959520492394816,
+    "avg_path_efficiency": 0.0455830884353177,
+    "post_convergence_chemotaxis_index": 0.3348406111260049,
+    "post_convergence_time_in_attractant": 0.6674203055630025,
+    "post_convergence_approach_frequency": 0.40126540836701546,
+    "post_convergence_path_efficiency": 0.04752787055641265,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/20251229_103149.json
+++ b/artifacts/benchmarks/20251229_110151/20251229_103149.json
@@ -1,0 +1,2069 @@
+{
+  "experiment_id": "20251229_103149",
+  "timestamp": "2025-12-29T10:45:18.024561+00:00",
+  "config_file": "configs/examples/mlp_predators_small.yml",
+  "config_hash": "796ead6841d18564d2d4b5a7dc3107ca669c2ea3534ea3633f189e3b7f1791cf",
+  "git_commit": "e5bda1d20d7244a1f5ce1d52fc59c559ba64a31e",
+  "git_branch": "main",
+  "git_dirty": false,
+  "system": {
+    "python_version": "3.12.10",
+    "qiskit_version": "1.4.5",
+    "torch_version": "2.9.0",
+    "device_type": "cpu",
+    "qpu_backend": null
+  },
+  "exports_path": "exports/20251229_103149",
+  "benchmark": null,
+  "config_summary": {
+    "brain_type": "mlp",
+    "environment_type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "results": {
+    "total_runs": 200,
+    "success_rate": 0.525,
+    "avg_steps": 286.195,
+    "avg_reward": 17.785225000000064,
+    "avg_foods_collected": 7.445,
+    "avg_distance_efficiency": 0.28311904233388313,
+    "completed_all_food": 105,
+    "starved": 17,
+    "max_steps_reached": 4,
+    "goal_reached": 0,
+    "predator_deaths": 74,
+    "avg_predator_encounters": 10.485,
+    "avg_successful_evasions": 9.925,
+    "converged": true,
+    "convergence_run": 64,
+    "runs_to_convergence": 63,
+    "post_convergence_success_rate": 0.6496350364963503,
+    "post_convergence_avg_steps": 329.13483146067415,
+    "post_convergence_avg_foods": 8.569343065693431,
+    "post_convergence_variance": 0.2276093558527359,
+    "post_convergence_distance_efficiency": 0.31837919002263704,
+    "composite_benchmark_score": 0.49236777160533124,
+    "learning_speed": 0.745,
+    "learning_speed_episodes": 51,
+    "stability": 0.2656119263654745,
+    "per_run_results": [
+      {
+        "run": 1,
+        "seed": 1173014599,
+        "success": false,
+        "steps": 240,
+        "total_reward": -13.899999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.1111111111111111
+      },
+      {
+        "run": 2,
+        "seed": 1173014600,
+        "success": false,
+        "steps": 157,
+        "total_reward": -16.985,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 3,
+        "seed": 1173014601,
+        "success": false,
+        "steps": 200,
+        "total_reward": -11.079999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 4,
+        "seed": 1173014602,
+        "success": false,
+        "steps": 242,
+        "total_reward": -13.000000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.18098556568489949
+      },
+      {
+        "run": 5,
+        "seed": 1173014603,
+        "success": false,
+        "steps": 200,
+        "total_reward": -10.269999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 6,
+        "seed": 1173014604,
+        "success": false,
+        "steps": 107,
+        "total_reward": -5.825000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.33087460484720754
+      },
+      {
+        "run": 7,
+        "seed": 1173014605,
+        "success": false,
+        "steps": 88,
+        "total_reward": -8.34,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.11594202898550725
+      },
+      {
+        "run": 8,
+        "seed": 1173014606,
+        "success": false,
+        "steps": 106,
+        "total_reward": -12.17,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 9,
+        "seed": 1173014607,
+        "success": false,
+        "steps": 176,
+        "total_reward": 6.71000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.524886756946818
+      },
+      {
+        "run": 10,
+        "seed": 1173014608,
+        "success": false,
+        "steps": 176,
+        "total_reward": -0.07000000000003048,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.1965669988925803
+      },
+      {
+        "run": 11,
+        "seed": 1173014609,
+        "success": false,
+        "steps": 320,
+        "total_reward": 3.279999999999987,
+        "termination_reason": "starved",
+        "foods_collected": 3,
+        "distance_efficiency": 0.08840641032421855
+      },
+      {
+        "run": 12,
+        "seed": 1173014610,
+        "success": false,
+        "steps": 200,
+        "total_reward": -6.489999999999995,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 13,
+        "seed": 1173014611,
+        "success": false,
+        "steps": 54,
+        "total_reward": -10.73,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 14,
+        "seed": 1173014612,
+        "success": false,
+        "steps": 200,
+        "total_reward": -10.659999999999997,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 15,
+        "seed": 1173014613,
+        "success": false,
+        "steps": 280,
+        "total_reward": -5.029999999999999,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.1218995765275257
+      },
+      {
+        "run": 16,
+        "seed": 1173014614,
+        "success": false,
+        "steps": 240,
+        "total_reward": -11.509999999999993,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.06993006993006994
+      },
+      {
+        "run": 17,
+        "seed": 1173014615,
+        "success": false,
+        "steps": 212,
+        "total_reward": -17.729999999999997,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.6666666666666666
+      },
+      {
+        "run": 18,
+        "seed": 1173014616,
+        "success": false,
+        "steps": 240,
+        "total_reward": -15.91000000000001,
+        "termination_reason": "starved",
+        "foods_collected": 1,
+        "distance_efficiency": 0.04093567251461988
+      },
+      {
+        "run": 19,
+        "seed": 1173014617,
+        "success": false,
+        "steps": 91,
+        "total_reward": -14.015,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.1509433962264151
+      },
+      {
+        "run": 20,
+        "seed": 1173014618,
+        "success": false,
+        "steps": 205,
+        "total_reward": -4.635000000000002,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.2214105339105339
+      },
+      {
+        "run": 21,
+        "seed": 1173014619,
+        "success": false,
+        "steps": 440,
+        "total_reward": -0.2100000000000808,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.20498716975357686
+      },
+      {
+        "run": 22,
+        "seed": 1173014620,
+        "success": false,
+        "steps": 200,
+        "total_reward": -9.109999999999998,
+        "termination_reason": "starved",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 23,
+        "seed": 1173014621,
+        "success": false,
+        "steps": 397,
+        "total_reward": -0.8950000000000919,
+        "termination_reason": "starved",
+        "foods_collected": 6,
+        "distance_efficiency": 0.27626475359279146
+      },
+      {
+        "run": 24,
+        "seed": 1173014622,
+        "success": false,
+        "steps": 93,
+        "total_reward": -9.004999999999999,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.0945945945945946
+      },
+      {
+        "run": 25,
+        "seed": 1173014623,
+        "success": false,
+        "steps": 340,
+        "total_reward": -2.3400000000000087,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.16071905555419413
+      },
+      {
+        "run": 26,
+        "seed": 1173014624,
+        "success": false,
+        "steps": 25,
+        "total_reward": -6.825,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 27,
+        "seed": 1173014625,
+        "success": false,
+        "steps": 280,
+        "total_reward": 3.0599999999999365,
+        "termination_reason": "starved",
+        "foods_collected": 2,
+        "distance_efficiency": 0.16348088531187122
+      },
+      {
+        "run": 28,
+        "seed": 1173014626,
+        "success": false,
+        "steps": 360,
+        "total_reward": 8.540000000000056,
+        "termination_reason": "starved",
+        "foods_collected": 4,
+        "distance_efficiency": 0.13269918645990098
+      },
+      {
+        "run": 29,
+        "seed": 1173014627,
+        "success": false,
+        "steps": 317,
+        "total_reward": -3.4849999999999905,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.2229923171467907
+      },
+      {
+        "run": 30,
+        "seed": 1173014628,
+        "success": false,
+        "steps": 500,
+        "total_reward": 31.680000000000287,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.26679784725394273
+      },
+      {
+        "run": 31,
+        "seed": 1173014629,
+        "success": false,
+        "steps": 336,
+        "total_reward": -2.0200000000000333,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.20143087982587665
+      },
+      {
+        "run": 32,
+        "seed": 1173014630,
+        "success": false,
+        "steps": 474,
+        "total_reward": 16.630000000000045,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.1793295413697706
+      },
+      {
+        "run": 33,
+        "seed": 1173014631,
+        "success": false,
+        "steps": 156,
+        "total_reward": -10.759999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.075
+      },
+      {
+        "run": 34,
+        "seed": 1173014632,
+        "success": true,
+        "steps": 463,
+        "total_reward": 26.985000000000223,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.17810364763754594
+      },
+      {
+        "run": 35,
+        "seed": 1173014633,
+        "success": false,
+        "steps": 39,
+        "total_reward": -5.645,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.4375
+      },
+      {
+        "run": 36,
+        "seed": 1173014634,
+        "success": false,
+        "steps": 475,
+        "total_reward": 15.69500000000026,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.21997653197034372
+      },
+      {
+        "run": 37,
+        "seed": 1173014635,
+        "success": true,
+        "steps": 488,
+        "total_reward": 23.93000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.18845884775803318
+      },
+      {
+        "run": 38,
+        "seed": 1173014636,
+        "success": false,
+        "steps": 500,
+        "total_reward": 27.18000000000021,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.16633949504320314
+      },
+      {
+        "run": 39,
+        "seed": 1173014637,
+        "success": true,
+        "steps": 282,
+        "total_reward": 45.03000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4028974528453424
+      },
+      {
+        "run": 40,
+        "seed": 1173014638,
+        "success": false,
+        "steps": 136,
+        "total_reward": 7.530000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3370255183413078
+      },
+      {
+        "run": 41,
+        "seed": 1173014639,
+        "success": false,
+        "steps": 138,
+        "total_reward": 6.350000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.3717948717948718
+      },
+      {
+        "run": 42,
+        "seed": 1173014640,
+        "success": false,
+        "steps": 258,
+        "total_reward": 8.719999999999985,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3132008914756362
+      },
+      {
+        "run": 43,
+        "seed": 1173014641,
+        "success": true,
+        "steps": 385,
+        "total_reward": 27.305000000000042,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23940162762042308
+      },
+      {
+        "run": 44,
+        "seed": 1173014642,
+        "success": true,
+        "steps": 373,
+        "total_reward": 24.56500000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.1965930040067237
+      },
+      {
+        "run": 45,
+        "seed": 1173014643,
+        "success": false,
+        "steps": 82,
+        "total_reward": -1.9499999999999993,
+        "termination_reason": "predator",
+        "foods_collected": 1,
+        "distance_efficiency": 0.19230769230769232
+      },
+      {
+        "run": 46,
+        "seed": 1173014644,
+        "success": true,
+        "steps": 382,
+        "total_reward": 34.01000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2157901244947428
+      },
+      {
+        "run": 47,
+        "seed": 1173014645,
+        "success": true,
+        "steps": 429,
+        "total_reward": 21.505000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2186114650154823
+      },
+      {
+        "run": 48,
+        "seed": 1173014646,
+        "success": true,
+        "steps": 458,
+        "total_reward": 32.77000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24840229888381243
+      },
+      {
+        "run": 49,
+        "seed": 1173014647,
+        "success": true,
+        "steps": 402,
+        "total_reward": 19.390000000000025,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.21879557883759565
+      },
+      {
+        "run": 50,
+        "seed": 1173014648,
+        "success": true,
+        "steps": 379,
+        "total_reward": 24.264999999999997,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2588276323160044
+      },
+      {
+        "run": 51,
+        "seed": 1173014649,
+        "success": true,
+        "steps": 435,
+        "total_reward": 32.34500000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.25337588606191147
+      },
+      {
+        "run": 52,
+        "seed": 1173014650,
+        "success": false,
+        "steps": 338,
+        "total_reward": 10.530000000000005,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.32447865377472
+      },
+      {
+        "run": 53,
+        "seed": 1173014651,
+        "success": false,
+        "steps": 500,
+        "total_reward": 31.250000000000192,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.19785924351901374
+      },
+      {
+        "run": 54,
+        "seed": 1173014652,
+        "success": true,
+        "steps": 337,
+        "total_reward": 24.20500000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3069596202176381
+      },
+      {
+        "run": 55,
+        "seed": 1173014653,
+        "success": false,
+        "steps": 119,
+        "total_reward": -2.575000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.2904511398055157
+      },
+      {
+        "run": 56,
+        "seed": 1173014654,
+        "success": true,
+        "steps": 312,
+        "total_reward": 32.07000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30331517020297855
+      },
+      {
+        "run": 57,
+        "seed": 1173014655,
+        "success": false,
+        "steps": 500,
+        "total_reward": 20.389999999999976,
+        "termination_reason": "max_steps",
+        "foods_collected": 9,
+        "distance_efficiency": 0.249966726144006
+      },
+      {
+        "run": 58,
+        "seed": 1173014656,
+        "success": true,
+        "steps": 339,
+        "total_reward": 25.545000000000112,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30388164884132624
+      },
+      {
+        "run": 59,
+        "seed": 1173014657,
+        "success": false,
+        "steps": 188,
+        "total_reward": 9.780000000000022,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.35652534599903024
+      },
+      {
+        "run": 60,
+        "seed": 1173014658,
+        "success": false,
+        "steps": 128,
+        "total_reward": 9.449999999999985,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.42874085666655326
+      },
+      {
+        "run": 61,
+        "seed": 1173014659,
+        "success": true,
+        "steps": 317,
+        "total_reward": 31.905000000000165,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3312012149773061
+      },
+      {
+        "run": 62,
+        "seed": 1173014660,
+        "success": true,
+        "steps": 328,
+        "total_reward": 31.020000000000163,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.20957600611114433
+      },
+      {
+        "run": 63,
+        "seed": 1173014661,
+        "success": false,
+        "steps": 55,
+        "total_reward": -5.224999999999998,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.2222222222222222
+      },
+      {
+        "run": 64,
+        "seed": 1173014662,
+        "success": true,
+        "steps": 414,
+        "total_reward": 42.260000000000154,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33074724258974336
+      },
+      {
+        "run": 65,
+        "seed": 1173014663,
+        "success": true,
+        "steps": 367,
+        "total_reward": 36.075000000000166,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.37622633979776837
+      },
+      {
+        "run": 66,
+        "seed": 1173014664,
+        "success": true,
+        "steps": 367,
+        "total_reward": 27.905000000000026,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3228520691020691
+      },
+      {
+        "run": 67,
+        "seed": 1173014665,
+        "success": true,
+        "steps": 415,
+        "total_reward": 36.475000000000136,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2696200532982402
+      },
+      {
+        "run": 68,
+        "seed": 1173014666,
+        "success": true,
+        "steps": 466,
+        "total_reward": 32.2900000000002,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29363673123085554
+      },
+      {
+        "run": 69,
+        "seed": 1173014667,
+        "success": true,
+        "steps": 187,
+        "total_reward": 23.515000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4550686813186813
+      },
+      {
+        "run": 70,
+        "seed": 1173014668,
+        "success": true,
+        "steps": 370,
+        "total_reward": 26.670000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31254839484992253
+      },
+      {
+        "run": 71,
+        "seed": 1173014669,
+        "success": true,
+        "steps": 318,
+        "total_reward": 20.32000000000003,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.32000307209342804
+      },
+      {
+        "run": 72,
+        "seed": 1173014670,
+        "success": true,
+        "steps": 300,
+        "total_reward": 38.3500000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3422953014635543
+      },
+      {
+        "run": 73,
+        "seed": 1173014671,
+        "success": true,
+        "steps": 245,
+        "total_reward": 33.70500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3524557189639077
+      },
+      {
+        "run": 74,
+        "seed": 1173014672,
+        "success": true,
+        "steps": 318,
+        "total_reward": 34.8800000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26970964872658143
+      },
+      {
+        "run": 75,
+        "seed": 1173014673,
+        "success": false,
+        "steps": 281,
+        "total_reward": 9.035000000000029,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3175518524219735
+      },
+      {
+        "run": 76,
+        "seed": 1173014674,
+        "success": true,
+        "steps": 368,
+        "total_reward": 44.82000000000027,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29609038278110866
+      },
+      {
+        "run": 77,
+        "seed": 1173014675,
+        "success": true,
+        "steps": 254,
+        "total_reward": 29.87000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3774293957194358
+      },
+      {
+        "run": 78,
+        "seed": 1173014676,
+        "success": true,
+        "steps": 353,
+        "total_reward": 39.28500000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30001337299163167
+      },
+      {
+        "run": 79,
+        "seed": 1173014677,
+        "success": false,
+        "steps": 136,
+        "total_reward": 6.649999999999984,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.2785530551576483
+      },
+      {
+        "run": 80,
+        "seed": 1173014678,
+        "success": false,
+        "steps": 314,
+        "total_reward": 8.479999999999958,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.29705630194352
+      },
+      {
+        "run": 81,
+        "seed": 1173014679,
+        "success": false,
+        "steps": 151,
+        "total_reward": 8.975000000000016,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.4034104784104784
+      },
+      {
+        "run": 82,
+        "seed": 1173014680,
+        "success": false,
+        "steps": 327,
+        "total_reward": 7.884999999999945,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.22140611461442186
+      },
+      {
+        "run": 83,
+        "seed": 1173014681,
+        "success": true,
+        "steps": 331,
+        "total_reward": 32.63500000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27805751719544824
+      },
+      {
+        "run": 84,
+        "seed": 1173014682,
+        "success": true,
+        "steps": 304,
+        "total_reward": 24.960000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2754718323974402
+      },
+      {
+        "run": 85,
+        "seed": 1173014683,
+        "success": false,
+        "steps": 322,
+        "total_reward": 25.400000000000126,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.47225305558638886
+      },
+      {
+        "run": 86,
+        "seed": 1173014684,
+        "success": true,
+        "steps": 204,
+        "total_reward": 34.12000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4723522220184607
+      },
+      {
+        "run": 87,
+        "seed": 1173014685,
+        "success": false,
+        "steps": 140,
+        "total_reward": -0.5200000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.4612573099415205
+      },
+      {
+        "run": 88,
+        "seed": 1173014686,
+        "success": true,
+        "steps": 351,
+        "total_reward": 20.214999999999982,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2830703895345839
+      },
+      {
+        "run": 89,
+        "seed": 1173014687,
+        "success": true,
+        "steps": 294,
+        "total_reward": 23.630000000000155,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2584301807985394
+      },
+      {
+        "run": 90,
+        "seed": 1173014688,
+        "success": false,
+        "steps": 220,
+        "total_reward": 4.7199999999999775,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.21952495974235106
+      },
+      {
+        "run": 91,
+        "seed": 1173014689,
+        "success": false,
+        "steps": 254,
+        "total_reward": 19.000000000000146,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.31677298787261193
+      },
+      {
+        "run": 92,
+        "seed": 1173014690,
+        "success": false,
+        "steps": 201,
+        "total_reward": 4.954999999999977,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.2703995768347825
+      },
+      {
+        "run": 93,
+        "seed": 1173014691,
+        "success": false,
+        "steps": 160,
+        "total_reward": 5.71999999999997,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3923306595365419
+      },
+      {
+        "run": 94,
+        "seed": 1173014692,
+        "success": true,
+        "steps": 376,
+        "total_reward": 34.01000000000023,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3436788337233543
+      },
+      {
+        "run": 95,
+        "seed": 1173014693,
+        "success": false,
+        "steps": 329,
+        "total_reward": 16.814999999999966,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.28192715321718553
+      },
+      {
+        "run": 96,
+        "seed": 1173014694,
+        "success": true,
+        "steps": 379,
+        "total_reward": 27.415000000000113,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.318669092741043
+      },
+      {
+        "run": 97,
+        "seed": 1173014695,
+        "success": true,
+        "steps": 355,
+        "total_reward": 28.245000000000115,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3095910640483698
+      },
+      {
+        "run": 98,
+        "seed": 1173014696,
+        "success": true,
+        "steps": 339,
+        "total_reward": 26.505000000000145,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.324630370703302
+      },
+      {
+        "run": 99,
+        "seed": 1173014697,
+        "success": true,
+        "steps": 340,
+        "total_reward": 32.550000000000125,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28106503770420554
+      },
+      {
+        "run": 100,
+        "seed": 1173014698,
+        "success": false,
+        "steps": 343,
+        "total_reward": 22.59500000000014,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3660937166889548
+      },
+      {
+        "run": 101,
+        "seed": 1173014699,
+        "success": false,
+        "steps": 79,
+        "total_reward": -4.695,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.22660294703305453
+      },
+      {
+        "run": 102,
+        "seed": 1173014700,
+        "success": true,
+        "steps": 314,
+        "total_reward": 26.140000000000043,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3525294363138206
+      },
+      {
+        "run": 103,
+        "seed": 1173014701,
+        "success": false,
+        "steps": 292,
+        "total_reward": 7.170000000000158,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.3014476491043511
+      },
+      {
+        "run": 104,
+        "seed": 1173014702,
+        "success": true,
+        "steps": 260,
+        "total_reward": 23.960000000000058,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3132467532467532
+      },
+      {
+        "run": 105,
+        "seed": 1173014703,
+        "success": true,
+        "steps": 217,
+        "total_reward": 29.875000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34388038120414616
+      },
+      {
+        "run": 106,
+        "seed": 1173014704,
+        "success": true,
+        "steps": 397,
+        "total_reward": 44.425000000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3550889985933929
+      },
+      {
+        "run": 107,
+        "seed": 1173014705,
+        "success": false,
+        "steps": 385,
+        "total_reward": 18.21500000000021,
+        "termination_reason": "starved",
+        "foods_collected": 9,
+        "distance_efficiency": 0.3840599007733839
+      },
+      {
+        "run": 108,
+        "seed": 1173014706,
+        "success": true,
+        "steps": 422,
+        "total_reward": 39.86999999999996,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2823153723828583
+      },
+      {
+        "run": 109,
+        "seed": 1173014707,
+        "success": true,
+        "steps": 244,
+        "total_reward": 32.53000000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4672541996047431
+      },
+      {
+        "run": 110,
+        "seed": 1173014708,
+        "success": false,
+        "steps": 162,
+        "total_reward": 4.639999999999992,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.2321698113207547
+      },
+      {
+        "run": 111,
+        "seed": 1173014709,
+        "success": true,
+        "steps": 375,
+        "total_reward": 30.705000000000105,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2303422161710557
+      },
+      {
+        "run": 112,
+        "seed": 1173014710,
+        "success": false,
+        "steps": 272,
+        "total_reward": 13.450000000000056,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.2682796584542908
+      },
+      {
+        "run": 113,
+        "seed": 1173014711,
+        "success": true,
+        "steps": 242,
+        "total_reward": 29.08000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3675868417973681
+      },
+      {
+        "run": 114,
+        "seed": 1173014712,
+        "success": true,
+        "steps": 392,
+        "total_reward": 29.46000000000021,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24850319726805298
+      },
+      {
+        "run": 115,
+        "seed": 1173014713,
+        "success": true,
+        "steps": 350,
+        "total_reward": 27.05000000000006,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29611668937939395
+      },
+      {
+        "run": 116,
+        "seed": 1173014714,
+        "success": true,
+        "steps": 355,
+        "total_reward": 29.725000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2797753585269113
+      },
+      {
+        "run": 117,
+        "seed": 1173014715,
+        "success": true,
+        "steps": 265,
+        "total_reward": 37.185000000000144,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3537015349767464
+      },
+      {
+        "run": 118,
+        "seed": 1173014716,
+        "success": false,
+        "steps": 311,
+        "total_reward": 11.885000000000097,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.26169566640885605
+      },
+      {
+        "run": 119,
+        "seed": 1173014717,
+        "success": false,
+        "steps": 93,
+        "total_reward": 4.294999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.3076936026936027
+      },
+      {
+        "run": 120,
+        "seed": 1173014718,
+        "success": true,
+        "steps": 294,
+        "total_reward": 30.96000000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3061343207582458
+      },
+      {
+        "run": 121,
+        "seed": 1173014719,
+        "success": true,
+        "steps": 315,
+        "total_reward": 25.46500000000004,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.38135700771536685
+      },
+      {
+        "run": 122,
+        "seed": 1173014720,
+        "success": true,
+        "steps": 230,
+        "total_reward": 28.000000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.43689190711249537
+      },
+      {
+        "run": 123,
+        "seed": 1173014721,
+        "success": true,
+        "steps": 219,
+        "total_reward": 23.225000000000037,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3072551578433932
+      },
+      {
+        "run": 124,
+        "seed": 1173014722,
+        "success": true,
+        "steps": 398,
+        "total_reward": 31.79000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2984459924254351
+      },
+      {
+        "run": 125,
+        "seed": 1173014723,
+        "success": false,
+        "steps": 167,
+        "total_reward": 15.325000000000031,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.43227513227513226
+      },
+      {
+        "run": 126,
+        "seed": 1173014724,
+        "success": false,
+        "steps": 90,
+        "total_reward": 2.869999999999978,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.49420289855072463
+      },
+      {
+        "run": 127,
+        "seed": 1173014725,
+        "success": false,
+        "steps": 180,
+        "total_reward": 16.090000000000092,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.4729166666666667
+      },
+      {
+        "run": 128,
+        "seed": 1173014726,
+        "success": true,
+        "steps": 231,
+        "total_reward": 31.825000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3588126937034193
+      },
+      {
+        "run": 129,
+        "seed": 1173014727,
+        "success": true,
+        "steps": 427,
+        "total_reward": 27.955000000000094,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.24186641297759887
+      },
+      {
+        "run": 130,
+        "seed": 1173014728,
+        "success": true,
+        "steps": 420,
+        "total_reward": 36.130000000000095,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2933647160503274
+      },
+      {
+        "run": 131,
+        "seed": 1173014729,
+        "success": true,
+        "steps": 482,
+        "total_reward": 13.909999999999934,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2957795904730234
+      },
+      {
+        "run": 132,
+        "seed": 1173014730,
+        "success": false,
+        "steps": 271,
+        "total_reward": 8.70500000000008,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.2457485490813903
+      },
+      {
+        "run": 133,
+        "seed": 1173014731,
+        "success": false,
+        "steps": 6,
+        "total_reward": -9.18,
+        "termination_reason": "predator",
+        "foods_collected": 0,
+        "distance_efficiency": 0.0
+      },
+      {
+        "run": 134,
+        "seed": 1173014732,
+        "success": true,
+        "steps": 274,
+        "total_reward": 27.610000000000117,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2439475761399136
+      },
+      {
+        "run": 135,
+        "seed": 1173014733,
+        "success": true,
+        "steps": 373,
+        "total_reward": 28.815000000000087,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.31986640497363517
+      },
+      {
+        "run": 136,
+        "seed": 1173014734,
+        "success": true,
+        "steps": 242,
+        "total_reward": 39.300000000000075,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.5074675513648799
+      },
+      {
+        "run": 137,
+        "seed": 1173014735,
+        "success": true,
+        "steps": 355,
+        "total_reward": 18.724999999999987,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2608210155235327
+      },
+      {
+        "run": 138,
+        "seed": 1173014736,
+        "success": false,
+        "steps": 247,
+        "total_reward": 13.48500000000006,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.4087432959627232
+      },
+      {
+        "run": 139,
+        "seed": 1173014737,
+        "success": true,
+        "steps": 248,
+        "total_reward": 34.87000000000008,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3773502230331599
+      },
+      {
+        "run": 140,
+        "seed": 1173014738,
+        "success": false,
+        "steps": 289,
+        "total_reward": 10.905000000000037,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.272743066267036
+      },
+      {
+        "run": 141,
+        "seed": 1173014739,
+        "success": true,
+        "steps": 369,
+        "total_reward": 34.66500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2599547665048307
+      },
+      {
+        "run": 142,
+        "seed": 1173014740,
+        "success": true,
+        "steps": 257,
+        "total_reward": 27.805000000000092,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28184287417326276
+      },
+      {
+        "run": 143,
+        "seed": 1173014741,
+        "success": true,
+        "steps": 299,
+        "total_reward": 25.055000000000078,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26150086602038936
+      },
+      {
+        "run": 144,
+        "seed": 1173014742,
+        "success": false,
+        "steps": 172,
+        "total_reward": 4.440000000000003,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.4024769262948728
+      },
+      {
+        "run": 145,
+        "seed": 1173014743,
+        "success": true,
+        "steps": 369,
+        "total_reward": 28.02500000000012,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3021463799358536
+      },
+      {
+        "run": 146,
+        "seed": 1173014744,
+        "success": true,
+        "steps": 435,
+        "total_reward": 41.695000000000135,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3442325669204901
+      },
+      {
+        "run": 147,
+        "seed": 1173014745,
+        "success": false,
+        "steps": 320,
+        "total_reward": 14.480000000000093,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.35583385508080057
+      },
+      {
+        "run": 148,
+        "seed": 1173014746,
+        "success": true,
+        "steps": 332,
+        "total_reward": 28.56000000000009,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27581474178311566
+      },
+      {
+        "run": 149,
+        "seed": 1173014747,
+        "success": false,
+        "steps": 320,
+        "total_reward": 15.720000000000109,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.25273994935261507
+      },
+      {
+        "run": 150,
+        "seed": 1173014748,
+        "success": true,
+        "steps": 226,
+        "total_reward": 31.61000000000005,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39362890693535857
+      },
+      {
+        "run": 151,
+        "seed": 1173014749,
+        "success": true,
+        "steps": 226,
+        "total_reward": 28.510000000000062,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.396102114260009
+      },
+      {
+        "run": 152,
+        "seed": 1173014750,
+        "success": false,
+        "steps": 291,
+        "total_reward": 6.195000000000061,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.34119152046783624
+      },
+      {
+        "run": 153,
+        "seed": 1173014751,
+        "success": true,
+        "steps": 426,
+        "total_reward": 11.349999999999948,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.17601399132137902
+      },
+      {
+        "run": 154,
+        "seed": 1173014752,
+        "success": true,
+        "steps": 298,
+        "total_reward": 20.600000000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.39541678814248893
+      },
+      {
+        "run": 155,
+        "seed": 1173014753,
+        "success": true,
+        "steps": 304,
+        "total_reward": 21.720000000000063,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34849587714180796
+      },
+      {
+        "run": 156,
+        "seed": 1173014754,
+        "success": false,
+        "steps": 117,
+        "total_reward": 6.725000000000016,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.44750957854406126
+      },
+      {
+        "run": 157,
+        "seed": 1173014755,
+        "success": true,
+        "steps": 462,
+        "total_reward": 18.30999999999991,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.17114253968734444
+      },
+      {
+        "run": 158,
+        "seed": 1173014756,
+        "success": true,
+        "steps": 277,
+        "total_reward": 35.1850000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.33760280923963787
+      },
+      {
+        "run": 159,
+        "seed": 1173014757,
+        "success": true,
+        "steps": 365,
+        "total_reward": 42.165000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3480817514260499
+      },
+      {
+        "run": 160,
+        "seed": 1173014758,
+        "success": true,
+        "steps": 434,
+        "total_reward": 30.61000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2671104257305759
+      },
+      {
+        "run": 161,
+        "seed": 1173014759,
+        "success": false,
+        "steps": 160,
+        "total_reward": 5.429999999999989,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.311814765694076
+      },
+      {
+        "run": 162,
+        "seed": 1173014760,
+        "success": true,
+        "steps": 330,
+        "total_reward": 28.3400000000001,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2624585796159831
+      },
+      {
+        "run": 163,
+        "seed": 1173014761,
+        "success": true,
+        "steps": 283,
+        "total_reward": 21.035000000000018,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2662863672145756
+      },
+      {
+        "run": 164,
+        "seed": 1173014762,
+        "success": false,
+        "steps": 103,
+        "total_reward": -0.6350000000000033,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.33210084033613446
+      },
+      {
+        "run": 165,
+        "seed": 1173014763,
+        "success": true,
+        "steps": 331,
+        "total_reward": 47.09500000000013,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2884895735812213
+      },
+      {
+        "run": 166,
+        "seed": 1173014764,
+        "success": false,
+        "steps": 138,
+        "total_reward": 10.15000000000001,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.3543650793650794
+      },
+      {
+        "run": 167,
+        "seed": 1173014765,
+        "success": false,
+        "steps": 109,
+        "total_reward": 7.294999999999991,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.36124371124371124
+      },
+      {
+        "run": 168,
+        "seed": 1173014766,
+        "success": true,
+        "steps": 339,
+        "total_reward": 30.54500000000016,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.29167356519512905
+      },
+      {
+        "run": 169,
+        "seed": 1173014767,
+        "success": false,
+        "steps": 446,
+        "total_reward": 17.47000000000006,
+        "termination_reason": "predator",
+        "foods_collected": 9,
+        "distance_efficiency": 0.2752339804874635
+      },
+      {
+        "run": 170,
+        "seed": 1173014768,
+        "success": true,
+        "steps": 403,
+        "total_reward": 27.035000000000107,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2974575498357333
+      },
+      {
+        "run": 171,
+        "seed": 1173014769,
+        "success": true,
+        "steps": 406,
+        "total_reward": 30.270000000000067,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3427301626125697
+      },
+      {
+        "run": 172,
+        "seed": 1173014770,
+        "success": true,
+        "steps": 325,
+        "total_reward": 26.115000000000073,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27381780004682565
+      },
+      {
+        "run": 173,
+        "seed": 1173014771,
+        "success": true,
+        "steps": 253,
+        "total_reward": 30.015000000000118,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.4013495654672125
+      },
+      {
+        "run": 174,
+        "seed": 1173014772,
+        "success": false,
+        "steps": 282,
+        "total_reward": 5.799999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 5,
+        "distance_efficiency": 0.26929092092463214
+      },
+      {
+        "run": 175,
+        "seed": 1173014773,
+        "success": false,
+        "steps": 291,
+        "total_reward": 21.635000000000144,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.30038385259607087
+      },
+      {
+        "run": 176,
+        "seed": 1173014774,
+        "success": true,
+        "steps": 412,
+        "total_reward": 35.81000000000022,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.27939624678755115
+      },
+      {
+        "run": 177,
+        "seed": 1173014775,
+        "success": true,
+        "steps": 357,
+        "total_reward": 44.34500000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.34112117736400377
+      },
+      {
+        "run": 178,
+        "seed": 1173014776,
+        "success": true,
+        "steps": 358,
+        "total_reward": 32.15000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28902704183669436
+      },
+      {
+        "run": 179,
+        "seed": 1173014777,
+        "success": true,
+        "steps": 352,
+        "total_reward": 29.85000000000011,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.28848006931340264
+      },
+      {
+        "run": 180,
+        "seed": 1173014778,
+        "success": false,
+        "steps": 239,
+        "total_reward": 15.755000000000113,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.29715793741625496
+      },
+      {
+        "run": 181,
+        "seed": 1173014779,
+        "success": true,
+        "steps": 274,
+        "total_reward": 32.60000000000014,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3513329882677709
+      },
+      {
+        "run": 182,
+        "seed": 1173014780,
+        "success": true,
+        "steps": 245,
+        "total_reward": 24.855000000000068,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.30777042072836613
+      },
+      {
+        "run": 183,
+        "seed": 1173014781,
+        "success": false,
+        "steps": 111,
+        "total_reward": 1.1249999999999964,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.3835965077383841
+      },
+      {
+        "run": 184,
+        "seed": 1173014782,
+        "success": false,
+        "steps": 260,
+        "total_reward": 7.60999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 6,
+        "distance_efficiency": 0.1857543714147488
+      },
+      {
+        "run": 185,
+        "seed": 1173014783,
+        "success": true,
+        "steps": 357,
+        "total_reward": 27.08500000000017,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2729973781108586
+      },
+      {
+        "run": 186,
+        "seed": 1173014784,
+        "success": false,
+        "steps": 324,
+        "total_reward": 19.83000000000004,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.24641140260705477
+      },
+      {
+        "run": 187,
+        "seed": 1173014785,
+        "success": true,
+        "steps": 353,
+        "total_reward": 25.50499999999997,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.26667841434263206
+      },
+      {
+        "run": 188,
+        "seed": 1173014786,
+        "success": true,
+        "steps": 419,
+        "total_reward": 37.115000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3251380474278922
+      },
+      {
+        "run": 189,
+        "seed": 1173014787,
+        "success": true,
+        "steps": 238,
+        "total_reward": 26.790000000000084,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3974556489262372
+      },
+      {
+        "run": 190,
+        "seed": 1173014788,
+        "success": false,
+        "steps": 168,
+        "total_reward": -8.599999999999996,
+        "termination_reason": "predator",
+        "foods_collected": 3,
+        "distance_efficiency": 0.2762416794674859
+      },
+      {
+        "run": 191,
+        "seed": 1173014789,
+        "success": false,
+        "steps": 88,
+        "total_reward": -7.1899999999999995,
+        "termination_reason": "predator",
+        "foods_collected": 2,
+        "distance_efficiency": 0.2296650717703349
+      },
+      {
+        "run": 192,
+        "seed": 1173014790,
+        "success": false,
+        "steps": 175,
+        "total_reward": 6.34499999999997,
+        "termination_reason": "predator",
+        "foods_collected": 4,
+        "distance_efficiency": 0.38692922374429223
+      },
+      {
+        "run": 193,
+        "seed": 1173014791,
+        "success": false,
+        "steps": 215,
+        "total_reward": 9.634999999999987,
+        "termination_reason": "predator",
+        "foods_collected": 7,
+        "distance_efficiency": 0.36470143613000755
+      },
+      {
+        "run": 194,
+        "seed": 1173014792,
+        "success": false,
+        "steps": 378,
+        "total_reward": 17.19000000000014,
+        "termination_reason": "predator",
+        "foods_collected": 8,
+        "distance_efficiency": 0.3248658392020512
+      },
+      {
+        "run": 195,
+        "seed": 1173014793,
+        "success": true,
+        "steps": 213,
+        "total_reward": 23.375000000000007,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.36266457950678344
+      },
+      {
+        "run": 196,
+        "seed": 1173014794,
+        "success": true,
+        "steps": 436,
+        "total_reward": 35.64000000000019,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2639967489987414
+      },
+      {
+        "run": 197,
+        "seed": 1173014795,
+        "success": true,
+        "steps": 377,
+        "total_reward": 28.485000000000134,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.23283106751585012
+      },
+      {
+        "run": 198,
+        "seed": 1173014796,
+        "success": true,
+        "steps": 223,
+        "total_reward": 39.215000000000146,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.46505744588353287
+      },
+      {
+        "run": 199,
+        "seed": 1173014797,
+        "success": true,
+        "steps": 354,
+        "total_reward": 30.470000000000066,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.2602518876069123
+      },
+      {
+        "run": 200,
+        "seed": 1173014798,
+        "success": true,
+        "steps": 220,
+        "total_reward": 33.65000000000015,
+        "termination_reason": "completed_all_food",
+        "foods_collected": 10,
+        "distance_efficiency": 0.3647836912542795
+      }
+    ],
+    "avg_chemotaxis_index": 0.2721757649849908,
+    "avg_time_in_attractant": 0.6360878824924954,
+    "avg_approach_frequency": 0.4015980711106641,
+    "avg_path_efficiency": 0.04095731369426039,
+    "post_convergence_chemotaxis_index": 0.3384735454579364,
+    "post_convergence_time_in_attractant": 0.6692367727289682,
+    "post_convergence_approach_frequency": 0.4032869689401844,
+    "post_convergence_path_efficiency": 0.03661695128519644,
+    "chemotaxis_validation_level": "none",
+    "biological_ci_range": [
+      0.5,
+      0.85
+    ],
+    "biological_ci_typical": 0.7,
+    "matches_biology": false,
+    "literature_source": "Bargmann et al. (1993). Cell 74(3):515-527"
+  }
+}

--- a/artifacts/benchmarks/20251229_110151/config.yml
+++ b/artifacts/benchmarks/20251229_110151/config.yml
@@ -1,0 +1,64 @@
+# Dynamic Foraging with Predators - Small Configuration
+# Introduces predator evasion challenge in an easy 20x20 environment
+# Uses MLP (classical neural network) brain architecture
+# Multi-objective learning: find food while avoiding predators
+
+max_steps: 500
+brain:
+  name: mlp
+  config:
+    baseline: 0.0
+    baseline_alpha: 0.05
+    entropy_beta: 0.01
+    gamma: 0.99
+    hidden_dim: 64
+    learning_rate: 0.001
+    lr_scheduler_step_size: 100
+    lr_scheduler_gamma: 0.9
+    num_hidden_layers: 2
+
+body_length: 2
+
+reward:
+  reward_goal: 2.0
+  reward_distance_scale: 0.5
+  reward_exploration: 0.05
+  penalty_step: 0.005
+  penalty_anti_dithering: 0.02
+  penalty_stuck_position: 0
+  penalty_starvation: 10.0
+  penalty_predator_death: 10.0
+  penalty_predator_proximity: 0.1
+  stuck_position_threshold: 0
+
+satiety:
+  initial_satiety: 200.0
+  satiety_decay_rate: 1.0
+  satiety_gain_per_food: 0.2
+
+environment:
+  type: dynamic
+  dynamic:
+    grid_size: 20
+    viewport_size: [11, 11]
+
+    foraging:
+      foods_on_grid: 5
+      target_foods_to_collect: 10
+      min_food_distance: 3
+      agent_exclusion_radius: 5
+      gradient_decay_constant: 8.0
+      gradient_strength: 1.0
+
+    predators:
+      enabled: true
+      count: 2
+      speed: 1.0
+      movement_pattern: random
+      detection_radius: 8
+      kill_radius: 0
+      gradient_decay_constant: 12.0
+      gradient_strength: 1.0
+
+gradient:
+  method: clip

--- a/benchmarks/predator_small/classical/20251229_110151.json
+++ b/benchmarks/predator_small/classical/20251229_110151.json
@@ -1,0 +1,132 @@
+{
+  "submission_id": "20251229_110151",
+  "timestamp": "2025-12-29T11:01:51.594022+00:00",
+  "brain_type": "mlp",
+  "brain_config": {
+    "type": "mlp"
+  },
+  "environment": {
+    "type": "dynamic",
+    "grid_size": 20,
+    "predators_enabled": true
+  },
+  "category": "predator_small/classical",
+  "sessions": [
+    {
+      "experiment_id": "20251229_100737",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_100737.json",
+      "session_seed": 3476363261,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_100739",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_100739.json",
+      "session_seed": 1622328474,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_100742",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_100742.json",
+      "session_seed": 3491961207,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_100745",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_100745.json",
+      "session_seed": 2040640726,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_101742",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_101742.json",
+      "session_seed": 3489526730,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_101745",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_101745.json",
+      "session_seed": 1070406003,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_101747",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_101747.json",
+      "session_seed": 1150672159,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_101750",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_101750.json",
+      "session_seed": 642802586,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_103141",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_103141.json",
+      "session_seed": 827597606,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_103144",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_103144.json",
+      "session_seed": 3089410929,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_103146",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_103146.json",
+      "session_seed": 1670133920,
+      "num_runs": 200
+    },
+    {
+      "experiment_id": "20251229_103149",
+      "file_path": "artifacts/benchmarks/20251229_110151/20251229_103149.json",
+      "session_seed": 1173014599,
+      "num_runs": 200
+    }
+  ],
+  "total_sessions": 12,
+  "total_runs": 2400,
+  "metrics": {
+    "success_rate": {
+      "mean": 0.7341666666666667,
+      "std": 0.10948427081346232,
+      "min": 0.495,
+      "max": 0.835
+    },
+    "composite_score": {
+      "mean": 0.6242451915810817,
+      "std": 0.1226453534821249,
+      "min": 0.28593554502019536,
+      "max": 0.7246736326575645
+    },
+    "distance_efficiency": {
+      "mean": 0.3920073517436431,
+      "std": 0.06516264376223198,
+      "min": 0.26532042411946904,
+      "max": 0.4749385289440613
+    },
+    "learning_speed": {
+      "mean": 0.8379166666666666,
+      "std": 0.08984844492563886,
+      "min": 0.575,
+      "max": 0.915
+    },
+    "learning_speed_episodes": {
+      "mean": 32.416666666666664,
+      "std": 17.969688985127767,
+      "min": 17.0,
+      "max": 85.0
+    },
+    "stability": {
+      "mean": 0.5161516316767072,
+      "std": 0.1858521563179021,
+      "min": 0.0,
+      "max": 0.6860070871886204
+    }
+  },
+  "all_seeds_unique": true,
+  "contributor": "Chris Zaharia",
+  "github_username": "chrisjz",
+  "notes": "REINFORCE policy gradient MLP"
+}

--- a/docs/nematodebench/LEADERBOARD.md
+++ b/docs/nematodebench/LEADERBOARD.md
@@ -67,6 +67,7 @@ _No NematodeBench submissions yet._
 | Brain | Score | Success Rate | Learning Speed | Stability | Distance Efficiency | Sessions | Contributor | Date |
 |---|---|---|---|---|---|---|---|---|
 | ppo | 0.728 ± 0.029 | 83.3% ± 2.9% | 0.92 ± 0.02 | 0.62 ± 0.05 | 0.51 ± 0.02 | 12 | @chrisjz | 2025-12-29 |
+| mlp | 0.624 ± 0.123 | 73.4% ± 10.9% | 0.84 ± 0.09 | 0.52 ± 0.19 | 0.39 ± 0.07 | 12 | @chrisjz | 2025-12-29 |
 
 ### Predator Medium (≤50x50)
 


### PR DESCRIPTION
## NematodeBench Submission

**Brain Architecture:** REINFORCE MLP
**Category:** predator_small/classical
**Composite Score:** 0.624 ± 0.123
**Success Rate:** 73.4% ± 10.9%

### Configuration
- Optimization: REINFORCE policy gradient MLP

### Approach
REINFORCE MLP using current default config.

### Reproducibility
- [x] 10+ independent sessions completed
- [x] 50+ runs per session
- [x] All seeds unique across all runs
- [x] evaluate_submission.py passes
- [x] Config files in artifacts/experiments/
- [x] Leaderboards regenerated

### Files Changed
- `benchmarks/predator_small/20251229_110151.json`
- `artifacts/experiments/20251229_110151/` (10+ session folders)
- `README.md` (Current Leaders section updated)
- `docs/nematodebench/LEADERBOARD.md` (Full leaderboard updated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark results with new mlp model metrics for Predator Small - Classical environment (Score 0.624 ± 0.123, Success Rate 73.4% ± 10.9%, Learning Speed 0.84 ± 0.09, Stability 0.52 ± 0.19).

* **Chores**
  * Added comprehensive benchmark data artifacts containing detailed experiment results and performance metrics from multiple experimental runs and configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->