### PR TITLE
Fix tests writing weight files to project exports/ directory

### DIFF
--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
@@ -262,8 +262,9 @@ class TestFusionMechanism:
 class TestStageAwareTraining:
     """Test that correct optimizers are active per stage."""
 
-    def test_stage1_reflex_trains(self):
+    def test_stage1_reflex_trains(self, tmp_path, monkeypatch):
         """Test reflex weights change during stage 1 REINFORCE training."""
+        monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
             training_stage=1,
             reinforce_window_size=5,
@@ -289,8 +290,9 @@ class TestStageAwareTraining:
                 break
         assert changed
 
-    def test_stage2_reflex_frozen(self):
+    def test_stage2_reflex_frozen(self, tmp_path, monkeypatch):
         """Test reflex weights remain unchanged during stage 2 PPO training."""
+        monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
             training_stage=2,
             ppo_buffer_size=5,
@@ -317,8 +319,9 @@ class TestStageAwareTraining:
 class TestReinforceUpdate:
     """Test reflex REINFORCE update."""
 
-    def test_reinforce_runs_without_error(self):
+    def test_reinforce_runs_without_error(self, tmp_path, monkeypatch):
         """Test REINFORCE update completes without error."""
+        monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
             training_stage=1,
             reinforce_window_size=3,
@@ -336,8 +339,9 @@ class TestReinforceUpdate:
 class TestPPOBuffer:
     """Test cortex PPO rollout buffer."""
 
-    def test_buffer_fill_and_trigger(self):
+    def test_buffer_fill_and_trigger(self, tmp_path, monkeypatch):
         """Test PPO buffer fills and triggers update correctly."""
+        monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
             training_stage=2,
             ppo_buffer_size=4,
@@ -382,8 +386,9 @@ class TestPPOBuffer:
 class TestEpisodeReset:
     """Test episode boundary handling."""
 
-    def test_state_reset(self):
+    def test_state_reset(self, tmp_path, monkeypatch):
         """Test state and buffers are cleared after episode."""
+        monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
             training_stage=1,
             seed=42,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
@@ -309,8 +309,9 @@ class TestFusionMechanism:
 class TestStageAwareTraining:
     """Test that correct optimizers are active per stage."""
 
-    def test_stage1_qsnn_trains(self):
+    def test_stage1_qsnn_trains(self, tmp_path, monkeypatch):
         """Test QSNN weights change during stage 1 REINFORCE training."""
+        monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
             training_stage=1,
             shots=100,
@@ -332,8 +333,9 @@ class TestStageAwareTraining:
         # QSNN weights should have changed (REINFORCE update)
         assert not torch.allclose(w_sh_before, w_sh_after)
 
-    def test_stage2_qsnn_frozen(self):
+    def test_stage2_qsnn_frozen(self, tmp_path, monkeypatch):
         """Test QSNN weights remain unchanged during stage 2 PPO training."""
+        monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
             training_stage=2,
             shots=100,
@@ -360,8 +362,9 @@ class TestStageAwareTraining:
 class TestReinforceUpdate:
     """Test QSNN REINFORCE update."""
 
-    def test_reinforce_runs_without_error(self):
+    def test_reinforce_runs_without_error(self, tmp_path, monkeypatch):
         """Test REINFORCE update completes without error."""
+        monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
             training_stage=1,
             shots=100,
@@ -381,8 +384,9 @@ class TestReinforceUpdate:
 class TestPPOBuffer:
     """Test cortex PPO rollout buffer."""
 
-    def test_buffer_fill_and_trigger(self):
+    def test_buffer_fill_and_trigger(self, tmp_path, monkeypatch):
         """Test PPO buffer fills and triggers update correctly."""
+        monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
             training_stage=2,
             shots=100,
@@ -429,8 +433,9 @@ class TestPPOBuffer:
 class TestEpisodeReset:
     """Test episode boundary handling."""
 
-    def test_qsnn_state_reset(self):
+    def test_qsnn_state_reset(self, tmp_path, monkeypatch):
         """Test QSNN state and buffers are cleared after episode."""
+        monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
             training_stage=1,
             shots=100,


### PR DESCRIPTION
## Summary

- Ten tests in `test_hybridclassical.py` and `test_hybridquantum.py` were calling `learn(episode_done=True)` without redirecting the working directory, causing `cortex_weights.pt`, `reflex_weights.pt`, and `qsnn_weights.pt` to be written into `./exports/` in the project root
- Added `tmp_path, monkeypatch` fixtures and `monkeypatch.chdir(tmp_path)` to each affected test, consistent with the pattern already used elsewhere in the weight-persistence test suite

## Affected tests

**`test_hybridclassical.py`** (5 tests):
- `test_stage1_reflex_trains` — saves `reflex_weights.pt`
- `test_stage2_reflex_frozen` — saves `cortex_weights.pt`
- `test_reinforce_runs_without_error` — saves `reflex_weights.pt`
- `test_buffer_fill_and_trigger` — saves `cortex_weights.pt`
- `test_state_reset` — saves `reflex_weights.pt`

**`test_hybridquantum.py`** (5 tests):
- `test_stage1_qsnn_trains` — saves `qsnn_weights.pt`
- `test_stage2_qsnn_frozen` — saves `cortex_weights.pt`
- `test_reinforce_runs_without_error` — saves `qsnn_weights.pt`
- `test_buffer_fill_and_trigger` — saves `cortex_weights.pt`
- `test_qsnn_state_reset` — saves `qsnn_weights.pt`

## Test plan

- [x] Run `test_hybridclassical.py` and confirm no files appear in `./exports/`
- [x] Run `test_hybridquantum.py` and confirm no files appear in `./exports/`
- [x] All affected tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test methods across hybrid classical and hybrid quantum test suites to use temporary directory fixtures, ensuring improved test isolation and preventing interference between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->