### PR TITLE
ci: remove Python 3.11 from test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,21 +12,17 @@ on:
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }}
+    name: Python 3.12
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.11', '3.12']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -42,7 +38,6 @@ jobs:
           uv run pytest -m "not nightly" --cov --cov-branch --cov-report=xml --cov-report=term -v --tb=short --color=yes
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes `3.11` from the pytest matrix — `pyproject.toml` constrains `requires-python = ">=3.12,<3.13"`, so uv was silently resolving 3.12 for both matrix jobs anyway
- Drops the now-redundant `if: matrix.python-version == '3.12'` guard on the Codecov upload step

## Effect

Halves the CI compute for this workflow on every PR with no loss of coverage.

## Test plan

- [ ] Confirm the single `Python 3.12` job runs and passes
- [ ] Confirm Codecov upload still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)