### PR TITLE
fix: Fix nightly test failures from legacy removal changes

### DIFF
--- a/configs/scenarios/thermal_foraging/mlpppo_large_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_large_oracle.yml
@@ -47,6 +47,7 @@ reward:
   penalty_starvation: 10.0
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.3
   reward_health_gain: 0.2
 

--- a/configs/scenarios/thermal_foraging/mlpppo_medium_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_medium_oracle.yml
@@ -56,6 +56,7 @@ reward:
   penalty_starvation: 10.0
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_foraging/mlpppo_small_derivative.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_derivative.yml
@@ -47,6 +47,7 @@ reward:
   penalty_starvation: 10.0
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_foraging/mlpppo_small_isothermal_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_isothermal_oracle.yml
@@ -56,6 +56,7 @@ reward:
   penalty_starvation: 10.0
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.5
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_foraging/mlpppo_small_oracle.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_oracle.yml
@@ -51,6 +51,7 @@ reward:
   penalty_starvation: 10.0
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_foraging/mlpppo_small_temporal.yml
+++ b/configs/scenarios/thermal_foraging/mlpppo_small_temporal.yml
@@ -47,6 +47,7 @@ reward:
   penalty_starvation: 10.0
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_pursuit/mlpppo_medium_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_medium_oracle.yml
@@ -68,6 +68,7 @@ reward:
   penalty_predator_proximity: 0.15
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_pursuit/mlpppo_small_derivative.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_small_derivative.yml
@@ -52,6 +52,7 @@ reward:
   penalty_predator_proximity: 0.15
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_pursuit/mlpppo_small_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_small_oracle.yml
@@ -63,6 +63,7 @@ reward:
   penalty_predator_proximity: 0.15
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_pursuit/mlpppo_small_temporal.yml
+++ b/configs/scenarios/thermal_pursuit/mlpppo_small_temporal.yml
@@ -54,6 +54,7 @@ reward:
   penalty_predator_proximity: 0.15
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_pursuit/qrh_small_oracle.yml
+++ b/configs/scenarios/thermal_pursuit/qrh_small_oracle.yml
@@ -74,6 +74,7 @@ reward:
   penalty_predator_proximity: 0.15
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_stationary/mlpppo_large_oracle.yml
+++ b/configs/scenarios/thermal_stationary/mlpppo_large_oracle.yml
@@ -69,6 +69,7 @@ reward:
   penalty_predator_proximity: 0.3
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.3
   reward_health_gain: 0.2
 

--- a/configs/scenarios/thermal_stationary/mlpppo_medium_oracle.yml
+++ b/configs/scenarios/thermal_stationary/mlpppo_medium_oracle.yml
@@ -66,6 +66,7 @@ reward:
   penalty_predator_proximity: 0.3
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/configs/scenarios/thermal_stationary/mlpppo_small_oracle.yml
+++ b/configs/scenarios/thermal_stationary/mlpppo_small_oracle.yml
@@ -60,6 +60,7 @@ reward:
   penalty_predator_proximity: 0.3
   stuck_position_threshold: 0
   penalty_boundary_collision: 0.02
+  penalty_temperature_proximity: 0.0
   penalty_health_damage: 0.0
   reward_health_gain: 0.1
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/e2e_benchmarks.json
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/e2e_benchmarks.json
@@ -79,14 +79,6 @@
       "success_rate_min": 0.89,
       "success_rate_max": 1.0,
       "source": "benchmarks/foraging_small/classical: sessions 94.0%-98.5% with 5% buffer"
-    },
-    {
-      "name": "mlpppo_predators_small",
-      "config": "configs/scenarios/predators/mlpppo_small_oracle.yml",
-      "runs": 200,
-      "success_rate_min": 0.72,
-      "success_rate_max": 0.92,
-      "source": "benchmarks/predator_small/classical: sessions 77.0%-87.0% with 5% buffer"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes two nightly test failures caused by recent legacy removal PRs:

1. **`mlpppo_predators_small`** — Config `configs/scenarios/predators/mlpppo_small_oracle.yml` was deleted in PR #100 but the e2e benchmark entry still referenced it. Removed the benchmark entry.

2. **`mlpppo_thermotaxis_stationary_medium`** (52.8% < 58.0% floor) — PR #101 changed `penalty_temperature_proximity` default from `0.0` to `0.3`. 14 thermal configs lacked an explicit value, so the new default changed their reward signal. These configs were tuned in logbook-007 with the penalty at `0.0`. Added explicit `penalty_temperature_proximity: 0.0` to all 14 affected thermal configs to preserve their original tuned behavior.

## Test plan

- [x] Pre-commit checks pass
- [x] `mlpppo_thermotaxis_stationary_medium` nightly test passes (121s)
- [x] `mlpppo_predators_small` benchmark entry removed (no longer collected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated thermal scenario configurations to include a new temperature proximity penalty parameter across multiple simulation models and environments.
  * Removed deprecated predators benchmark configuration entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->