### PR TITLE
docs: Add new quantum architecture candidates

### DIFF
--- a/docs/research/quantum-architectures.md
+++ b/docs/research/quantum-architectures.md
@@ -2174,7 +2174,7 @@ COMPLETED:
     Genuine quantum advantage on pursuit predators (+9.4pp over CRH).
     Task-dependent: CRH wins stationary. Structured topology falsified.
 
-  QA-4 QLIF-LSTM (Stages 4a-4d) — 12 rounds, ~66 sessions + 22 reservoir-LSTM
+  QA-4 QLIF-LSTM (Stages 4a-4d) — 12 rounds, ~66 sessions + 22 reservoir-LSTM sessions
     Classical LSTM: 98% last-100 on pursuit predators (best temporal arch).
     Quantum QLIF gates: no measurable advantage on any task.
     Stationary predators: 37% ceiling despite 6 rounds of tuning.


### PR DESCRIPTION
Changes:

- Add new quantum architecture candidates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Next-Generation Architecture Proposals from H.1–H.6 into QA-1–QA-7, expanding the set to seven architectures
  * Added QA-5–QA-7 designs (Entangled Feature Extraction, QRH+ weak-measurement feedback, Quantum Plasticity Test) with priorities and rationale
  * Updated nomenclature, navigation, stage/decision-gate references, evaluation narrative, rankings, and roadmap
  * Expanded references and open questions with March 2026 additions and minor consistency edits
<!-- end of auto-generated comment: release notes by coderabbit.ai -->