### PR TITLE
feat!: Enable boundary collision and temperature proximity penalty defaults

### DIFF
--- a/packages/quantum-nematode/quantumnematode/agent/agent.py
+++ b/packages/quantum-nematode/quantumnematode/agent/agent.py
@@ -40,10 +40,8 @@ DEFAULT_PENALTY_PREDATOR_DEATH = 10.0
 DEFAULT_PENALTY_PREDATOR_PROXIMITY = 0.1
 DEFAULT_PENALTY_HEALTH_DAMAGE = 0.5  # Penalty when taking damage (per hit)
 DEFAULT_REWARD_HEALTH_GAIN = 0.1  # Reward when healing (per healing event)
-DEFAULT_PENALTY_BOUNDARY_COLLISION = (
-    0.0  # Penalty for touching grid boundary (disabled by default for backward compatibility)
-)
-DEFAULT_PENALTY_TEMPERATURE_PROXIMITY = 0.0  # Disabled by default for backward compat
+DEFAULT_PENALTY_BOUNDARY_COLLISION = 0.02  # Penalty for wall collision (mechanosensation)
+DEFAULT_PENALTY_TEMPERATURE_PROXIMITY = 0.3  # Scale factor for temp deviation reward
 DEFAULT_REWARD_DISTANCE_SCALE = 0.3
 DEFAULT_REWARD_GOAL = 0.2
 DEFAULT_REWARD_EXPLORATION = 0.05

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_reward_calculator.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_reward_calculator.py
@@ -19,6 +19,8 @@ def default_config():
         penalty_stuck_position=0.02,
         stuck_position_threshold=3,
         reward_exploration=0.02,
+        penalty_boundary_collision=0.0,
+        penalty_temperature_proximity=0.0,
     )
 
 
@@ -45,6 +47,8 @@ class TestDynamicForagingRewards:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(3, 3), (2, 2)]  # Previous nearest was Manhattan=4, now=1
@@ -66,6 +70,8 @@ class TestDynamicForagingRewards:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(1, 2)]
@@ -86,6 +92,8 @@ class TestDynamicForagingRewards:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(1, 2)]
@@ -109,6 +117,8 @@ class TestAntiDitheringPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(1, 1), (2, 2), (1, 1)]  # Back to same position
@@ -129,6 +139,8 @@ class TestAntiDitheringPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(1, 1), (2, 2), (3, 3)]  # Normal progression
@@ -159,6 +171,8 @@ class TestPredatorEvasionReward:
         env.predator.enabled = True
         env.is_agent_in_danger = Mock(return_value=in_danger)
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         # Create predator mocks
         predators = []
@@ -313,6 +327,8 @@ class TestPredatorEvasionReward:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(config)
         path = [(4, 5), (5, 5)]
@@ -384,6 +400,8 @@ class TestTemperatureAvoidanceReward:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         # Thermotaxis setup
         env.thermotaxis = Mock()
@@ -587,6 +605,8 @@ class TestStuckPositionPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(2, 2), (2, 2)]
@@ -607,6 +627,8 @@ class TestStuckPositionPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(2, 2), (2, 2)]
@@ -626,6 +648,8 @@ class TestStuckPositionPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(default_config)
         path = [(2, 2), (2, 2)]
@@ -660,6 +684,8 @@ class TestBoundaryCollisionPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = True  # Tried to move into wall
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(config)
         path = [(0, 5)]
@@ -684,6 +710,8 @@ class TestBoundaryCollisionPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False  # No wall collision
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(config)
         path = [(5, 5)]
@@ -712,6 +740,8 @@ class TestBoundaryCollisionPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False  # At edge but no collision attempt
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(config)
         path = [(0, 5)]
@@ -736,6 +766,8 @@ class TestBoundaryCollisionPenalty:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = True  # Collision occurred but penalty is 0
+        env.thermotaxis = Mock()
+        env.thermotaxis.enabled = False
 
         calculator = RewardCalculator(config)
         path = [(0, 5)]

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_reward_calculator.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_reward_calculator.py
@@ -400,8 +400,6 @@ class TestTemperatureAvoidanceReward:
         env.predator = Mock()
         env.predator.enabled = False
         env.wall_collision_occurred = False
-        env.thermotaxis = Mock()
-        env.thermotaxis.enabled = False
 
         # Thermotaxis setup
         env.thermotaxis = Mock()


### PR DESCRIPTION
## Summary

Remove the backward-compat `0.0` overrides on two penalty defaults:

- **`DEFAULT_PENALTY_BOUNDARY_COLLISION`**: `0.0` → `0.02` — matches all 93 scenario configs that explicitly set this value
- **`DEFAULT_PENALTY_TEMPERATURE_PROXIMITY`**: `0.0` → `0.3` — matches all 27 thermal scenario configs that set this value. Non-thermal scenarios are unaffected since the penalty is gated by `env.thermotaxis.enabled`

Update reward calculator test mocks to include `thermotaxis.enabled = False` so the temperature penalty early-returns for non-thermal test scenarios. Also explicitly set both penalties to `0.0` in the test's `default_config` fixture to keep non-penalty tests isolated.

## Test plan

- [x] Pre-commit checks pass
- [x] All 1940 tests pass
- [x] Verified all 93 configs already set `penalty_boundary_collision: 0.02`
- [x] Verified all 27 thermal configs already set `penalty_temperature_proximity: 0.3`
- [x] Non-thermal configs (66) don't set the temperature penalty but are unaffected due to `thermotaxis.enabled` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled wall-collision detection in agent reward calculation with a default penalty of 0.02.
  * Enabled temperature proximity detection in agent reward calculation with a default penalty of 0.3.

* **Tests**
  * Updated test suite to ensure compatibility with new default penalty configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->