### PR TITLE
Write simulation_results.csv incrementally per episode

### DIFF
--- a/packages/quantum-nematode/quantumnematode/report/csv_export.py
+++ b/packages/quantum-nematode/quantumnematode/report/csv_export.py
@@ -2,7 +2,7 @@
 
 import csv
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -26,6 +26,7 @@ def export_simulation_results_to_csv(  # pragma: no cover
     data_dir: Path,
     file_prefix: str = "",
     *,
+    skip_main_results: bool = False,
     skip_path_data: bool = False,
 ) -> None:
     """
@@ -35,12 +36,14 @@ def export_simulation_results_to_csv(  # pragma: no cover
         all_results (list[SimulationResult]): List of simulation results.
         data_dir (Path): Directory to save the CSV files.
         file_prefix (str): Prefix for the output file names.
+        skip_main_results (bool): Skip main results export (already written incrementally).
         skip_path_data (bool): Skip path data export (already written incrementally).
     """
     data_dir.mkdir(parents=True, exist_ok=True)
 
-    # Export main simulation results
-    _export_main_results(all_results, data_dir, file_prefix)
+    # Export main simulation results (skip if already written incrementally)
+    if not skip_main_results:
+        _export_main_results(all_results, data_dir, file_prefix)
 
     # Export run-specific metrics
     _export_run_metrics(all_results, data_dir, file_prefix)
@@ -60,64 +63,11 @@ def _export_main_results(
     filepath = data_dir / filename
 
     with filepath.open("w", newline="") as csvfile:
-        fieldnames = [
-            "run",
-            "steps",
-            "total_reward",
-            "last_total_reward",
-            "path_length",
-            "termination_reason",
-            "success",
-            "foods_collected",
-            "foods_available",
-            "satiety_remaining",
-            "avg_distance_efficiency",
-            "predator_encounters",
-            "successful_evasions",
-            "died_to_predator",
-            "died_to_health_depletion",
-        ]
-        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer = csv.DictWriter(csvfile, fieldnames=_SIMULATION_RESULTS_FIELDNAMES)
         writer.writeheader()
 
         for result in all_results:
-            writer.writerow(
-                {
-                    "run": result.run,
-                    "steps": result.steps,
-                    "total_reward": result.total_reward,
-                    "last_total_reward": result.last_total_reward,
-                    "path_length": result.path_length
-                    if result.path_length is not None
-                    else len(result.path),
-                    "termination_reason": result.termination_reason.value,
-                    "success": result.success,
-                    "foods_collected": result.foods_collected
-                    if result.foods_collected is not None
-                    else np.nan,
-                    "foods_available": result.foods_available
-                    if result.foods_available is not None
-                    else np.nan,
-                    "satiety_remaining": result.satiety_remaining
-                    if result.satiety_remaining is not None
-                    else np.nan,
-                    "avg_distance_efficiency": result.average_distance_efficiency
-                    if result.average_distance_efficiency is not None
-                    else np.nan,
-                    "predator_encounters": result.predator_encounters
-                    if result.predator_encounters is not None
-                    else np.nan,
-                    "successful_evasions": result.successful_evasions
-                    if result.successful_evasions is not None
-                    else np.nan,
-                    "died_to_predator": result.died_to_predator
-                    if result.died_to_predator is not None
-                    else np.nan,
-                    "died_to_health_depletion": result.died_to_health_depletion
-                    if result.died_to_health_depletion is not None
-                    else np.nan,
-                },
-            )
+            writer.writerow(_simulation_result_to_row(result))
 
 
 def _export_run_metrics(
@@ -198,6 +148,102 @@ def _export_path_data(
                         "y": y,
                     },
                 )
+
+
+_SIMULATION_RESULTS_FIELDNAMES = [
+    "run",
+    "steps",
+    "total_reward",
+    "last_total_reward",
+    "path_length",
+    "termination_reason",
+    "success",
+    "foods_collected",
+    "foods_available",
+    "satiety_remaining",
+    "avg_distance_efficiency",
+    "predator_encounters",
+    "successful_evasions",
+    "died_to_predator",
+    "died_to_health_depletion",
+]
+
+
+def _simulation_result_to_row(result: SimulationResult) -> dict[str, object]:
+    """Convert a SimulationResult to a dict suitable for CSV writing."""
+    return {
+        "run": result.run,
+        "steps": result.steps,
+        "total_reward": result.total_reward,
+        "last_total_reward": result.last_total_reward,
+        "path_length": result.path_length if result.path_length is not None else len(result.path),
+        "termination_reason": result.termination_reason.value,
+        "success": result.success,
+        "foods_collected": result.foods_collected if result.foods_collected is not None else np.nan,
+        "foods_available": result.foods_available if result.foods_available is not None else np.nan,
+        "satiety_remaining": result.satiety_remaining
+        if result.satiety_remaining is not None
+        else np.nan,
+        "avg_distance_efficiency": result.average_distance_efficiency
+        if result.average_distance_efficiency is not None
+        else np.nan,
+        "predator_encounters": result.predator_encounters
+        if result.predator_encounters is not None
+        else np.nan,
+        "successful_evasions": result.successful_evasions
+        if result.successful_evasions is not None
+        else np.nan,
+        "died_to_predator": result.died_to_predator
+        if result.died_to_predator is not None
+        else np.nan,
+        "died_to_health_depletion": result.died_to_health_depletion
+        if result.died_to_health_depletion is not None
+        else np.nan,
+    }
+
+
+def create_simulation_results_csv_writer(
+    filepath: Path,
+) -> tuple[Any, csv.DictWriter]:
+    """Open simulation results CSV file and write header for incremental writing.
+
+    Parameters
+    ----------
+    filepath : Path
+        Path to the CSV file.
+
+    Returns
+    -------
+    tuple[Any, csv.DictWriter]
+        File handle and CSV writer. Caller must close the file handle.
+    """
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    csvfile = filepath.open("w", newline="")
+    writer = csv.DictWriter(csvfile, fieldnames=_SIMULATION_RESULTS_FIELDNAMES)
+    writer.writeheader()
+    csvfile.flush()
+    return csvfile, writer
+
+
+def write_simulation_result_row(
+    writer: csv.DictWriter,
+    result: SimulationResult,
+    csvfile: IO[str] | None = None,
+) -> None:
+    """Write a single simulation result row to an already-open CSV writer.
+
+    Parameters
+    ----------
+    writer : csv.DictWriter
+        CSV writer with simulation results fieldnames.
+    result : SimulationResult
+        Simulation result for one episode.
+    csvfile : file object, optional
+        File handle to flush after writing. If None, no flush is performed.
+    """
+    writer.writerow(_simulation_result_to_row(result))
+    if csvfile is not None:
+        csvfile.flush()
 
 
 def create_path_csv_writer(filepath: Path) -> tuple[Any, csv.DictWriter]:

--- a/packages/quantum-nematode/quantumnematode/utils/interrupt_handler.py
+++ b/packages/quantum-nematode/quantumnematode/utils/interrupt_handler.py
@@ -128,6 +128,7 @@ def manage_simulation_halt(  # noqa: PLR0913
                 all_results=all_results,
                 data_dir=data_dir,
                 file_prefix=file_prefix,
+                skip_main_results=True,  # Main results already written incrementally
                 skip_path_data=True,  # Path data already written incrementally
             )
             export_performance_metrics_to_csv(

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -54,6 +54,7 @@ from quantumnematode.optimizers.learning_rate import (
 from quantumnematode.report.csv_export import (
     IncrementalDetailedTrackingWriter,
     create_path_csv_writer,
+    create_simulation_results_csv_writer,
     export_convergence_metrics_to_csv,
     export_distance_efficiencies_to_csv,
     export_foraging_results_to_csv,
@@ -65,6 +66,7 @@ from quantumnematode.report.csv_export import (
     export_simulation_results_to_csv,
     export_tracking_data_to_csv,
     write_path_data_row,
+    write_simulation_result_row,
 )
 from quantumnematode.report.dtypes import (
     BrainDataSnapshot,
@@ -455,6 +457,9 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
     # Incremental CSV writers — write heavy per-step data each episode, then flush from memory
     data_dir.mkdir(parents=True, exist_ok=True)
     path_csv_file, path_csv_writer = create_path_csv_writer(data_dir / "paths.csv")
+    sim_results_csv_file, sim_results_csv_writer = create_simulation_results_csv_writer(
+        data_dir / "simulation_results.csv",
+    )
     detailed_tracking_writer = IncrementalDetailedTrackingWriter(data_dir)
 
     # Pre-computed chemotaxis metrics (populated per-episode when --track-experiment is set)
@@ -480,6 +485,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
             print(message)
         finally:
             path_csv_file.close()
+            sim_results_csv_file.close()
             detailed_tracking_writer.close()
         return
 
@@ -620,7 +626,8 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
             running_total_steps += result.steps
 
             # --- Incremental exports (before data flush) ---
-            # Write path data to CSV incrementally
+            # Write simulation results and path data to CSV incrementally
+            write_simulation_result_row(sim_results_csv_writer, result, sim_results_csv_file)
             write_path_data_row(path_csv_writer, result)
 
             # Write detailed brain tracking data incrementally
@@ -767,6 +774,8 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         # Ensure incremental writers are always closed (safe to call twice)
         if not path_csv_file.closed:
             path_csv_file.close()
+        if not sim_results_csv_file.closed:
+            sim_results_csv_file.close()
         detailed_tracking_writer.close()
 
     # Calculate and log performance metrics
@@ -801,6 +810,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         export_simulation_results_to_csv(
             all_results=all_results,
             data_dir=data_dir,
+            skip_main_results=True,
             skip_path_data=True,
         )
         export_performance_metrics_to_csv(metrics=metrics, data_dir=data_dir)


### PR DESCRIPTION
## Summary

- Writes `simulation_results.csv` incrementally after each episode instead of only at session end, enabling progress monitoring during long headless runs via `tail -f`
- Extracts shared fieldnames and row-building logic to avoid duplication between batch and incremental code paths
- Flushes to disk after each row write to ensure data is immediately visible

## Test plan

- [x] Verified CSV output matches previous batch-written format
- [x] Run a multi-episode session and confirm rows appear in `simulation_results.csv` after each episode
- [x] Verify interrupt handler still produces correct partial exports
- [x] Confirm end-of-session export skips main results (no duplicate/overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulation results now export incrementally to CSV as each step completes, providing real-time data access without waiting for full simulation completion.
  * Export process is now more flexible, with options to independently control main results and path data export during simulation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->