### PR TITLE
fix!: Remove instant death — health system always on

### DIFF
--- a/configs/scenarios/pursuit/crhqlstm_small_classical_oracle.yml
+++ b/configs/scenarios/pursuit/crhqlstm_small_classical_oracle.yml
@@ -96,12 +96,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/crhqlstm_small_oracle.yml
+++ b/configs/scenarios/pursuit/crhqlstm_small_oracle.yml
@@ -97,12 +97,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/hybridclassical_small_oracle.yml
+++ b/configs/scenarios/pursuit/hybridclassical_small_oracle.yml
@@ -97,12 +97,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/hybridquantum_small_oracle.yml
+++ b/configs/scenarios/pursuit/hybridquantum_small_oracle.yml
@@ -103,12 +103,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/mlpppo_sensory_small_oracle.yml
+++ b/configs/scenarios/pursuit/mlpppo_sensory_small_oracle.yml
@@ -80,12 +80,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/mlpppo_small_derivative.yml
+++ b/configs/scenarios/pursuit/mlpppo_small_derivative.yml
@@ -83,12 +83,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/mlpppo_small_fair_oracle.yml
+++ b/configs/scenarios/pursuit/mlpppo_small_fair_oracle.yml
@@ -76,12 +76,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/mlpppo_small_oracle.yml
+++ b/configs/scenarios/pursuit/mlpppo_small_oracle.yml
@@ -65,12 +65,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/mlpppo_small_temporal.yml
+++ b/configs/scenarios/pursuit/mlpppo_small_temporal.yml
@@ -84,12 +84,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qef_small_modality_paired_oracle.yml
+++ b/configs/scenarios/pursuit/qef_small_modality_paired_oracle.yml
@@ -100,12 +100,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qef_small_oracle.yml
+++ b/configs/scenarios/pursuit/qef_small_oracle.yml
@@ -106,12 +106,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qef_small_ring_compact_oracle.yml
+++ b/configs/scenarios/pursuit/qef_small_ring_compact_oracle.yml
@@ -93,12 +93,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qliflstm_small_classical_oracle.yml
+++ b/configs/scenarios/pursuit/qliflstm_small_classical_oracle.yml
@@ -83,12 +83,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qliflstm_small_oracle.yml
+++ b/configs/scenarios/pursuit/qliflstm_small_oracle.yml
@@ -83,12 +83,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qrh_small_oracle.yml
+++ b/configs/scenarios/pursuit/qrh_small_oracle.yml
@@ -84,12 +84,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qrhqlstm_small_classical_oracle.yml
+++ b/configs/scenarios/pursuit/qrhqlstm_small_classical_oracle.yml
@@ -91,12 +91,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qrhqlstm_small_oracle.yml
+++ b/configs/scenarios/pursuit/qrhqlstm_small_oracle.yml
@@ -91,12 +91,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qsnnppo_small_oracle.yml
+++ b/configs/scenarios/pursuit/qsnnppo_small_oracle.yml
@@ -96,12 +96,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qsnnreinforce_a2c_small_oracle.yml
+++ b/configs/scenarios/pursuit/qsnnreinforce_a2c_small_oracle.yml
@@ -88,12 +88,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/pursuit/qsnnreinforce_small_oracle.yml
+++ b/configs/scenarios/pursuit/qsnnreinforce_small_oracle.yml
@@ -77,12 +77,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/scenarios/stationary/mlpppo_sensory_small_oracle.yml
+++ b/configs/scenarios/stationary/mlpppo_sensory_small_oracle.yml
@@ -79,13 +79,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 4
-    kill_radius: 0
     damage_radius: 2
     gradient_decay_constant: 8.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 15.0
     food_healing: 10.0

--- a/configs/scenarios/stationary/mlpppo_small_oracle.yml
+++ b/configs/scenarios/stationary/mlpppo_small_oracle.yml
@@ -66,13 +66,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 4
-    kill_radius: 0
     damage_radius: 2
     gradient_decay_constant: 8.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 15.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_foraging/mlpppo_large_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_large_oracle.yml
@@ -68,7 +68,6 @@ environment:
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 0.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_foraging/mlpppo_medium_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_medium_oracle.yml
@@ -77,7 +77,6 @@ environment:
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 0.0
     food_healing: 5.0

--- a/configs/scenarios/thermal_foraging/mlpppo_small_derivative.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_derivative.yml
@@ -75,7 +75,6 @@ environment:
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 0.0
     food_healing: 5.0

--- a/configs/scenarios/thermal_foraging/mlpppo_small_isothermal_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_isothermal_oracle.yml
@@ -77,7 +77,6 @@ environment:
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 0.0
     food_healing: 5.0

--- a/configs/scenarios/thermal_foraging/mlpppo_small_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_oracle.yml
@@ -72,7 +72,6 @@ environment:
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 0.0
     food_healing: 5.0

--- a/configs/scenarios/thermal_foraging/mlpppo_small_temporal.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_temporal.yml
@@ -75,7 +75,6 @@ environment:
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 0.0
     food_healing: 5.0

--- a/configs/scenarios/thermal_pursuit/crh_large_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/crh_large_oracle.yml
@@ -116,12 +116,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/crh_large_standalone_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/crh_large_standalone_oracle.yml
@@ -109,12 +109,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/crhqlstm_large_classical_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/crhqlstm_large_classical_oracle.yml
@@ -100,12 +100,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/crhqlstm_large_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/crhqlstm_large_oracle.yml
@@ -105,12 +105,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/lstmppo_large_derivative.yml
+++ b/configs/scenarios/thermal_pursuit/lstmppo_large_derivative.yml
@@ -111,12 +111,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 4.0  # Steeper for detectable predator derivatives
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/lstmppo_large_temporal.yml
+++ b/configs/scenarios/thermal_pursuit/lstmppo_large_temporal.yml
@@ -112,12 +112,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 4.0  # Steeper for detectable predator concentration
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/mlpppo_large_fair_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_large_fair_oracle.yml
@@ -82,12 +82,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/mlpppo_large_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_large_oracle.yml
@@ -99,12 +99,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/mlpppo_medium_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_medium_oracle.yml
@@ -94,12 +94,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 8.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_pursuit/mlpppo_small_derivative.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_small_derivative.yml
@@ -86,12 +86,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_pursuit/mlpppo_small_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_small_oracle.yml
@@ -89,12 +89,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_pursuit/mlpppo_small_temporal.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_small_temporal.yml
@@ -88,12 +88,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_pursuit/qef_large_modality_paired_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qef_large_modality_paired_oracle.yml
@@ -104,12 +104,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/qef_large_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qef_large_oracle.yml
@@ -106,12 +106,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/qliflstm_large_classical_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qliflstm_large_classical_oracle.yml
@@ -99,12 +99,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/qliflstm_large_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qliflstm_large_oracle.yml
@@ -99,12 +99,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/qrh_large_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qrh_large_oracle.yml
@@ -119,12 +119,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/qrh_small_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qrh_small_oracle.yml
@@ -100,12 +100,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 6.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_pursuit/qrhqlstm_large_classical_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qrhqlstm_large_classical_oracle.yml
@@ -103,12 +103,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_pursuit/qrhqlstm_large_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qrhqlstm_large_oracle.yml
@@ -102,12 +102,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 10
-    kill_radius: 0
     gradient_decay_constant: 12.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 15.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/crh_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/crh_large_oracle.yml
@@ -120,13 +120,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/crhqlstm_large_classical_oracle.yml
+++ b/configs/scenarios/thermal_stationary/crhqlstm_large_classical_oracle.yml
@@ -100,13 +100,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/crhqlstm_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/crhqlstm_large_oracle.yml
@@ -103,13 +103,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/lstmppo_large_derivative.yml
+++ b/configs/scenarios/thermal_stationary/lstmppo_large_derivative.yml
@@ -113,13 +113,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 4.0  # Steeper for detectable predator derivatives
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/lstmppo_large_temporal.yml
+++ b/configs/scenarios/thermal_stationary/lstmppo_large_temporal.yml
@@ -115,13 +115,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 4.0  # Steeper for detectable predator concentration
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/mlpppo_large_fair_oracle.yml
+++ b/configs/scenarios/thermal_stationary/mlpppo_large_fair_oracle.yml
@@ -82,13 +82,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/mlpppo_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/mlpppo_large_oracle.yml
@@ -95,13 +95,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/mlpppo_medium_oracle.yml
+++ b/configs/scenarios/thermal_stationary/mlpppo_medium_oracle.yml
@@ -92,13 +92,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 4
-    kill_radius: 0
     damage_radius: 1
     gradient_decay_constant: 4.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 8.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_stationary/mlpppo_small_oracle.yml
+++ b/configs/scenarios/thermal_stationary/mlpppo_small_oracle.yml
@@ -86,13 +86,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 4
-    kill_radius: 0
     damage_radius: 1
     gradient_decay_constant: 4.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 8.0
     food_healing: 10.0

--- a/configs/scenarios/thermal_stationary/qef_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/qef_large_oracle.yml
@@ -110,13 +110,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/qliflstm_large_classical_oracle.yml
+++ b/configs/scenarios/thermal_stationary/qliflstm_large_classical_oracle.yml
@@ -100,13 +100,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/qliflstm_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/qliflstm_large_oracle.yml
@@ -100,13 +100,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/qrh_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/qrh_large_oracle.yml
@@ -110,13 +110,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/qrhqlstm_large_classical_oracle.yml
+++ b/configs/scenarios/thermal_stationary/qrhqlstm_large_classical_oracle.yml
@@ -94,13 +94,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/scenarios/thermal_stationary/qrhqlstm_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/qrhqlstm_large_oracle.yml
@@ -102,13 +102,11 @@ environment:
     speed: 0.0
     movement_pattern: stationary
     detection_radius: 8
-    kill_radius: 0
     damage_radius: 4
     gradient_decay_constant: 5.0
     gradient_strength: 1.2
 
   health:
-    enabled: true
     max_hp: 150.0
     predator_damage: 10.0
     food_healing: 15.0

--- a/configs/special/hybridclassical_pursuit_small_finetune_oracle.yml
+++ b/configs/special/hybridclassical_pursuit_small_finetune_oracle.yml
@@ -109,12 +109,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/special/hybridquantum_pursuit_small_finetune_oracle.yml
+++ b/configs/special/hybridquantum_pursuit_small_finetune_oracle.yml
@@ -119,12 +119,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/special/hybridquantumcortex_pursuit_small_2b_oracle.yml
+++ b/configs/special/hybridquantumcortex_pursuit_small_2b_oracle.yml
@@ -121,12 +121,10 @@ environment:
     speed: 0.3
     movement_pattern: pursuit
     detection_radius: 5
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 200.0
     predator_damage: 15.0
     food_healing: 10.0

--- a/configs/special/hybridquantumcortex_pursuit_small_2c_oracle.yml
+++ b/configs/special/hybridquantumcortex_pursuit_small_2c_oracle.yml
@@ -126,12 +126,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/special/hybridquantumcortex_pursuit_small_2c_round2_oracle.yml
+++ b/configs/special/hybridquantumcortex_pursuit_small_2c_round2_oracle.yml
@@ -129,12 +129,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/configs/special/hybridquantumcortex_pursuit_small_finetune_3_oracle.yml
+++ b/configs/special/hybridquantumcortex_pursuit_small_finetune_3_oracle.yml
@@ -129,12 +129,10 @@ environment:
     speed: 0.5
     movement_pattern: pursuit
     detection_radius: 6
-    kill_radius: 0
     gradient_decay_constant: 10.0
     gradient_strength: 1.0
 
   health:
-    enabled: true
     max_hp: 100.0
     predator_damage: 20.0
     food_healing: 10.0

--- a/openspec/specs/configuration-system/spec.md
+++ b/openspec/specs/configuration-system/spec.md
@@ -179,7 +179,7 @@ The system SHALL support comprehensive configuration of predator behavior, appea
   - `speed` (float, default 1.0)
   - `movement_pattern` (string, default "random")
   - `detection_radius` (integer, default 8)
-  - `kill_radius` (integer, default 0)
+  - `damage_radius` (integer, default 0)
 - **AND** all parameters SHALL have sensible defaults allowing minimal configuration
 
 #### Scenario: Predator Gradient Configuration
@@ -261,9 +261,9 @@ environment:
       enabled: true
       count: 3
       speed: 1.0
-      movement_pattern: "random"
+      movement_pattern: "pursuit"
       detection_radius: 8
-      kill_radius: 0
+      damage_radius: 0
       gradient_decay_constant: 12.0
       gradient_strength: 1.0
 

--- a/openspec/specs/configuration-system/spec.md
+++ b/openspec/specs/configuration-system/spec.md
@@ -177,7 +177,7 @@ The system SHALL support comprehensive configuration of predator behavior, appea
   - `enabled` (boolean, default false)
   - `count` (integer, default 2)
   - `speed` (float, default 1.0)
-  - `movement_pattern` (string, default "random")
+  - `movement_pattern` (string: "stationary" or "pursuit", default "pursuit")
   - `detection_radius` (integer, default 8)
   - `damage_radius` (integer, default 0)
 - **AND** all parameters SHALL have sensible defaults allowing minimal configuration
@@ -325,28 +325,26 @@ environment:
 
 The system SHALL validate predator movement pattern configuration and provide clear errors for invalid values.
 
-#### Scenario: Valid Movement Pattern
+#### Scenario: Valid Movement Pattern — Pursuit
 
-- **GIVEN** a configuration with `movement_pattern: "random"`
+- **GIVEN** a configuration with `movement_pattern: "pursuit"`
 - **WHEN** the configuration is validated
 - **THEN** validation SHALL pass
-- **AND** the predator SHALL use random movement behavior
+- **AND** the predator SHALL actively pursue the agent when within detection radius
+
+#### Scenario: Valid Movement Pattern — Stationary
+
+- **GIVEN** a configuration with `movement_pattern: "stationary"`
+- **WHEN** the configuration is validated
+- **THEN** validation SHALL pass
+- **AND** the predator SHALL remain at its spawn position (toxic zone)
 
 #### Scenario: Invalid Movement Pattern
 
 - **GIVEN** a configuration with `movement_pattern: "invalid_pattern"`
 - **WHEN** the configuration is validated
 - **THEN** validation SHALL fail with clear error message
-- **AND** error SHALL list valid options: "random"
-- **AND** error SHALL indicate future options (commented): "patrol", "pursue"
-
-#### Scenario: Future Movement Pattern Placeholder
-
-- **GIVEN** a configuration with `movement_pattern: "pursue"`
-- **WHEN** the configuration is validated
-- **THEN** validation SHALL fail
-- **AND** error SHALL indicate "pursue pattern not yet implemented"
-- **AND** error SHALL suggest using "random" for current version
+- **AND** error SHALL list valid options: "stationary", "pursuit"
 
 ### Requirement: Configuration Examples and Templates
 

--- a/openspec/specs/environment-simulation/spec.md
+++ b/openspec/specs/environment-simulation/spec.md
@@ -271,8 +271,8 @@ The system SHALL provide three preset configurations for curriculum learning: sm
   - count: 2
   - speed: 1.0
   - detection radius: 8
-  - kill radius: 0
-  - movement pattern: "random"
+  - damage radius: 0
+  - movement pattern: "pursuit"
 - **AND** both foraging and predator mechanics SHALL be active
 
 ### Requirement: Brain Architecture Compatibility

--- a/openspec/specs/environment-simulation/spec.md
+++ b/openspec/specs/environment-simulation/spec.md
@@ -358,29 +358,28 @@ The environment SHALL compute a unified chemotaxis gradient that superimposes fo
 
 ### Requirement: Predator Collision Detection and Termination
 
-The system SHALL detect when the agent collides with a predator and terminate the episode immediately with appropriate termination reason.
+The system SHALL detect when the agent is within a predator's damage radius and apply HP damage. If HP reaches zero, the episode terminates with `TerminationReason.HEALTH_DEPLETED`.
 
-#### Scenario: Predator Kill on Direct Collision
+#### Scenario: Predator Damage on Contact
 
-- **GIVEN** an agent at position (10, 10) and a predator at position (10, 10)
-- **WHEN** collision is detected (same cell occupation)
-- **THEN** the episode SHALL terminate immediately
-- **AND** the termination reason SHALL be `TerminationReason.PREDATOR`
+- **GIVEN** an agent at position (10, 10) and a predator with `damage_radius: 1` at position (10, 10)
+- **WHEN** damage radius check runs
+- **THEN** predator damage SHALL be applied to agent HP
+- **AND** if HP reaches zero, the episode SHALL terminate with `TerminationReason.HEALTH_DEPLETED`
 - **AND** a death penalty reward SHALL be applied (configurable, default -10)
 
-#### Scenario: Kill Radius Configuration
+#### Scenario: Damage Radius Configuration
 
-- **GIVEN** a configuration with `kill_radius: 0`
-- **WHEN** collision detection runs
-- **THEN** collision SHALL be detected when agent is within 0 cells (Manhattan distance) of any predator
-- **AND** kill_radius of 0 SHALL include the center cell only
+- **GIVEN** a configuration with `damage_radius: 1`
+- **WHEN** damage radius detection runs
+- **THEN** contact SHALL be detected when agent is within 1 cell (Manhattan distance) of any predator
 - **AND** diagonal adjacency SHALL be excluded (Manhattan distance only)
 
-#### Scenario: No Collision Outside Kill Radius
+#### Scenario: No Contact Outside Damage Radius
 
-- **GIVEN** an agent at (10, 10) and predator at (11, 10) with `kill_radius: 0`
+- **GIVEN** an agent at (10, 10) and predator at (12, 10) with `damage_radius: 1`
 - **WHEN** positions are checked
-- **THEN** no collision SHALL be detected (distance = 1 > kill_radius)
+- **THEN** no contact SHALL be detected (distance = 2 > damage_radius)
 - **AND** the episode SHALL continue normally
 - **AND** agent SHALL still sense predator gradient if within detection radius
 
@@ -462,17 +461,17 @@ The system SHALL track predator-related performance metrics including encounters
 - **THEN** `successful_evasions` metric SHALL increment by 1
 - **AND** evasion is defined as entering detection radius and leaving without death
 
-#### Scenario: Death by Predator Tracking
+#### Scenario: Death by Health Depletion Tracking
 
-- **GIVEN** an episode terminated by predator collision
+- **GIVEN** an episode terminated by HP reaching zero (from predator damage, temperature, or other sources)
 - **WHEN** episode metrics are computed
-- **THEN** `predator_deaths` metric SHALL equal 1
-- **AND** termination reason SHALL be `TerminationReason.PREDATOR`
+- **THEN** `health_depleted` metric SHALL increment by 1
+- **AND** termination reason SHALL be `TerminationReason.HEALTH_DEPLETED`
 - **AND** this SHALL be distinct from starvation or timeout terminations
 
 #### Scenario: Food Collected Before Death
 
-- **GIVEN** an agent that collected 8 foods before predator collision
+- **GIVEN** an agent that collected 8 foods before health depletion
 - **WHEN** episode metrics are computed
 - **THEN** `foods_collected` metric SHALL equal 8
 - **AND** this SHALL be tracked alongside predator death
@@ -533,14 +532,14 @@ The system SHALL execute each simulation step in a deterministic order to ensure
   9. Other termination conditions checked (starvation, max steps)
 - **AND** this order SHALL be deterministic and consistent across all episodes
 
-#### Scenario: Collision Detection Before Predator Movement
+#### Scenario: Damage Check Before Predator Movement
 
 - **GIVEN** an agent at (10, 10) after moving, and a predator at (10, 10) before predator update
 - **WHEN** the step sequence executes
-- **THEN** collision SHALL be detected at step 5 (before predator movement)
-- **AND** the episode SHALL terminate with `TerminationReason.PREDATOR`
-- **AND** predator movement (step 7) SHALL NOT occur after collision
-- **AND** this prevents predators from moving away before collision is registered
+- **THEN** damage SHALL be applied at step 5 (before predator movement)
+- **AND** if HP reaches zero, the episode SHALL terminate with `TerminationReason.HEALTH_DEPLETED`
+- **AND** predator movement (step 7) SHALL NOT occur after termination
+- **AND** this prevents predators from moving away before damage is applied
 
 #### Scenario: Predator Movement After Safe Step
 

--- a/openspec/specs/experiment-tracking/spec.md
+++ b/openspec/specs/experiment-tracking/spec.md
@@ -224,8 +224,8 @@ The experiment tracking system SHALL capture comprehensive predator configuratio
 - **THEN** each episode SHALL include predator metrics:
   - `predator_encounters` (integer)
   - `successful_evasions` (integer)
-  - `predator_deaths` (boolean or integer)
-  - `foods_collected_before_death` (integer, if applicable)
+  - `died_to_health_depletion` (boolean)
+  - `foods_collected` (integer)
 - **AND** these SHALL be included in the episode performance data
 
 #### Scenario: Experiment Metadata When Predators Disabled
@@ -357,9 +357,9 @@ The experiment tracking system SHALL include predator metrics in CSV exports and
 - **THEN** the CSV SHALL include columns:
   - `predator_encounters`
   - `successful_evasions`
-  - `predator_deaths` (boolean)
-  - `foods_collected` (existing, but crucial for predator context)
-  - `termination_reason` (showing "predator" when applicable)
+  - `died_to_health_depletion` (boolean)
+  - `foods_collected`
+  - `termination_reason` (showing "health_depleted" when HP reaches zero)
 - **AND** columns SHALL be empty/null when predators disabled (backward compatibility)
 
 #### Scenario: JSON Export with Full Predator Configuration

--- a/openspec/specs/experiment-tracking/spec.md
+++ b/openspec/specs/experiment-tracking/spec.md
@@ -211,7 +211,7 @@ The experiment tracking system SHALL capture comprehensive predator configuratio
   - `predator_speed` (float)
   - `predator_movement_pattern` (string)
   - `predator_detection_radius` (integer)
-  - `predator_kill_radius` (integer)
+  - `predator_damage_radius` (integer)
   - `predator_gradient_decay_constant` (float)
   - `predator_gradient_strength` (float)
 - **AND** this SHALL be stored in experiment JSON metadata

--- a/packages/quantum-nematode/quantumnematode/agent/agent.py
+++ b/packages/quantum-nematode/quantumnematode/agent/agent.py
@@ -499,11 +499,8 @@ class QuantumNematodeAgent:
         predator_contact = self.env.is_agent_in_predator_contact()
 
         # Health state
-        health = None
-        max_health = None
-        if self.env.health.enabled:
-            health = self.env.agent_hp
-            max_health = self.env.health.max_hp
+        health = self.env.agent_hp
+        max_health = self.env.health.max_hp
 
         # Thermotaxis: temperature sensing
         temperature = None
@@ -807,7 +804,6 @@ class QuantumNematodeAgent:
             total_successes=metrics.total_successes,
             total_starved=metrics.total_starved,
             total_predator_encounters=metrics.total_predator_encounters,
-            total_predator_deaths=metrics.total_predator_deaths,
             total_successful_evasions=metrics.total_successful_evasions,
             total_max_steps=metrics.total_max_steps,
             total_interrupted=metrics.total_interrupted,

--- a/packages/quantum-nematode/quantumnematode/agent/metrics.py
+++ b/packages/quantum-nematode/quantumnematode/agent/metrics.py
@@ -36,7 +36,6 @@ class MetricsTracker:
         # Predator tracking
         self.total_predator_encounters = 0
         self.total_successful_evasions = 0
-        self.total_predator_deaths = 0
         self.total_starved = 0
         self.total_max_steps = 0
         self.total_interrupted = 0
@@ -90,9 +89,7 @@ class MetricsTracker:
 
         # Track termination reasons
         if termination_reason:
-            if termination_reason == TerminationReason.PREDATOR:
-                self.total_predator_deaths += 1
-            elif termination_reason == TerminationReason.STARVED:
+            if termination_reason == TerminationReason.STARVED:
                 self.total_starved += 1
             elif termination_reason == TerminationReason.HEALTH_DEPLETED:
                 self.total_health_depleted += 1
@@ -164,7 +161,6 @@ class MetricsTracker:
             total_successes=self.success_count,
             total_starved=self.total_starved,
             total_predator_encounters=self.total_predator_encounters,
-            total_predator_deaths=self.total_predator_deaths,
             total_health_depleted=self.total_health_depleted,
             total_successful_evasions=self.total_successful_evasions,
             total_max_steps=self.total_max_steps,
@@ -181,7 +177,6 @@ class MetricsTracker:
         self.distance_efficiencies = []
         self.total_predator_encounters = 0
         self.total_successful_evasions = 0
-        self.total_predator_deaths = 0
         self.total_starved = 0
         self.total_max_steps = 0
         self.total_interrupted = 0

--- a/packages/quantum-nematode/quantumnematode/agent/runners.py
+++ b/packages/quantum-nematode/quantumnematode/agent/runners.py
@@ -313,7 +313,7 @@ class StandardEpisodeRunner(EpisodeRunner):
         *,
         after_movement: bool = False,
     ) -> tuple[EpisodeResult | None, float]:
-        """Check for predator collision and apply damage or instant death.
+        """Check for predator contact and apply damage.
 
         Parameters
         ----------
@@ -326,59 +326,32 @@ class StandardEpisodeRunner(EpisodeRunner):
             A termination result if the agent died (or None), and the
             updated reward value.
         """
-        predator_contact = (
-            agent.env.is_agent_in_damage_radius()
-            if agent.env.health.enabled
-            else agent.env.check_predator_collision()
-        )
-        if not predator_contact:
+        if not agent.env.is_agent_in_damage_radius():
             return None, reward
 
-        if agent.env.health.enabled:
-            damage = agent.env.apply_predator_damage()
-            log_prefix = "Predator stepped on agent!" if after_movement else "Predator contact!"
-            logger.info(
-                f"{log_prefix} Took {damage:.1f} damage. "
-                f"HP: {agent.env.agent_hp:.1f}/{agent.env.health.max_hp:.1f}",
-            )
+        damage = agent.env.apply_predator_damage()
+        log_prefix = "Predator stepped on agent!" if after_movement else "Predator contact!"
+        logger.info(
+            f"{log_prefix} Took {damage:.1f} damage. "
+            f"HP: {agent.env.agent_hp:.1f}/{agent.env.health.max_hp:.1f}",
+        )
 
-            # Apply damage penalty (learning signal for taking damage)
-            damage_penalty = -reward_config.penalty_health_damage
-            reward += damage_penalty
-            agent._episode_tracker.track_reward(damage_penalty)
+        # Apply damage penalty (learning signal for taking damage)
+        damage_penalty = -reward_config.penalty_health_damage
+        reward += damage_penalty
+        agent._episode_tracker.track_reward(damage_penalty)
 
-            # Check if health depleted
-            if not agent.env.is_health_depleted():
-                return None, reward
+        # Check if health depleted
+        if not agent.env.is_health_depleted():
+            return None, reward
 
-            # Track final health (0 HP) before returning
-            agent._episode_tracker.track_health(agent.env.agent_hp)
+        # Track final health (0 HP) before returning
+        agent._episode_tracker.track_health(agent.env.agent_hp)
 
-            logger.warning(
-                "Failed to complete episode: health depleted from predator damage!",
-            )
-            # Apply death penalty
-            penalty = -reward_config.penalty_predator_death
-            reward += penalty
-            agent._episode_tracker.track_reward(penalty)
-
-            return self._terminate_episode(
-                agent,
-                params,
-                reward,
-                success=False,
-                termination_reason=TerminationReason.HEALTH_DEPLETED,
-            ), reward
-
-        # Instant death (original behavior when health system disabled)
-        if after_movement:
-            logger.warning(
-                "Failed to complete episode: agent caught by predator (after predator movement)!",
-            )
-        else:
-            logger.warning("Failed to complete episode: agent caught by predator!")
-
-        # Apply death penalty to both brain reward and episode tracker
+        logger.warning(
+            "Failed to complete episode: health depleted from predator damage!",
+        )
+        # Apply death penalty
         penalty = -reward_config.penalty_predator_death
         reward += penalty
         agent._episode_tracker.track_reward(penalty)
@@ -388,7 +361,7 @@ class StandardEpisodeRunner(EpisodeRunner):
             params,
             reward,
             success=False,
-            termination_reason=TerminationReason.PREDATOR,
+            termination_reason=TerminationReason.HEALTH_DEPLETED,
         ), reward
 
     def _handle_predator_phase(
@@ -657,9 +630,8 @@ class StandardEpisodeRunner(EpisodeRunner):
             # Track satiety after decay
             agent._episode_tracker.track_satiety(agent.current_satiety)
 
-            # Track health if health system is enabled
-            if agent.env.health.enabled:
-                agent._episode_tracker.track_health(agent.env.agent_hp)
+            # Track health
+            agent._episode_tracker.track_health(agent.env.agent_hp)
 
             # Temperature effects
             result, reward = self._handle_temperature_effects(agent, reward_config, params, reward)

--- a/packages/quantum-nematode/quantumnematode/agent/runners.py
+++ b/packages/quantum-nematode/quantumnematode/agent/runners.py
@@ -457,6 +457,9 @@ class StandardEpisodeRunner(EpisodeRunner):
                 f"(took {temp_damage:.1f} damage)",
             )
 
+            # Track health after temperature damage
+            agent._episode_tracker.track_health(agent.env.agent_hp)
+
         # Check if temperature damage depleted health
         if temp_damage > 0 and agent.env.is_health_depleted():
             logger.warning(

--- a/packages/quantum-nematode/quantumnematode/env/env.py
+++ b/packages/quantum-nematode/quantumnematode/env/env.py
@@ -1647,7 +1647,7 @@ class DynamicForagingEnvironment(BaseEnvironment):
         Returns
         -------
         bool
-            True if HP <= 0 and health system is enabled, False otherwise.
+            True if HP <= 0, False otherwise.
         """
         return self.agent_hp <= 0.0
 

--- a/packages/quantum-nematode/quantumnematode/env/env.py
+++ b/packages/quantum-nematode/quantumnematode/env/env.py
@@ -132,10 +132,8 @@ class PredatorParams:
         Movement speed relative to agent.
     detection_radius : int
         Distance at which pursuit predators detect the agent.
-    kill_radius : int
-        Distance for instant death (when health system disabled).
     damage_radius : int
-        Distance at which predators deal damage (when health system enabled).
+        Distance at which predators deal damage.
         Stationary predators typically have larger damage_radius (toxic zones).
     gradient_decay_constant : float
         Controls how quickly predator gradient signal decays with distance.
@@ -148,7 +146,6 @@ class PredatorParams:
     predator_type: PredatorType = PredatorType.PURSUIT
     speed: float = 1.0
     detection_radius: int = 8
-    kill_radius: int = 0
     damage_radius: int = 0
     gradient_decay_constant: float = 12.0
     gradient_strength: float = 1.0
@@ -163,7 +160,6 @@ class HealthParams:
     https://github.com/microsoft/pylance-release/issues/7801
     """
 
-    enabled: bool = False
     max_hp: float = DEFAULT_MAX_HP
     predator_damage: float = DEFAULT_PREDATOR_DAMAGE
     food_healing: float = DEFAULT_FOOD_HEALING
@@ -894,7 +890,7 @@ class DynamicForagingEnvironment(BaseEnvironment):
         self.viewport_size = viewport_size
 
         # Health state (runtime, not config)
-        self.agent_hp: float = self.health.max_hp if self.health.enabled else 0.0
+        self.agent_hp: float = self.health.max_hp
 
         # Temperature field (runtime, created from thermotaxis config)
         self.temperature_field: TemperatureField | None = None
@@ -1469,31 +1465,6 @@ class DynamicForagingEnvironment(BaseEnvironment):
         for pred in self.predators:
             pred.update_position(self.grid_size, self.rng, agent_pos)
 
-    def check_predator_collision(self) -> bool:
-        """
-        Check if agent collided with any predator.
-
-        Returns
-        -------
-        bool
-            True if collision detected (within kill_radius), False otherwise.
-        """
-        if not self.predator.enabled:
-            return False
-
-        agent_pos = self.agent_pos
-        for pred in self.predators:
-            # Manhattan distance for kill radius
-            distance = abs(agent_pos[0] - pred.position[0]) + abs(
-                agent_pos[1] - pred.position[1],
-            )
-            if distance <= self.predator.kill_radius:
-                logger.debug(
-                    f"Predator collision! Agent at {agent_pos}, Predator at {pred.position}",
-                )
-                return True
-        return False
-
     def is_agent_in_danger(self) -> bool:
         """
         Check if agent is within detection radius of any predator.
@@ -1623,21 +1594,12 @@ class DynamicForagingEnvironment(BaseEnvironment):
         Mechanosensation: Detects harsh touch from predator contact,
         modeled after C. elegans harsh touch response (ASH, ADL neurons).
 
-        This uses kill_radius for non-health environments and damage_radius
-        for health-enabled environments to determine physical contact.
-
         Returns
         -------
         bool
-            True if agent is within contact radius of any predator.
+            True if agent is within damage radius of any predator.
         """
-        if not self.predator.enabled:
-            return False
-
-        # Use damage_radius if health system enabled, otherwise kill_radius
-        if self.health.enabled:
-            return self.is_agent_in_damage_radius()
-        return self.check_predator_collision()
+        return self.is_agent_in_damage_radius()
 
     # --- Health methods ---
 
@@ -1648,12 +1610,9 @@ class DynamicForagingEnvironment(BaseEnvironment):
         Returns
         -------
         float
-            Actual amount of damage applied (0 if health system disabled).
+            Actual amount of damage applied.
             May be less than configured damage if HP was already low.
         """
-        if not self.health.enabled:
-            return 0.0
-
         old_hp = self.agent_hp
         self.agent_hp = max(0.0, self.agent_hp - self.health.predator_damage)
         actual_damage = old_hp - self.agent_hp
@@ -1670,11 +1629,8 @@ class DynamicForagingEnvironment(BaseEnvironment):
         Returns
         -------
         float
-            Amount of HP restored (0 if health system disabled).
+            Amount of HP restored.
         """
-        if not self.health.enabled:
-            return 0.0
-
         old_hp = self.agent_hp
         self.agent_hp = min(self.health.max_hp, self.agent_hp + self.health.food_healing)
         actual_healing = self.agent_hp - old_hp
@@ -1693,12 +1649,11 @@ class DynamicForagingEnvironment(BaseEnvironment):
         bool
             True if HP <= 0 and health system is enabled, False otherwise.
         """
-        return self.health.enabled and self.agent_hp <= 0.0
+        return self.agent_hp <= 0.0
 
     def reset_health(self) -> None:
         """Reset agent HP to maximum (called at episode start)."""
-        if self.health.enabled:
-            self.agent_hp = self.health.max_hp
+        self.agent_hp = self.health.max_hp
 
     # -------------------------------------------------------------------------
     # Thermotaxis Methods
@@ -1852,8 +1807,8 @@ class DynamicForagingEnvironment(BaseEnvironment):
             reward_delta = self.thermotaxis.danger_penalty  # Use danger penalty for lethal too
             hp_damage = self.thermotaxis.lethal_hp_damage
 
-        # Apply HP damage if health system is enabled
-        if hp_damage > 0 and self.health.enabled:
+        # Apply HP damage
+        if hp_damage > 0:
             self.agent_hp = max(0.0, self.agent_hp - hp_damage)
             logger.debug(
                 f"Temperature damage: zone={zone.value}, damage={hp_damage}, hp={self.agent_hp}",

--- a/packages/quantum-nematode/quantumnematode/experiment/metadata.py
+++ b/packages/quantum-nematode/quantumnematode/experiment/metadata.py
@@ -352,11 +352,11 @@ class ResultsMetadata(BaseModel):
         Per-run result data for full transparency and reproducibility verification.
         Contains essential metrics for each run including seeds.
     avg_survival_score : float | None
-        Average survival score across all runs (final_hp / max_hp). None if health disabled.
+        Average survival score across all runs (final_hp / max_hp).
     avg_temperature_comfort_score : float | None
         Average temperature comfort score across all runs. None if thermotaxis disabled.
     post_convergence_survival_score : float | None
-        Average survival score in post-convergence runs. None if health disabled.
+        Average survival score in post-convergence runs.
     post_convergence_temperature_comfort_score : float | None
         Average temperature comfort score in post-convergence runs. None if thermotaxis disabled.
     avg_chemotaxis_index : float | None

--- a/packages/quantum-nematode/quantumnematode/experiment/metadata.py
+++ b/packages/quantum-nematode/quantumnematode/experiment/metadata.py
@@ -124,10 +124,8 @@ class EnvironmentMetadata(BaseModel):
         Predator movement speed (predator environments only).
     predator_detection_radius : int | None
         Predator detection radius (predator environments only).
-    predator_kill_radius : int | None
-        Predator kill radius (predator environments only).
     predator_damage_radius : int | None
-        Predator damage radius for HP damage (predator environments with health system only).
+        Predator damage radius for HP damage (predator environments only).
     predator_gradient_decay : float | None
         Predator gradient decay constant (predator environments only).
     predator_gradient_strength : float | None
@@ -144,7 +142,6 @@ class EnvironmentMetadata(BaseModel):
     num_predators: int | None = None
     predator_speed: float | None = None
     predator_detection_radius: int | None = None
-    predator_kill_radius: int | None = None
     predator_damage_radius: int | None = None
     predator_gradient_decay: float | None = None
     predator_gradient_strength: float | None = None
@@ -316,10 +313,8 @@ class ResultsMetadata(BaseModel):
         Number of runs that reached max steps.
     goal_reached : int
         Number of runs that reached the goal.
-    predator_deaths : int
-        Number of runs that ended due to predator collision.
     health_depleted : int
-        Number of runs that ended due to HP reaching zero (health system enabled).
+        Number of runs that ended due to HP reaching zero.
     avg_predator_encounters : float | None
         Average predator encounters per run (predator environments only).
     avg_successful_evasions : float | None
@@ -402,7 +397,6 @@ class ResultsMetadata(BaseModel):
     starved: int = 0
     max_steps_reached: int = 0
     goal_reached: int = 0
-    predator_deaths: int = 0
     health_depleted: int = 0
     avg_predator_encounters: float | None = None
     avg_successful_evasions: float | None = None

--- a/packages/quantum-nematode/quantumnematode/experiment/tracker.py
+++ b/packages/quantum-nematode/quantumnematode/experiment/tracker.py
@@ -81,7 +81,6 @@ def extract_environment_metadata(
         num_predators=env.predator.count if env.predator.enabled else None,
         predator_speed=env.predator.speed if env.predator.enabled else None,
         predator_detection_radius=env.predator.detection_radius if env.predator.enabled else None,
-        predator_kill_radius=env.predator.kill_radius if env.predator.enabled else None,
         predator_damage_radius=env.predator.damage_radius if env.predator.enabled else None,
         predator_gradient_decay=env.predator.gradient_decay_constant
         if env.predator.enabled
@@ -312,11 +311,6 @@ def aggregate_results_metadata(  # noqa: PLR0912, PLR0915, C901
         1 for r in all_results if r.termination_reason == TerminationReason.GOAL_REACHED
     )
 
-    # Predator-specific metrics
-    predator_deaths = sum(
-        1 for r in all_results if r.termination_reason == TerminationReason.PREDATOR
-    )
-
     # Health system metrics
     health_depleted = sum(
         1 for r in all_results if r.termination_reason == TerminationReason.HEALTH_DEPLETED
@@ -516,7 +510,6 @@ def aggregate_results_metadata(  # noqa: PLR0912, PLR0915, C901
         starved=starved,
         max_steps_reached=max_steps_reached,
         goal_reached=goal_reached,
-        predator_deaths=predator_deaths,
         health_depleted=health_depleted,
         avg_predator_encounters=avg_predator_encounters,
         avg_successful_evasions=avg_successful_evasions,

--- a/packages/quantum-nematode/quantumnematode/report/csv_export.py
+++ b/packages/quantum-nematode/quantumnematode/report/csv_export.py
@@ -164,7 +164,6 @@ _SIMULATION_RESULTS_FIELDNAMES = [
     "avg_distance_efficiency",
     "predator_encounters",
     "successful_evasions",
-    "died_to_predator",
     "died_to_health_depletion",
 ]
 
@@ -192,9 +191,6 @@ def _simulation_result_to_row(result: SimulationResult) -> dict[str, object]:
         else np.nan,
         "successful_evasions": result.successful_evasions
         if result.successful_evasions is not None
-        else np.nan,
-        "died_to_predator": result.died_to_predator
-        if result.died_to_predator is not None
         else np.nan,
         "died_to_health_depletion": result.died_to_health_depletion
         if result.died_to_health_depletion is not None
@@ -994,7 +990,6 @@ def export_foraging_results_to_csv(  # pragma: no cover
             "foraging_efficiency",  # foods per step
             "predator_encounters",
             "successful_evasions",
-            "died_to_predator",
             "died_to_health_depletion",
         ]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
@@ -1027,9 +1022,6 @@ def export_foraging_results_to_csv(  # pragma: no cover
                         else np.nan,
                         "successful_evasions": result.successful_evasions
                         if result.successful_evasions is not None
-                        else np.nan,
-                        "died_to_predator": result.died_to_predator
-                        if result.died_to_predator is not None
                         else np.nan,
                         "died_to_health_depletion": result.died_to_health_depletion
                         if result.died_to_health_depletion is not None
@@ -1215,7 +1207,7 @@ def export_predator_results_to_csv(  # pragma: no cover
             "predator_encounters",
             "successful_evasions",
             "evasion_rate",
-            "died_to_predator",
+            "died_to_health_depletion",
             "foods_collected",
         ]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
@@ -1237,7 +1229,7 @@ def export_predator_results_to_csv(  # pragma: no cover
                     "predator_encounters": result.predator_encounters,
                     "successful_evasions": result.successful_evasions,
                     "evasion_rate": evasion_rate,
-                    "died_to_predator": result.died_to_predator,
+                    "died_to_health_depletion": result.died_to_health_depletion,
                     "foods_collected": result.foods_collected
                     if result.foods_collected is not None
                     else np.nan,
@@ -1284,8 +1276,8 @@ def export_predator_session_metrics_to_csv(  # pragma: no cover
     total_evasions = sum(
         r.successful_evasions for r in predator_results if r.successful_evasions is not None
     )
-    total_deaths = sum(1 for r in predator_results if r.died_to_predator)
-    survival_rate = 1.0 - (total_deaths / total_runs) if total_runs > 0 else 0.0
+    total_health_deaths = sum(1 for r in predator_results if r.died_to_health_depletion)
+    survival_rate = 1.0 - (total_health_deaths / total_runs) if total_runs > 0 else 0.0
     overall_evasion_rate = total_evasions / total_encounters if total_encounters > 0 else 0.0
 
     with filepath.open("w", newline="") as csvfile:
@@ -1296,7 +1288,7 @@ def export_predator_session_metrics_to_csv(  # pragma: no cover
         writer.writerow({"metric": "total_runs", "value": total_runs})
         writer.writerow({"metric": "total_predator_encounters", "value": total_encounters})
         writer.writerow({"metric": "total_successful_evasions", "value": total_evasions})
-        writer.writerow({"metric": "total_predator_deaths", "value": total_deaths})
+        writer.writerow({"metric": "total_health_depleted", "value": total_health_deaths})
         writer.writerow({"metric": "survival_rate", "value": f"{survival_rate:.4f}"})
         writer.writerow({"metric": "overall_evasion_rate", "value": f"{overall_evasion_rate:.4f}"})
 

--- a/packages/quantum-nematode/quantumnematode/report/csv_export.py
+++ b/packages/quantum-nematode/quantumnematode/report/csv_export.py
@@ -1277,7 +1277,7 @@ def export_predator_session_metrics_to_csv(  # pragma: no cover
         r.successful_evasions for r in predator_results if r.successful_evasions is not None
     )
     total_health_deaths = sum(1 for r in predator_results if r.died_to_health_depletion)
-    survival_rate = 1.0 - (total_health_deaths / total_runs) if total_runs > 0 else 0.0
+    hp_survival_rate = 1.0 - (total_health_deaths / total_runs) if total_runs > 0 else 0.0
     overall_evasion_rate = total_evasions / total_encounters if total_encounters > 0 else 0.0
 
     with filepath.open("w", newline="") as csvfile:
@@ -1289,7 +1289,7 @@ def export_predator_session_metrics_to_csv(  # pragma: no cover
         writer.writerow({"metric": "total_predator_encounters", "value": total_encounters})
         writer.writerow({"metric": "total_successful_evasions", "value": total_evasions})
         writer.writerow({"metric": "total_health_depleted", "value": total_health_deaths})
-        writer.writerow({"metric": "survival_rate", "value": f"{survival_rate:.4f}"})
+        writer.writerow({"metric": "hp_survival_rate", "value": f"{hp_survival_rate:.4f}"})
         writer.writerow({"metric": "overall_evasion_rate", "value": f"{overall_evasion_rate:.4f}"})
 
         # Add metrics from PerformanceMetrics

--- a/packages/quantum-nematode/quantumnematode/report/dtypes.py
+++ b/packages/quantum-nematode/quantumnematode/report/dtypes.py
@@ -20,10 +20,8 @@ class TerminationReason(StrEnum):
         Agent collected all available food (DynamicForagingEnvironment - not yet implemented).
     STARVED : str
         Agent's satiety reached zero (DynamicForagingEnvironment).
-    PREDATOR : str
-        Agent was caught by a predator (DynamicForagingEnvironment with predators enabled).
     HEALTH_DEPLETED : str
-        Agent's HP reached zero from accumulated damage (health system enabled).
+        Agent's HP reached zero from accumulated damage.
     MAX_STEPS : str
         Agent reached maximum allowed steps.
     INTERRUPTED : str
@@ -33,7 +31,6 @@ class TerminationReason(StrEnum):
     GOAL_REACHED = "goal_reached"
     COMPLETED_ALL_FOOD = "completed_all_food"
     STARVED = "starved"
-    PREDATOR = "predator"
     HEALTH_DEPLETED = "health_depleted"
     MAX_STEPS = "max_steps"
     INTERRUPTED = "interrupted"
@@ -79,10 +76,8 @@ class SimulationResult(BaseModel):
         Number of predator encounters (predator environments only).
     successful_evasions : int | None
         Number of successful predator evasions (predator environments only).
-    died_to_predator : bool | None
-        Whether run ended due to predator death (predator environments only).
     died_to_health_depletion : bool | None
-        Whether run ended due to HP reaching zero (health system enabled).
+        Whether run ended due to HP reaching zero.
     food_history : FoodHistory | None
         Food positions at each step (DynamicForagingEnvironment only).
     survival_score : float | None
@@ -108,7 +103,6 @@ class SimulationResult(BaseModel):
     temperature_history: list[float] | None = None
     predator_encounters: int | None = None
     successful_evasions: int | None = None
-    died_to_predator: bool | None = None
     died_to_health_depletion: bool | None = None
     food_history: FoodHistory | None = None
     survival_score: float | None = None
@@ -218,10 +212,8 @@ class PerformanceMetrics(BaseModel):
         Total number of runs that ended due to starvation.
     total_predator_encounters : int
         Total number of predator encounters across all runs.
-    total_predator_deaths : int
-        Total number of runs that ended due to predator collision.
     total_health_depleted : int
-        Total number of runs that ended due to HP reaching zero (health system).
+        Total number of runs that ended due to HP reaching zero.
     total_successful_evasions : int
         Total number of successful predator evasions across all runs.
     total_max_steps : int
@@ -247,7 +239,6 @@ class PerformanceMetrics(BaseModel):
     total_successes: int = 0
     total_starved: int = 0
     total_predator_encounters: int = 0
-    total_predator_deaths: int = 0
     total_health_depleted: int = 0
     total_successful_evasions: int = 0
     total_max_steps: int = 0

--- a/packages/quantum-nematode/quantumnematode/report/plots.py
+++ b/packages/quantum-nematode/quantumnematode/report/plots.py
@@ -1400,7 +1400,7 @@ def plot_survival_vs_food_collection(  # pragma: no cover
             s=100,
             color="green",
             edgecolors="black",
-            label=f"Survived ({len(survived_foods)} runs)",
+            label=f"Not Depleted ({len(survived_foods)} runs)",
         )
 
     # Plot died runs
@@ -1423,9 +1423,9 @@ def plot_survival_vs_food_collection(  # pragma: no cover
     avg_foods_died_str = f"{avg_foods_died:.1f}" if died_foods else "N/A"
 
     stats_text = (
-        f"Survival Rate: {survival_rate:.1%}\n"
-        f"Avg Foods (Survived): {avg_foods_survived:.1f}\n"
-        f"Avg Foods (Died): {avg_foods_died_str}"
+        f"HP Survival Rate: {survival_rate:.1%}\n"
+        f"Avg Foods (Not Depleted): {avg_foods_survived:.1f}\n"
+        f"Avg Foods (Depleted): {avg_foods_died_str}"
     )
     plt.text(
         0.05,
@@ -1437,8 +1437,8 @@ def plot_survival_vs_food_collection(  # pragma: no cover
         bbox={"boxstyle": "round", "facecolor": "wheat", "alpha": 0.8},
     )
 
-    plt.yticks([0, 1], ["Killed", "Survived"])
-    plt.title("Survival vs Food Collection")
+    plt.yticks([0, 1], ["Health Depleted", "Not Depleted"])
+    plt.title("Health Depletion vs Food Collection")
     plt.xlabel("Foods Collected")
     plt.ylabel("Outcome")
     plt.legend()

--- a/packages/quantum-nematode/quantumnematode/report/plots.py
+++ b/packages/quantum-nematode/quantumnematode/report/plots.py
@@ -1353,7 +1353,7 @@ def plot_survival_vs_food_collection(  # pragma: no cover
     file_prefix: str,
     plot_dir: Path,
     foods_collected: list[int],
-    predator_deaths: list[bool],
+    health_depleted: list[bool],
 ) -> None:
     """Plot survival rate vs food collection scatter plot.
 
@@ -1365,28 +1365,28 @@ def plot_survival_vs_food_collection(  # pragma: no cover
         Directory to save the plot.
     foods_collected : list[int]
         Number of foods collected in each run.
-    predator_deaths : list[bool]
-        Whether each run ended in predator death (True) or survival (False).
+    health_depleted : list[bool]
+        Whether each run ended in health depletion (True) or survival (False).
     """
     # Guard against empty inputs
-    if not foods_collected or not predator_deaths:
+    if not foods_collected or not health_depleted:
         logger.warning("No survival/food collection data to plot")
         return
 
     # Validate input lengths match
-    if len(foods_collected) != len(predator_deaths):
+    if len(foods_collected) != len(health_depleted):
         logger.warning(
             f"Length mismatch: foods_collected ({len(foods_collected)}) vs "
-            f"predator_deaths ({len(predator_deaths)}). Skipping plot.",
+            f"health_depleted ({len(health_depleted)}). Skipping plot.",
         )
         return
 
     # Separate data by survival status
     survived_foods = [
-        foods for foods, died in zip(foods_collected, predator_deaths, strict=True) if not died
+        foods for foods, died in zip(foods_collected, health_depleted, strict=True) if not died
     ]
     died_foods = [
-        foods for foods, died in zip(foods_collected, predator_deaths, strict=True) if died
+        foods for foods, died in zip(foods_collected, health_depleted, strict=True) if died
     ]
 
     plt.figure(figsize=(10, 8))
@@ -1412,11 +1412,11 @@ def plot_survival_vs_food_collection(  # pragma: no cover
             s=100,
             color="red",
             edgecolors="black",
-            label=f"Killed by Predator ({len(died_foods)} runs)",
+            label=f"Health Depleted ({len(died_foods)} runs)",
         )
 
     # Add statistics
-    total_runs = len(predator_deaths)
+    total_runs = len(health_depleted)
     survival_rate = len(survived_foods) / total_runs if total_runs > 0 else 0.0
     avg_foods_survived = sum(survived_foods) / len(survived_foods) if survived_foods else 0.0
     avg_foods_died = sum(died_foods) / len(died_foods) if died_foods else 0.0

--- a/packages/quantum-nematode/quantumnematode/report/summary.py
+++ b/packages/quantum-nematode/quantumnematode/report/summary.py
@@ -98,11 +98,6 @@ def summary(  # noqa: C901, PLR0912, PLR0913, PLR0915
             f"Failed runs - Starved: {metrics.total_starved} "
             f"({metrics.total_starved / total_runs_done * 100:.1f}%)",
         )
-    if metrics.total_predator_deaths is not None and metrics.total_predator_deaths > 0:
-        output_lines.append(
-            f"Failed runs - Eaten by Predator: {metrics.total_predator_deaths} "
-            f"({metrics.total_predator_deaths / total_runs_done * 100:.1f}%)",
-        )
     if metrics.total_health_depleted is not None and metrics.total_health_depleted > 0:
         output_lines.append(
             f"Failed runs - Health Depleted: {metrics.total_health_depleted} "

--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -293,10 +293,8 @@ class PredatorConfig(BaseModel):
         Movement behavior: "stationary" or "pursuit".
     detection_radius : int
         Distance at which pursuit predators detect the agent.
-    kill_radius : int
-        Distance for instant death (when health system disabled).
     damage_radius : int
-        Distance at which predators deal damage (when health system enabled).
+        Distance at which predators deal damage.
         Stationary predators typically have larger damage_radius (toxic zones).
     gradient_decay_constant : float
         Controls how quickly predator gradient signal decays with distance.
@@ -310,8 +308,7 @@ class PredatorConfig(BaseModel):
     movement_pattern: MovementPattern = "pursuit"
     # Maps to DynamicForagingEnvironment.predator_detection_radius
     detection_radius: int = 8
-    kill_radius: int = 0  # Maps to DynamicForagingEnvironment.predator_kill_radius
-    damage_radius: int = 0  # Distance for damage application (health system)
+    damage_radius: int = 0  # Distance for damage application
     # Maps to DynamicForagingEnvironment.predator_gradient_decay
     gradient_decay_constant: float = 12.0
     # Maps to DynamicForagingEnvironment.predator_gradient_strength
@@ -332,7 +329,6 @@ class PredatorConfig(BaseModel):
             predator_type=predator_type,
             speed=self.speed,
             detection_radius=self.detection_radius,
-            kill_radius=self.kill_radius,
             damage_radius=self.damage_radius,
             gradient_decay_constant=self.gradient_decay_constant,
             gradient_strength=self.gradient_strength,
@@ -342,11 +338,10 @@ class PredatorConfig(BaseModel):
 class HealthConfig(BaseModel):
     """Configuration for HP-based health system.
 
-    When enabled, predator contact deals damage instead of instant death.
-    Food consumption restores both HP and satiety (when both systems are enabled).
+    Predator contact deals damage based on proximity within damage_radius.
+    Food consumption restores both HP and satiety.
     """
 
-    enabled: bool = False
     max_hp: float = 100.0
     predator_damage: float = 10.0
     food_healing: float = 5.0
@@ -354,7 +349,6 @@ class HealthConfig(BaseModel):
     def to_params(self) -> HealthParams:
         """Convert to HealthParams for environment initialization."""
         return HealthParams(
-            enabled=self.enabled,
             max_hp=self.max_hp,
             predator_damage=self.predator_damage,
             food_healing=self.food_healing,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_metrics.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_metrics.py
@@ -21,7 +21,6 @@ class TestMetricsTrackerInitialization:
         assert tracker.total_predator_encounters == 0
         assert tracker.total_successful_evasions == 0
         # Verify termination reason counters
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0
@@ -153,7 +152,6 @@ class TestMetricsReset:
         assert tracker.total_predator_encounters == 0
         assert tracker.total_successful_evasions == 0
         # Verify termination reason counters are reset
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0
@@ -222,7 +220,7 @@ class TestPredatorMetrics:
         # Non-predator environment: metrics should be None
         assert metrics.average_predator_encounters is None
         assert metrics.average_successful_evasions is None
-        assert metrics.total_predator_deaths == 0
+        assert metrics.total_health_depleted == 0
         assert metrics.total_predator_encounters == 0
         assert metrics.total_successful_evasions == 0
 
@@ -239,7 +237,7 @@ class TestPredatorMetrics:
         # Predator-enabled environment with zero encounters: metrics should be 0.0
         assert metrics.average_predator_encounters == 0.0
         assert metrics.average_successful_evasions == 0.0
-        assert metrics.total_predator_deaths == 0
+        assert metrics.total_health_depleted == 0
         assert metrics.total_predator_encounters == 0
         assert metrics.total_successful_evasions == 0
 
@@ -272,7 +270,7 @@ class TestPredatorMetrics:
         # Total counts
         assert metrics.total_predator_encounters == 4
         assert metrics.total_successful_evasions == 3
-        assert metrics.total_predator_deaths == 0
+        assert metrics.total_health_depleted == 0
 
     def test_predator_metrics_distinction(self):
         """Test that we can distinguish predator-enabled from non-predator environments."""
@@ -297,8 +295,6 @@ class TestPredatorMetrics:
         assert metrics_with_predators.average_predator_encounters == 0.0
         assert metrics_no_predators.average_successful_evasions is None
         assert metrics_with_predators.average_successful_evasions == 0.0
-        assert metrics_no_predators.total_predator_deaths == 0
-        assert metrics_with_predators.total_predator_deaths == 0
         assert metrics_no_predators.total_predator_encounters == 0
         assert metrics_with_predators.total_predator_encounters == 0
         assert metrics_no_predators.total_successful_evasions == 0
@@ -317,22 +313,22 @@ class TestTerminationReasonTracking:
             success=False,
             steps=10,
             reward=-50.0,
-            termination_reason=TerminationReason.PREDATOR,
+            termination_reason=TerminationReason.HEALTH_DEPLETED,
         )
         tracker.track_episode_completion(
             success=False,
             steps=8,
             reward=-50.0,
-            termination_reason=TerminationReason.PREDATOR,
+            termination_reason=TerminationReason.HEALTH_DEPLETED,
         )
 
-        assert tracker.total_predator_deaths == 2
+        assert tracker.total_health_depleted == 2
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0
 
         metrics = tracker.calculate_metrics(total_runs=2)
-        assert metrics.total_predator_deaths == 2
+        assert metrics.total_health_depleted == 2
 
     def test_termination_reason_starved(self):
         """Test that starvation deaths are tracked correctly."""
@@ -359,7 +355,7 @@ class TestTerminationReasonTracking:
         )
 
         assert tracker.total_starved == 3
-        assert tracker.total_predator_deaths == 0
+        assert tracker.total_health_depleted == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0
 
@@ -379,7 +375,6 @@ class TestTerminationReasonTracking:
         )
 
         assert tracker.total_max_steps == 1
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_interrupted == 0
 
@@ -405,7 +400,6 @@ class TestTerminationReasonTracking:
         )
 
         assert tracker.total_interrupted == 2
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
 
@@ -425,14 +419,13 @@ class TestTerminationReasonTracking:
         )
 
         # No failure counters should be incremented
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0
 
         metrics = tracker.calculate_metrics(total_runs=1)
         assert metrics.total_successes == 1
-        assert metrics.total_predator_deaths == 0
+        assert metrics.total_health_depleted == 0
         assert metrics.total_starved == 0
         assert metrics.total_max_steps == 0
         assert metrics.total_interrupted == 0
@@ -451,14 +444,13 @@ class TestTerminationReasonTracking:
         )
 
         # No failure counters should be incremented
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0
 
         metrics = tracker.calculate_metrics(total_runs=1)
         assert metrics.total_successes == 1
-        assert metrics.total_predator_deaths == 0
+        assert metrics.total_health_depleted == 0
 
     def test_termination_reason_mixed_scenarios(self):
         """Test tracking multiple different termination reasons."""
@@ -475,7 +467,7 @@ class TestTerminationReasonTracking:
             success=False,
             steps=10,
             reward=-50.0,
-            termination_reason=TerminationReason.PREDATOR,
+            termination_reason=TerminationReason.HEALTH_DEPLETED,
         )
         tracker.track_episode_completion(
             success=False,
@@ -499,11 +491,11 @@ class TestTerminationReasonTracking:
             success=False,
             steps=12,
             reward=-50.0,
-            termination_reason=TerminationReason.PREDATOR,
+            termination_reason=TerminationReason.HEALTH_DEPLETED,
         )
 
         assert tracker.success_count == 1
-        assert tracker.total_predator_deaths == 2
+        assert tracker.total_health_depleted == 2
         assert tracker.total_starved == 1
         assert tracker.total_max_steps == 1
         assert tracker.total_interrupted == 1
@@ -511,7 +503,7 @@ class TestTerminationReasonTracking:
         metrics = tracker.calculate_metrics(total_runs=6)
         assert metrics.success_rate == pytest.approx(1 / 6)
         assert metrics.total_successes == 1
-        assert metrics.total_predator_deaths == 2
+        assert metrics.total_health_depleted == 2
         assert metrics.total_starved == 1
         assert metrics.total_max_steps == 1
         assert metrics.total_interrupted == 1
@@ -535,13 +527,12 @@ class TestTerminationReasonTracking:
         )
 
         # No termination counters should be incremented
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0
 
         metrics = tracker.calculate_metrics(total_runs=2)
-        assert metrics.total_predator_deaths == 0
+        assert metrics.total_health_depleted == 0
         assert metrics.total_starved == 0
         assert metrics.total_max_steps == 0
         assert metrics.total_interrupted == 0
@@ -555,7 +546,7 @@ class TestTerminationReasonTracking:
             success=False,
             steps=10,
             reward=-50.0,
-            termination_reason=TerminationReason.PREDATOR,
+            termination_reason=TerminationReason.HEALTH_DEPLETED,
         )
         tracker.track_episode_completion(
             success=False,
@@ -564,13 +555,12 @@ class TestTerminationReasonTracking:
             termination_reason=TerminationReason.STARVED,
         )
 
-        assert tracker.total_predator_deaths == 1
+        assert tracker.total_health_depleted == 1
         assert tracker.total_starved == 1
 
         # Reset should clear termination counters
         tracker.reset()
 
-        assert tracker.total_predator_deaths == 0
         assert tracker.total_starved == 0
         assert tracker.total_max_steps == 0
         assert tracker.total_interrupted == 0

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_runners.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_runners.py
@@ -273,21 +273,21 @@ class TestRunnerComponentIntegration:
 class TestPredatorCollisionTermination:
     """Test predator collision handling in episode runner."""
 
-    def test_predator_instant_death_terminates_episode(self):
-        """Test that predator collision without health system causes instant death."""
+    def test_predator_damage_depletes_health(self):
+        """Test that predator contact depletes health and terminates episode."""
         config = MLPReinforceBrainConfig(hidden_dim=32, learning_rate=0.01, num_hidden_layers=2)
         brain = MLPReinforceBrain(config=config, input_dim=2, num_actions=4)
 
-        # Create environment with predator that has kill_radius=1
-        # (agent moves first in the step loop, so kill_radius=0 would miss)
+        # Create environment with predator that has damage_radius=1
+        # and high damage so health depletes quickly
         env = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            predator=PredatorParams(enabled=True, count=1, kill_radius=1),
-            health=HealthParams(enabled=False),  # Instant death mode
+            predator=PredatorParams(enabled=True, count=1, damage_radius=1),
+            health=HealthParams(max_hp=10.0, predator_damage=100.0),
         )
 
-        # Place predator adjacent to agent - will be in kill range after agent moves
+        # Place predator on agent - will be in damage range
         agent_x, agent_y = env.agent_pos[0], env.agent_pos[1]
         env.predators[0].position = (agent_x, agent_y)
 
@@ -297,8 +297,8 @@ class TestPredatorCollisionTermination:
         reward_config = RewardConfig()
         result = agent.run_episode(reward_config, max_steps=100)
 
-        # Should terminate due to predator
-        assert result.termination_reason == TerminationReason.PREDATOR
+        # Should terminate due to health depletion from predator damage
+        assert result.termination_reason == TerminationReason.HEALTH_DEPLETED
 
     def test_predator_with_health_system_applies_damage(self):
         """Test that predator collision with health system applies damage."""
@@ -308,8 +308,8 @@ class TestPredatorCollisionTermination:
         env = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            predator=PredatorParams(enabled=True, count=1, kill_radius=0),
-            health=HealthParams(enabled=True, max_hp=100.0, predator_damage=20.0),
+            predator=PredatorParams(enabled=True, count=1),
+            health=HealthParams(max_hp=100.0, predator_damage=20.0),
         )
 
         # Place predator on agent's starting position
@@ -334,8 +334,8 @@ class TestPredatorCollisionTermination:
         env = DynamicForagingEnvironment(
             grid_size=5,  # Small grid, hard to avoid predator
             foraging=ForagingParams(target_foods_to_collect=5),
-            predator=PredatorParams(enabled=True, count=3, kill_radius=0),  # Multiple predators
-            health=HealthParams(enabled=True, max_hp=20.0, predator_damage=20.0),  # One-hit kill
+            predator=PredatorParams(enabled=True, count=3),  # Multiple predators
+            health=HealthParams(max_hp=20.0, predator_damage=20.0),  # One-hit kill
         )
 
         satiety_config = SatietyConfig(initial_satiety=500.0)
@@ -427,7 +427,7 @@ class TestHealthHistoryTracking:
         env = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
         )
 
         satiety_config = SatietyConfig(initial_satiety=100.0)
@@ -456,7 +456,7 @@ class TestThermotaxisIntegration:
         env = DynamicForagingEnvironment(
             grid_size=20,
             foraging=ForagingParams(target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -488,7 +488,7 @@ class TestThermotaxisIntegration:
         env = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -517,7 +517,7 @@ class TestThermotaxisIntegration:
         env = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=50.0),  # Low HP
+            health=HealthParams(max_hp=50.0),  # Low HP
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -545,7 +545,7 @@ class TestThermotaxisIntegration:
         env = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -583,7 +583,7 @@ class TestThermotaxisIntegration:
         env1 = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -604,7 +604,7 @@ class TestThermotaxisIntegration:
         env2 = DynamicForagingEnvironment(
             grid_size=10,
             foraging=ForagingParams(target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -641,7 +641,7 @@ class TestBraveForagingBonus:
                 min_food_distance=1,
                 agent_exclusion_radius=1,
             ),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -686,7 +686,7 @@ class TestBraveForagingBonus:
                 min_food_distance=1,
                 agent_exclusion_radius=1,
             ),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -727,7 +727,7 @@ class TestBraveForagingBonus:
                 min_food_distance=1,
                 agent_exclusion_radius=1,
             ),
-            health=HealthParams(enabled=True, max_hp=200.0),  # High HP to survive
+            health=HealthParams(max_hp=200.0),  # High HP to survive
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,
@@ -767,7 +767,7 @@ class TestBraveForagingBonus:
                 min_food_distance=1,
                 agent_exclusion_radius=1,
             ),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_env.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_env.py
@@ -664,7 +664,6 @@ class TestPredatorMechanics:
                 count=2,
                 speed=1.0,
                 detection_radius=8,
-                kill_radius=0,
             ),
         )
 
@@ -712,32 +711,29 @@ class TestPredatorMechanics:
         # Verify all values are finite (no NaN or Inf)
         assert all(np.isfinite(val) for val in state)
 
-    def test_collision_detection_kill_radius(self, predator_env):
-        """Test collision detection with non-zero kill_radius using Manhattan distance."""
+    def test_damage_radius_detection(self, predator_env):
+        """Test damage radius detection using Manhattan distance."""
         predator_env.agent_pos = (10, 10)
-        predator_env.predator = PredatorParams(
-            enabled=True,
-            count=2,
-            speed=1.0,
-            detection_radius=8,
-            kill_radius=1,
-        )
+        # Set per-predator damage_radius to 1
+        for pred in predator_env.predators:
+            pred.damage_radius = 1
 
-        # Distance 0: same cell → kill
+        # Distance 0: same cell → in damage radius
         predator_env.predators[0].position = (10, 10)
-        assert predator_env.check_predator_collision() is True
+        assert predator_env.is_agent_in_damage_radius() is True
 
-        # Distance 1 (cardinal neighbour) → kill
+        # Distance 1 (cardinal neighbour) → in damage radius
         predator_env.predators[0].position = (11, 10)
-        assert predator_env.check_predator_collision() is True
+        assert predator_env.is_agent_in_damage_radius() is True
 
-        # Distance 2 → no kill
+        # Distance 2 → not in damage radius
         predator_env.predators[0].position = (12, 10)
-        assert predator_env.check_predator_collision() is False
+        predator_env.predators[1].position = (0, 0)  # Move other predator away
+        assert predator_env.is_agent_in_damage_radius() is False
 
-        # Distance 2 (diagonal) → no kill
+        # Distance 2 (diagonal) → not in damage radius
         predator_env.predators[0].position = (11, 11)
-        assert predator_env.check_predator_collision() is False
+        assert predator_env.is_agent_in_damage_radius() is False
 
     def test_proximity_detection(self, predator_env):
         """Test proximity detection with detection_radius."""
@@ -824,10 +820,6 @@ class TestPredatorMechanics:
                 assert 0 <= predator.position[0] < predator_env.grid_size
                 assert 0 <= predator.position[1] < predator_env.grid_size
 
-            # Check collision detection works
-            collision = predator_env.check_predator_collision()
-            assert isinstance(collision, bool)
-
             # Check danger detection works
             in_danger = predator_env.is_agent_in_danger()
             assert isinstance(in_danger, bool)
@@ -847,13 +839,9 @@ class TestPredatorMechanics:
         assert env.predator.enabled is False
         assert len(env.predators) == 0
         assert env.predator.detection_radius == 8  # Default value
-        assert env.predator.kill_radius == 0  # Default value
 
         # is_agent_in_danger should return False
         assert env.is_agent_in_danger() is False
-
-        # check_predator_collision should return False
-        assert env.check_predator_collision() is False
 
     def test_predators_spawn_outside_detection_radius(self, predator_env):
         """Test that predators spawn outside detection/damage radius of agent at initialization."""
@@ -1061,26 +1049,11 @@ class TestHealthSystem:
                 count=2,
                 speed=1.0,
                 detection_radius=8,
-                kill_radius=1,
             ),
         )
 
-    def test_health_disabled_by_default(self):
-        """Test that health system is disabled by default."""
-        env = DynamicForagingEnvironment(
-            grid_size=20,
-            start_pos=(10, 10),
-            foraging=ForagingParams(foods_on_grid=5, target_foods_to_collect=10),
-            theme=Theme.ASCII,
-            action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
-        )
-
-        assert env.health.enabled is False
-        assert env.agent_hp == 0.0  # HP is 0 when disabled
-
     def test_health_initialization(self, health_env):
         """Test health system initialization."""
-        assert health_env.health.enabled is True
         assert health_env.health.max_hp == 100.0
         assert health_env.health.predator_damage == 10.0
         assert health_env.health.food_healing == 5.0
@@ -1089,7 +1062,6 @@ class TestHealthSystem:
     def test_health_params_defaults(self):
         """Test HealthParams default values."""
         params = HealthParams()
-        assert params.enabled is False
         assert params.max_hp == 100.0
         assert params.predator_damage == 10.0
         assert params.food_healing == 5.0
@@ -1097,12 +1069,10 @@ class TestHealthSystem:
     def test_health_params_custom_values(self):
         """Test HealthParams with custom values."""
         params = HealthParams(
-            enabled=True,
             max_hp=200.0,
             predator_damage=50.0,
             food_healing=25.0,
         )
-        assert params.enabled is True
         assert params.max_hp == 200.0
         assert params.predator_damage == 50.0
         assert params.food_healing == 25.0
@@ -1131,21 +1101,6 @@ class TestHealthSystem:
 
         assert health_env.agent_hp == 0.0
         assert health_env.is_health_depleted() is True
-
-    def test_apply_predator_damage_when_disabled(self):
-        """Test that damage is not applied when health system is disabled."""
-        env = DynamicForagingEnvironment(
-            grid_size=20,
-            start_pos=(10, 10),
-            foraging=ForagingParams(foods_on_grid=5, target_foods_to_collect=10),
-            theme=Theme.ASCII,
-            action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
-            health=HealthParams(enabled=False),
-        )
-
-        damage = env.apply_predator_damage()
-        assert damage == 0.0
-        assert env.agent_hp == 0.0
 
     def test_apply_food_healing(self, health_env):
         """Test applying food healing."""
@@ -1176,20 +1131,6 @@ class TestHealthSystem:
         assert healing == 0.0
         assert health_env.agent_hp == 100.0
 
-    def test_apply_food_healing_when_disabled(self):
-        """Test that healing is not applied when health system is disabled."""
-        env = DynamicForagingEnvironment(
-            grid_size=20,
-            start_pos=(10, 10),
-            foraging=ForagingParams(foods_on_grid=5, target_foods_to_collect=10),
-            theme=Theme.ASCII,
-            action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
-            health=HealthParams(enabled=False),
-        )
-
-        healing = env.apply_food_healing()
-        assert healing == 0.0
-
     def test_is_health_depleted(self, health_env):
         """Test health depletion check."""
         assert health_env.is_health_depleted() is False
@@ -1200,40 +1141,11 @@ class TestHealthSystem:
         health_env.agent_hp = 0.1
         assert health_env.is_health_depleted() is False
 
-    def test_is_health_depleted_when_disabled(self):
-        """Test that health depletion returns False when disabled."""
-        env = DynamicForagingEnvironment(
-            grid_size=20,
-            start_pos=(10, 10),
-            foraging=ForagingParams(foods_on_grid=5, target_foods_to_collect=10),
-            theme=Theme.ASCII,
-            action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
-            health=HealthParams(enabled=False),
-        )
-
-        # Even with HP at 0, should return False when disabled
-        assert env.agent_hp == 0.0
-        assert env.is_health_depleted() is False
-
     def test_reset_health(self, health_env):
         """Test resetting health to max."""
         health_env.agent_hp = 25.0
         health_env.reset_health()
         assert health_env.agent_hp == 100.0
-
-    def test_reset_health_when_disabled(self):
-        """Test that reset_health does nothing when disabled."""
-        env = DynamicForagingEnvironment(
-            grid_size=20,
-            start_pos=(10, 10),
-            foraging=ForagingParams(foods_on_grid=5, target_foods_to_collect=10),
-            theme=Theme.ASCII,
-            action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
-            health=HealthParams(enabled=False),
-        )
-
-        env.reset_health()
-        assert env.agent_hp == 0.0  # Should remain 0 when disabled
 
     def test_health_with_predator_damage_workflow(self, health_predator_env):
         """Test complete health + predator workflow."""
@@ -1269,7 +1181,6 @@ class TestHealthSystem:
 
         copied_env = health_env.copy()
 
-        assert copied_env.health.enabled is True
         assert copied_env.health.max_hp == 100.0
         assert copied_env.agent_hp == 50.0
 
@@ -1852,7 +1763,7 @@ class TestMechanosensation:
             foraging=ForagingParams(foods_on_grid=5, target_foods_to_collect=10),
             theme=Theme.ASCII,
             action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             predator=PredatorParams(
                 enabled=True,
                 count=1,
@@ -1868,8 +1779,8 @@ class TestMechanosensation:
         env.predators[0].position = (13, 10)  # 3 cells away, outside damage_radius=2
         assert env.is_agent_in_predator_contact() is False
 
-    def test_is_agent_in_predator_contact_without_health(self):
-        """Test predator contact uses kill radius when health system disabled."""
+    def test_is_agent_in_predator_contact_with_damage_radius(self):
+        """Test predator contact uses damage radius."""
         env = DynamicForagingEnvironment(
             grid_size=20,
             start_pos=(10, 10),
@@ -1879,16 +1790,16 @@ class TestMechanosensation:
             predator=PredatorParams(
                 enabled=True,
                 count=1,
-                kill_radius=1,
+                damage_radius=1,
             ),
         )
 
-        # Place predator within kill radius
-        env.predators[0].position = (11, 10)  # 1 cell away, within kill_radius=1
+        # Place predator within damage radius
+        env.predators[0].position = (11, 10)  # 1 cell away, within damage_radius=1
         assert env.is_agent_in_predator_contact() is True
 
-        # Place predator outside kill radius
-        env.predators[0].position = (12, 10)  # 2 cells away, outside kill_radius=1
+        # Place predator outside damage radius
+        env.predators[0].position = (12, 10)  # 2 cells away, outside damage_radius=1
         assert env.is_agent_in_predator_contact() is False
 
     def test_is_agent_in_predator_contact_exact_boundary(self):
@@ -1899,7 +1810,7 @@ class TestMechanosensation:
             foraging=ForagingParams(foods_on_grid=5, target_foods_to_collect=10),
             theme=Theme.ASCII,
             action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             predator=PredatorParams(
                 enabled=True,
                 count=1,
@@ -2163,7 +2074,7 @@ class TestThermotaxisIntegration:
             grid_size=30,
             start_pos=(29, 15),  # 14 cells right of center (15, 15)
             foraging=ForagingParams(foods_on_grid=3, target_foods_to_collect=5),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_env.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_env.py
@@ -1022,7 +1022,6 @@ class TestHealthSystem:
             theme=Theme.ASCII,
             action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
             health=HealthParams(
-                enabled=True,
                 max_hp=100.0,
                 predator_damage=10.0,
                 food_healing=5.0,
@@ -1039,7 +1038,6 @@ class TestHealthSystem:
             theme=Theme.ASCII,
             action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
             health=HealthParams(
-                enabled=True,
                 max_hp=100.0,
                 predator_damage=25.0,
                 food_healing=10.0,
@@ -1204,7 +1202,6 @@ class TestHealthSystem:
             theme=Theme.ASCII,
             action_set=[Action.FORWARD, Action.LEFT, Action.RIGHT, Action.STAY],
             health=HealthParams(
-                enabled=True,
                 max_hp=50.0,
                 predator_damage=5.0,
                 food_healing=15.0,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
@@ -231,7 +231,7 @@ class TestPygameRenderer:
                 predator_type=PredatorType.STATIONARY,
                 damage_radius=1,
             ),
-            health=HealthParams(enabled=True, max_hp=100.0),
+            health=HealthParams(max_hp=100.0),
             thermotaxis=ThermotaxisParams(
                 enabled=True,
                 cultivation_temperature=20.0,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_predator_performance.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_predator_performance.py
@@ -32,7 +32,6 @@ class TestPredatorPerformance:
                 count=5,
                 speed=1.0,
                 detection_radius=8,
-                kill_radius=0,
                 gradient_decay_constant=5.0,
                 gradient_strength=1.0,
             ),
@@ -57,7 +56,7 @@ class TestPredatorPerformance:
             # Simulate a full environment step
             env.get_state(env.agent_pos)
             env.update_predators()
-            env.check_predator_collision()
+            env.is_agent_in_damage_radius()
             env.is_agent_in_danger()
 
             end = time.perf_counter()

--- a/packages/quantum-nematode/tests/quantumnematode_tests/experiment/test_metadata.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/experiment/test_metadata.py
@@ -52,7 +52,6 @@ class TestEnvironmentMetadata:
             num_predators=2,
             predator_speed=1.0,
             predator_detection_radius=8,
-            predator_kill_radius=0,
             predator_gradient_decay=12.0,
             predator_gradient_strength=1.0,
         )
@@ -61,7 +60,6 @@ class TestEnvironmentMetadata:
         assert env_meta.num_predators == 2
         assert env_meta.predator_speed == 1.0
         assert env_meta.predator_detection_radius == 8
-        assert env_meta.predator_kill_radius == 0
         assert env_meta.predator_gradient_decay == 12.0
         assert env_meta.predator_gradient_strength == 1.0
 
@@ -77,7 +75,6 @@ class TestEnvironmentMetadata:
         assert env_meta.num_predators is None
         assert env_meta.predator_speed is None
         assert env_meta.predator_detection_radius is None
-        assert env_meta.predator_kill_radius is None
         assert env_meta.predator_gradient_decay is None
         assert env_meta.predator_gradient_strength is None
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
@@ -21,7 +21,6 @@ class TestHealthConfig:
     def test_default_values(self):
         """Test HealthConfig default values."""
         config = HealthConfig()
-        assert config.enabled is False
         assert config.max_hp == 100.0
         assert config.predator_damage == 10.0
         assert config.food_healing == 5.0
@@ -29,12 +28,10 @@ class TestHealthConfig:
     def test_custom_values(self):
         """Test HealthConfig with custom values."""
         config = HealthConfig(
-            enabled=True,
             max_hp=200.0,
             predator_damage=25.0,
             food_healing=15.0,
         )
-        assert config.enabled is True
         assert config.max_hp == 200.0
         assert config.predator_damage == 25.0
         assert config.food_healing == 15.0
@@ -42,7 +39,6 @@ class TestHealthConfig:
     def test_to_params(self):
         """Test HealthConfig.to_params() conversion."""
         config = HealthConfig(
-            enabled=True,
             max_hp=150.0,
             predator_damage=20.0,
             food_healing=10.0,
@@ -51,7 +47,6 @@ class TestHealthConfig:
         params = config.to_params()
 
         assert isinstance(params, HealthParams)
-        assert params.enabled is True
         assert params.max_hp == 150.0
         assert params.predator_damage == 20.0
         assert params.food_healing == 10.0
@@ -62,7 +57,6 @@ class TestHealthConfig:
         params = config.to_params()
 
         assert isinstance(params, HealthParams)
-        assert params.enabled is False
         assert params.max_hp == 100.0
         assert params.predator_damage == 10.0
         assert params.food_healing == 5.0
@@ -130,7 +124,6 @@ class TestPredatorConfig:
         assert config.count == 2
         assert config.speed == 1.0
         assert config.detection_radius == 8
-        assert config.kill_radius == 0
         assert config.gradient_decay_constant == 12.0
         assert config.gradient_strength == 1.0
 
@@ -141,7 +134,6 @@ class TestPredatorConfig:
             count=5,
             speed=0.5,
             detection_radius=10,
-            kill_radius=2,
             gradient_decay_constant=15.0,
             gradient_strength=2.0,
         )
@@ -149,7 +141,6 @@ class TestPredatorConfig:
         assert config.count == 5
         assert config.speed == 0.5
         assert config.detection_radius == 10
-        assert config.kill_radius == 2
         assert config.gradient_decay_constant == 15.0
         assert config.gradient_strength == 2.0
 
@@ -160,7 +151,6 @@ class TestPredatorConfig:
             count=3,
             speed=0.75,
             detection_radius=6,
-            kill_radius=1,
             gradient_decay_constant=10.0,
             gradient_strength=1.5,
         )
@@ -172,7 +162,6 @@ class TestPredatorConfig:
         assert params.count == 3
         assert params.speed == 0.75
         assert params.detection_radius == 6
-        assert params.kill_radius == 1
         assert params.gradient_decay_constant == 10.0
         assert params.gradient_strength == 1.5
 
@@ -196,7 +185,7 @@ class TestEnvironmentConfig:
             viewport_size=(15, 15),
             foraging=ForagingConfig(foods_on_grid=20),
             predators=PredatorConfig(enabled=True, count=3),
-            health=HealthConfig(enabled=True, max_hp=200.0),
+            health=HealthConfig(max_hp=200.0),
         )
 
         assert config.grid_size == 30
@@ -207,7 +196,6 @@ class TestEnvironmentConfig:
         assert config.predators.enabled is True
         assert config.predators.count == 3
         assert config.health is not None
-        assert config.health.enabled is True
         assert config.health.max_hp == 200.0
 
     def test_get_foraging_config(self):
@@ -243,16 +231,14 @@ class TestEnvironmentConfig:
         """Test get_health_config returns configured or default."""
         # With explicit config
         config_with = EnvironmentConfig(
-            health=HealthConfig(enabled=True, max_hp=150.0),
+            health=HealthConfig(max_hp=150.0),
         )
         health = config_with.get_health_config()
-        assert health.enabled is True
         assert health.max_hp == 150.0
 
         # Without explicit config (should return default)
         config_without = EnvironmentConfig()
         health_default = config_without.get_health_config()
-        assert health_default.enabled is False  # Default value
         assert health_default.max_hp == 100.0  # Default value
 
 

--- a/scripts/experiment_query.py
+++ b/scripts/experiment_query.py
@@ -140,8 +140,8 @@ def print_experiment_details(metadata: ExperimentMetadata) -> None:  # noqa: C90
     print(f"  All Foods: {metadata.results.completed_all_food}")
     print(f"  Starved: {metadata.results.starved}")
     print(f"  Max Steps: {metadata.results.max_steps_reached}")
-    if metadata.results.predator_deaths > 0:
-        print(f"  Predator Deaths: {metadata.results.predator_deaths}")
+    if metadata.results.health_depleted > 0:
+        print(f"  Health Depleted: {metadata.results.health_depleted}")
 
     if metadata.results.avg_predator_encounters is not None:
         print("\nPredator Metrics:")

--- a/scripts/experiment_query.py
+++ b/scripts/experiment_query.py
@@ -104,7 +104,6 @@ def print_experiment_details(metadata: ExperimentMetadata) -> None:  # noqa: C90
         print(f"    Count: {metadata.environment.num_predators}")
         print(f"    Speed: {metadata.environment.predator_speed}")
         print(f"    Detection Radius: {metadata.environment.predator_detection_radius}")
-        print(f"    Kill Radius: {metadata.environment.predator_kill_radius}")
         if metadata.environment.predator_damage_radius:
             print(f"    Damage Radius: {metadata.environment.predator_damage_radius}")
         if metadata.environment.predator_gradient_decay:

--- a/scripts/export_screenshot.py
+++ b/scripts/export_screenshot.py
@@ -57,7 +57,6 @@ def main(output_path: str = "docs/assets/images/pixel_theme.png") -> None:
             damage_radius=2,
         ),
         health=HealthParams(
-            enabled=True,
             max_hp=100.0,
         ),
         thermotaxis=ThermotaxisParams(

--- a/scripts/run_evolution.py
+++ b/scripts/run_evolution.py
@@ -354,9 +354,17 @@ def run_episode(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     success = True
                     return True
 
-            # Move predators and check for death
+            # Check predator damage before and after movement
             if env.predator.enabled:
+                # Check before predators move (agent may have walked into radius)
+                if env.is_agent_in_damage_radius():
+                    env.apply_predator_damage()
+                    if env.is_health_depleted():
+                        return False  # Died from HP depletion
+
                 env.update_predators()
+
+                # Check after predators move (predator may have stepped onto agent)
                 if env.is_agent_in_damage_radius():
                     env.apply_predator_damage()
                     if env.is_health_depleted():

--- a/scripts/run_evolution.py
+++ b/scripts/run_evolution.py
@@ -298,15 +298,11 @@ def run_episode(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     temperature_gradient_direction = temp_grad[1]
                 cultivation_temperature = env.thermotaxis.cultivation_temperature
 
-            # Get health state if enabled
-            health = None
-            max_health = None
-            if env.health.enabled:
-                health = env.agent_hp
-                max_health = env.health.max_hp
+            # Get health state
+            health = env.agent_hp
+            max_health = env.health.max_hp
 
             # Mechanosensation
-            # (uses damage_radius when health enabled, kill_radius otherwise)
             boundary_contact = env.is_agent_at_boundary()
             predator_contact = env.is_agent_in_predator_contact()
 
@@ -350,9 +346,8 @@ def run_episode(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 satiety = min(satiety + satiety_gain, initial_satiety)
                 env.spawn_food()  # Spawn new food
 
-                # Apply food healing if health system enabled
-                if env.health.enabled:
-                    env.apply_food_healing()
+                # Apply food healing
+                env.apply_food_healing()
 
                 # Check for success (collected target foods)
                 if foods_collected >= env.foraging.target_foods_to_collect:
@@ -362,21 +357,15 @@ def run_episode(  # noqa: C901, PLR0912, PLR0913, PLR0915
             # Move predators and check for death
             if env.predator.enabled:
                 env.update_predators()
-                if env.check_predator_collision():
-                    if env.health.enabled:
-                        # HP-based damage: apply damage and check for death
-                        env.apply_predator_damage()
-                        if env.is_health_depleted():
-                            return False  # Died from HP depletion
-                    else:
-                        # Instant death (original behavior)
-                        return False  # Died to predator
+                if env.is_agent_in_damage_radius():
+                    env.apply_predator_damage()
+                    if env.is_health_depleted():
+                        return False  # Died from HP depletion
 
             # Apply temperature effects (rewards and HP damage) if thermotaxis enabled
             if env.thermotaxis.enabled:
                 _reward_delta, _hp_damage = env.apply_temperature_effects()
-                # Check for death from temperature damage (only if health enabled)
-                if env.health.enabled and env.is_health_depleted():
+                if env.is_health_depleted():
                     return False  # Died from temperature damage
 
             # Decay satiety

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -451,16 +451,13 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         predator_info = (
             f", {predator_config.count} predators "
             f"(detection_radius={predator_config.detection_radius}, "
-            f"kill_radius={predator_config.kill_radius}, "
             f"damage_radius={predator_config.damage_radius})"
         )
-    health_info = ""
-    if health_config.enabled:
-        health_info = (
-            f", health (max_hp={health_config.max_hp}, "
-            f"predator_damage={health_config.predator_damage}, "
-            f"food_healing={health_config.food_healing})"
-        )
+    health_info = (
+        f", health (max_hp={health_config.max_hp}, "
+        f"predator_damage={health_config.predator_damage}, "
+        f"food_healing={health_config.food_healing})"
+    )
     thermotaxis_info = ""
     if thermotaxis_config.enabled:
         thermotaxis_info = (
@@ -617,15 +614,11 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
             satiety_history_this_run = agent._episode_tracker.satiety_history.copy()  # noqa: SLF001
             predator_encounters_this_run = agent._episode_tracker.predator_encounters  # noqa: SLF001
             successful_evasions_this_run = agent._episode_tracker.successful_evasions  # noqa: SLF001
-            died_to_predator_this_run = step_result.termination_reason == TerminationReason.PREDATOR
             died_to_health_depletion_this_run = (
                 step_result.termination_reason == TerminationReason.HEALTH_DEPLETED
             )
-            health_history_this_run = None
+            health_history_this_run = agent._episode_tracker.health_history.copy()  # noqa: SLF001
             temperature_history_this_run = None
-            # Copy health history if health system is enabled
-            if agent.env.health.enabled:
-                health_history_this_run = agent._episode_tracker.health_history.copy()  # noqa: SLF001
             # Copy temperature history if thermotaxis is enabled
             if agent.env.thermotaxis.enabled:
                 temperature_history_this_run = (
@@ -637,7 +630,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
             temperature_comfort_score_this_run = None
 
             # Survival score: final_hp / max_hp
-            if agent.env.health.enabled and health_history_this_run:
+            if health_history_this_run:
                 final_hp = health_history_this_run[-1]
                 max_hp = agent.env.health.max_hp
                 survival_score_this_run = final_hp / max_hp if max_hp > 0 else 0.0
@@ -664,7 +657,6 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
                 temperature_history=temperature_history_this_run,
                 predator_encounters=predator_encounters_this_run,
                 successful_evasions=successful_evasions_this_run,
-                died_to_predator=died_to_predator_this_run,
                 died_to_health_depletion=died_to_health_depletion_this_run,
                 food_history=step_result.food_history,
                 survival_score=survival_score_this_run,
@@ -722,8 +714,6 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
                 outcome_msg += "FAILED: Agent starved"
             elif step_result.termination_reason == TerminationReason.MAX_STEPS:
                 outcome_msg += "FAILED: Max steps reached"
-            elif step_result.termination_reason == TerminationReason.PREDATOR:
-                outcome_msg += "FAILED: Killed by predator"
             elif step_result.termination_reason == TerminationReason.HEALTH_DEPLETED:
                 outcome_msg += "FAILED: Health depleted"
 
@@ -906,7 +896,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         r
         for r in all_results
         if r.predator_encounters is not None
-        and (r.predator_encounters > 0 or r.successful_evasions or r.died_to_predator)
+        and (r.predator_encounters > 0 or r.successful_evasions or r.died_to_health_depletion)
     ]
     if predator_results:
         export_predator_results_to_csv(all_results=all_results, data_dir=data_dir)
@@ -1341,7 +1331,7 @@ def plot_results(  # noqa: C901, PLR0912, PLR0913, PLR0915
         r
         for r in all_results
         if r.predator_encounters is not None
-        and (r.predator_encounters > 0 or r.successful_evasions or r.died_to_predator)
+        and (r.predator_encounters > 0 or r.successful_evasions or r.died_to_health_depletion)
     ]
     if predator_results:
         # Extract predator-specific data for encounters plot
@@ -1389,14 +1379,14 @@ def plot_results(  # noqa: C901, PLR0912, PLR0913, PLR0915
         predator_foraging_results = [
             r
             for r in predator_results
-            if r.foods_collected is not None and r.died_to_predator is not None
+            if r.foods_collected is not None and r.died_to_health_depletion is not None
         ]
         if predator_foraging_results:
             foods_in_predator = []
             deaths_in_predator = []
             for r in predator_foraging_results:
                 foods_in_predator.append(r.foods_collected)
-                deaths_in_predator.append(r.died_to_predator)
+                deaths_in_predator.append(r.died_to_health_depletion)
 
             if foods_in_predator and deaths_in_predator:
                 plot_survival_vs_food_collection(


### PR DESCRIPTION
## Summary

- Make the HP damage/healing system always-on by removing `HealthConfig.enabled` flag and `kill_radius` field
- Remove `TerminationReason.PREDATOR` — all HP-depletion deaths are now `HEALTH_DEPLETED` regardless of damage source (predator, temperature, future oxygen)
- Remove `check_predator_collision()` method; all proximity detection uses `damage_radius` via `is_agent_in_damage_radius()`
- Clean up metrics chain: remove `total_predator_deaths`, `died_to_predator`, `predator_kill_radius` from dtypes, metrics, tracker, metadata, CSV export, summary
- Remove `kill_radius: 0` from 63 YAML configs and `enabled: true` from 69 health sections
- Update OpenSpec specs to reflect new behavior

## Context

Item 2 from `tmp/legacy-deprecation-tracker.md`. The health system has been mature and used by all predator-enabled configs since logbook 005. Every config already had `kill_radius: 0` and `health.enabled: true`, making the instant-death path dead code.

## Test plan

- [x] 1934/1934 non-nightly tests pass (`-m "not nightly"`)
- [x] Ruff: all checks passed
- [x] Pyright: 0 errors on key files
- [x] Grep verification: zero remaining references to `kill_radius`, `check_predator_collision`, `health.enabled`, `TerminationReason.PREDATOR`, `died_to_predator`, `total_predator_deaths`
- [x] All YAML configs parse without errors
- [x] Sanity experiments (4 seeds × 500 episodes each):
  - Foraging: 98.6% success, 99.7% post-convergence (baseline ~98%)
  - Pursuit: 82.4% success, 85.4% post-convergence (baseline ~70-94%)
  - Stationary: 72.6% success, 75.9% post-convergence (baseline ~67-87%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Predator interactions now deal proximity-based damage via a damage radius; episodes end when HP depletes.

* **Bug Fixes**
  * Health is treated consistently (always tracked); predator “instant kill” behavior removed and termination reason unified as health depletion.
  * Metrics, CSV exports, and plots now report health-depletion events instead of predator deaths.

* **Documentation**
  * Specs, examples, and scenario configs updated to use damage-radius and revised movement-pattern defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->