### PR TITLE
feat!: Remove legacy 2-feature preprocessing mode

### DIFF
--- a/configs/scenarios/foraging/hybridclassical_small_oracle.yml
+++ b/configs/scenarios/foraging/hybridclassical_small_oracle.yml
@@ -1,7 +1,6 @@
 # Hybrid Classical Brain - Stage 1: Reflex MLP Training
 # Classical ablation of HybridQuantum: replaces QSNN with a small MLP reflex.
 # Trains the classical reflex MLP on foraging using REINFORCE.
-# Uses legacy 2-feature mode (gradient_strength, relative_angle).
 # After training, reflex weights are saved to exports/<session>/reflex_weights.pt
 # for use in stage 2 (cortex PPO training).
 #
@@ -31,6 +30,9 @@ brain:
     lr_min_factor: 0.1
     entropy_coeff: 0.02
     use_reward_normalization: true
+
+    sensory_modules:
+      - food_chemotaxis
 
     # Cortex params (unused in stage 1, but required for init)
     cortex_hidden_dim: 64

--- a/configs/scenarios/foraging/hybridquantum_small_oracle.yml
+++ b/configs/scenarios/foraging/hybridquantum_small_oracle.yml
@@ -1,6 +1,5 @@
 # Hybrid Quantum Brain - Stage 1: QSNN Reflex Training
 # Trains the QSNN reflex layer on foraging using REINFORCE.
-# Uses legacy 2-feature mode (gradient_strength, relative_angle).
 # After training, QSNN weights are saved to exports/<session>/qsnn_weights.pt
 # for use in stage 2 (cortex PPO training).
 
@@ -37,6 +36,9 @@ brain:
     lr_min_factor: 0.1
     entropy_coeff: 0.02
     use_reward_normalization: true
+
+    sensory_modules:
+      - food_chemotaxis
 
     # Cortex params (unused in stage 1, but required for init)
     cortex_hidden_dim: 64

--- a/configs/scenarios/foraging/mlpppo_large_oracle.yml
+++ b/configs/scenarios/foraging/mlpppo_large_oracle.yml
@@ -22,6 +22,8 @@ brain:
     num_minibatches: 4
     max_grad_norm: 0.5
     normalize_advantages: true
+    sensory_modules:
+      - food_chemotaxis
 
 body_length: 2
 

--- a/configs/scenarios/foraging/mlpppo_medium_oracle.yml
+++ b/configs/scenarios/foraging/mlpppo_medium_oracle.yml
@@ -22,6 +22,8 @@ brain:
     num_minibatches: 2
     max_grad_norm: 0.5
     normalize_advantages: true
+    sensory_modules:
+      - food_chemotaxis
 
 body_length: 2
 

--- a/configs/scenarios/foraging/mlpppo_small_oracle.yml
+++ b/configs/scenarios/foraging/mlpppo_small_oracle.yml
@@ -22,6 +22,8 @@ brain:
     num_minibatches: 2
     max_grad_norm: 0.5
     normalize_advantages: true
+    sensory_modules:
+      - food_chemotaxis
 
 body_length: 2
 

--- a/configs/scenarios/foraging/qliflstm_small_classical_oracle.yml
+++ b/configs/scenarios/foraging/qliflstm_small_classical_oracle.yml
@@ -36,6 +36,8 @@ brain:
     # Critic
     critic_hidden_dim: 64
     critic_num_layers: 2
+    sensory_modules:
+      - food_chemotaxis
 
 body_length: 2
 

--- a/configs/scenarios/foraging/qliflstm_small_oracle.yml
+++ b/configs/scenarios/foraging/qliflstm_small_oracle.yml
@@ -36,6 +36,8 @@ brain:
     # Critic
     critic_hidden_dim: 64
     critic_num_layers: 2
+    sensory_modules:
+      - food_chemotaxis
 
 body_length: 2
 

--- a/configs/scenarios/foraging/qliflstm_small_oracle.yml
+++ b/configs/scenarios/foraging/qliflstm_small_oracle.yml
@@ -36,6 +36,8 @@ brain:
     # Critic
     critic_hidden_dim: 64
     critic_num_layers: 2
+
+    # Unified sensory modules for single-objective task
     sensory_modules:
       - food_chemotaxis
 

--- a/configs/scenarios/pursuit/mlpppo_small_oracle.yml
+++ b/configs/scenarios/pursuit/mlpppo_small_oracle.yml
@@ -24,6 +24,9 @@ brain:
     num_minibatches: 2
     max_grad_norm: 0.5
     normalize_advantages: true
+    sensory_modules:
+      - food_chemotaxis
+      - nociception
 
 body_length: 2
 

--- a/configs/scenarios/stationary/mlpppo_small_oracle.yml
+++ b/configs/scenarios/stationary/mlpppo_small_oracle.yml
@@ -25,6 +25,9 @@ brain:
     num_minibatches: 2
     max_grad_norm: 0.5
     normalize_advantages: true
+    sensory_modules:
+      - food_chemotaxis
+      - nociception
 
 body_length: 2
 

--- a/configs/special/hybridquantumcortex_foraging_small_1_oracle.yml
+++ b/configs/special/hybridquantumcortex_foraging_small_1_oracle.yml
@@ -1,6 +1,5 @@
 # Hybrid Quantum Cortex Brain - Stage 1: QSNN Reflex Training
 # Trains the QSNN reflex layer on foraging using REINFORCE.
-# Uses legacy 2-feature mode (gradient_strength, relative_angle).
 # After training, reflex weights are saved to exports/<session>/reflex_weights.pt
 # for use in stage 2 (cortex REINFORCE+GAE training).
 #
@@ -40,6 +39,11 @@ brain:
     lr_min_factor: 0.1
     entropy_coeff: 0.02
     use_reward_normalization: true
+
+    sensory_modules:
+      - food_chemotaxis
+    cortex_sensory_modules:
+      - food_chemotaxis
 
     # Cortex QSNN params (unused in stage 1 but needed for init)
     cortex_neurons_per_group: 4

--- a/packages/quantum-nematode/quantumnematode/brain/arch/_hybrid_common.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/_hybrid_common.py
@@ -572,28 +572,3 @@ def exploration_schedule(
     current_epsilon = exploration_epsilon * (1.0 - progress * 0.7)
     current_temperature = 1.5 - 0.5 * progress
     return current_epsilon, current_temperature
-
-
-def preprocess_legacy(
-    params: object,
-) -> np.ndarray:
-    """Extract legacy 2-feature input (gradient_strength, relative_angle).
-
-    Accepts any object with gradient_strength, gradient_direction, and
-    agent_direction attributes (BrainParams protocol).
-    """
-    from quantumnematode.env import Direction
-
-    grad_strength = float(getattr(params, "gradient_strength", None) or 0.0)
-    grad_direction = float(getattr(params, "gradient_direction", None) or 0.0)
-    direction_map = {
-        Direction.UP: np.pi / 2,
-        Direction.DOWN: -np.pi / 2,
-        Direction.LEFT: np.pi,
-        Direction.RIGHT: 0.0,
-    }
-    agent_dir = getattr(params, "agent_direction", None) or Direction.UP
-    agent_facing_angle = direction_map.get(agent_dir, np.pi / 2)
-    relative_angle = (grad_direction - agent_facing_angle + np.pi) % (2 * np.pi) - np.pi
-    rel_angle_norm = relative_angle / np.pi
-    return np.array([grad_strength, rel_angle_norm], dtype=np.float32)

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
@@ -67,7 +67,6 @@ from quantumnematode.brain.arch._hybrid_common import (
     load_cortex_weights,
     normalize_reward,
     perform_ppo_update,
-    preprocess_legacy,
     save_cortex_weights,
     update_cortex_learning_rates,
 )
@@ -327,10 +326,9 @@ class HybridClassicalBrainConfig(BrainConfig):
         description="Path to pre-trained cortex weights (.pt file) for stage 3.",
     )
 
-    # Sensory modules
-    sensory_modules: list[ModuleName] | None = Field(
-        default=None,
-        description="List of sensory modules for feature extraction (None = legacy mode).",
+    # Sensory modules (required)
+    sensory_modules: list[ModuleName] = Field(
+        description="List of sensory modules for feature extraction.",
     )
 
     @field_validator("training_stage")
@@ -378,7 +376,7 @@ class HybridClassicalBrain(ClassicalBrain):
     architecture/curriculum is responsible for the observed performance gains.
     """
 
-    def __init__(  # noqa: PLR0915
+    def __init__(
         self,
         config: HybridClassicalBrainConfig,
         num_actions: int = 4,
@@ -409,16 +407,12 @@ class HybridClassicalBrain(ClassicalBrain):
 
         # Sensory modules
         self.sensory_modules = config.sensory_modules
-        if config.sensory_modules is not None:
-            self.input_dim = get_classical_feature_dimension(config.sensory_modules)
-            logger.info(
-                f"Using unified sensory modules: "
-                f"{[m.value for m in config.sensory_modules]} "
-                f"(input_dim={self.input_dim})",
-            )
-        else:
-            self.input_dim = 2
-            logger.info("Using legacy 2-feature preprocessing (gradient_strength, rel_angle)")
+        self.input_dim = get_classical_feature_dimension(config.sensory_modules)
+        logger.info(
+            f"Using sensory modules: "
+            f"{[m.value for m in config.sensory_modules]} "
+            f"(input_dim={self.input_dim})",
+        )
 
         # Data tracking
         self.history_data = BrainHistoryData()
@@ -697,23 +691,13 @@ class HybridClassicalBrain(ClassicalBrain):
     # Preprocessing
     # ──────────────────────────────────────────────────────────────────
 
-    def _preprocess_legacy(self, params: BrainParams) -> np.ndarray:
-        """Extract legacy 2-feature input (gradient_strength, relative_angle)."""
-        return preprocess_legacy(params)
-
     def preprocess(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams to extract reflex features (always legacy 2-feature)."""
-        return self._preprocess_legacy(params)
+        """Preprocess BrainParams to extract reflex features."""
+        return extract_classical_features(params, self.sensory_modules)
 
     def _preprocess_cortex(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams for cortex input.
-
-        Uses unified sensory modules when configured (multi-objective),
-        otherwise falls back to the same legacy 2-feature input as the reflex.
-        """
-        if self.sensory_modules is not None:
-            return extract_classical_features(params, self.sensory_modules)
-        return self._preprocess_legacy(params)
+        """Preprocess BrainParams for cortex input via sensory modules."""
+        return extract_classical_features(params, self.sensory_modules)
 
     # ──────────────────────────────────────────────────────────────────
     # Exploration schedule

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
@@ -86,7 +86,6 @@ from quantumnematode.utils.session import generate_session_id
 
 # Reflex MLP defaults
 DEFAULT_REFLEX_HIDDEN_DIM = 16
-DEFAULT_REFLEX_INPUT_DIM = 2  # only used as fallback if input_dim not set
 DEFAULT_NUM_MOTOR = 4
 DEFAULT_LOGIT_SCALE = 5.0
 

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
@@ -8,11 +8,11 @@ same mode-gated fusion, same 3-stage curriculum, same REINFORCE + PPO training.
 
 Architecture::
 
-    Sensory Input (2-dim legacy)
+    Sensory Input (from sensory_modules)
            |
            v
     Classical Reflex MLP (nn.Sequential)
-      2 -> 16 -> 4 (ReLU hidden)
+      input_dim -> 16 -> 4 (ReLU hidden)
       ~116 classical params, REINFORCE training
       Output: 4-dim reflex logits
            |
@@ -86,7 +86,7 @@ from quantumnematode.utils.session import generate_session_id
 
 # Reflex MLP defaults
 DEFAULT_REFLEX_HIDDEN_DIM = 16
-DEFAULT_REFLEX_INPUT_DIM = 2  # legacy 2-feature mode
+DEFAULT_REFLEX_INPUT_DIM = 2  # only used as fallback if input_dim not set
 DEFAULT_NUM_MOTOR = 4
 DEFAULT_LOGIT_SCALE = 5.0
 
@@ -492,11 +492,10 @@ class HybridClassicalBrain(ClassicalBrain):
     def _init_reflex(self) -> None:
         """Initialize the classical reflex MLP.
 
-        Architecture: Linear(2 -> hidden) -> ReLU -> Linear(hidden -> 4)
-        Matches QSNN's legacy 2-feature input and 4 motor outputs.
+        Architecture: Linear(input_dim -> hidden) -> ReLU -> Linear(hidden -> num_motor)
         """
         self.reflex_mlp = nn.Sequential(
-            nn.Linear(DEFAULT_REFLEX_INPUT_DIM, self.config.reflex_hidden_dim),
+            nn.Linear(self.input_dim, self.config.reflex_hidden_dim),
             nn.ReLU(),
             nn.Linear(self.config.reflex_hidden_dim, self.num_motor),
         ).to(self.device)

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
@@ -151,14 +151,8 @@ class HybridClassicalBrainConfig(BrainConfig):
     classical MLP reflex. Supports the same 3-stage curriculum and
     mode-gated fusion.
 
-    Supports two modes for cortex input feature extraction:
-
-    1. **Legacy mode** (default): Uses 2 features (gradient_strength, relative_angle)
-       - Set ``sensory_modules=None`` (default)
-
-    2. **Unified sensory mode**: Uses modular feature extraction from brain/modules.py
-       - Set ``sensory_modules`` to a list of ModuleName values
-       - Each module contributes 2 features [strength, angle]
+    Uses modular feature extraction via sensory_modules (required).
+    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
     """
 
     # Reflex MLP params

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridclassical.py
@@ -151,7 +151,7 @@ class HybridClassicalBrainConfig(BrainConfig):
     mode-gated fusion.
 
     Uses modular feature extraction via sensory_modules (required).
-    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
+    Each module contributes a variable number of features (typically 2).
     """
 
     # Reflex MLP params
@@ -323,6 +323,15 @@ class HybridClassicalBrainConfig(BrainConfig):
     sensory_modules: list[ModuleName] = Field(
         description="List of sensory modules for feature extraction.",
     )
+
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
 
     @field_validator("training_stage")
     @classmethod

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantum.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantum.py
@@ -170,7 +170,7 @@ class HybridQuantumBrainConfig(BrainConfig):
     """Configuration for the HybridQuantumBrain architecture.
 
     Uses modular feature extraction via sensory_modules (required).
-    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
+    Each module contributes a variable number of features (typically 2).
     """
 
     # QSNN reflex params
@@ -382,6 +382,15 @@ class HybridQuantumBrainConfig(BrainConfig):
     sensory_modules: list[ModuleName] = Field(
         description="List of sensory modules for feature extraction.",
     )
+
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
 
     @field_validator("num_sensory_neurons")
     @classmethod

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantum.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantum.py
@@ -169,14 +169,8 @@ STAGE_JOINT = 3
 class HybridQuantumBrainConfig(BrainConfig):
     """Configuration for the HybridQuantumBrain architecture.
 
-    Supports two modes for input feature extraction:
-
-    1. **Legacy mode** (default): Uses 2 features (gradient_strength, relative_angle)
-       - Set `sensory_modules=None` (default)
-
-    2. **Unified sensory mode**: Uses modular feature extraction from brain/modules.py
-       - Set `sensory_modules` to a list of ModuleName values
-       - Each module contributes 2 features [strength, angle]
+    Uses modular feature extraction via sensory_modules (required).
+    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
     """
 
     # QSNN reflex params

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantum.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantum.py
@@ -69,7 +69,6 @@ from quantumnematode.brain.arch._hybrid_common import (
     load_cortex_weights,
     normalize_reward,
     perform_ppo_update,
-    preprocess_legacy,
     save_cortex_weights,
     update_cortex_learning_rates,
 )
@@ -385,10 +384,9 @@ class HybridQuantumBrainConfig(BrainConfig):
         description="Path to pre-trained cortex weights (.pt file) for stage 3.",
     )
 
-    # Sensory modules
-    sensory_modules: list[ModuleName] | None = Field(
-        default=None,
-        description="List of sensory modules for feature extraction (None = legacy mode).",
+    # Sensory modules (required)
+    sensory_modules: list[ModuleName] = Field(
+        description="List of sensory modules for feature extraction.",
     )
 
     @field_validator("num_sensory_neurons")
@@ -508,16 +506,12 @@ class HybridQuantumBrain(ClassicalBrain):
 
         # Sensory modules
         self.sensory_modules = config.sensory_modules
-        if config.sensory_modules is not None:
-            self.input_dim = get_classical_feature_dimension(config.sensory_modules)
-            logger.info(
-                f"Using unified sensory modules: "
-                f"{[m.value for m in config.sensory_modules]} "
-                f"(input_dim={self.input_dim})",
-            )
-        else:
-            self.input_dim = 2
-            logger.info("Using legacy 2-feature preprocessing (gradient_strength, rel_angle)")
+        self.input_dim = get_classical_feature_dimension(config.sensory_modules)
+        logger.info(
+            f"Using sensory modules: "
+            f"{[m.value for m in config.sensory_modules]} "
+            f"(input_dim={self.input_dim})",
+        )
 
         # Data tracking
         self.history_data = BrainHistoryData()
@@ -987,23 +981,13 @@ class HybridQuantumBrain(ClassicalBrain):
     # Preprocessing
     # ──────────────────────────────────────────────────────────────────
 
-    def _preprocess_legacy(self, params: BrainParams) -> np.ndarray:
-        """Extract legacy 2-feature input (gradient_strength, relative_angle)."""
-        return preprocess_legacy(params)
-
     def preprocess(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams to extract QSNN features (always legacy 2-feature)."""
-        return self._preprocess_legacy(params)
+        """Preprocess BrainParams to extract QSNN reflex features."""
+        return extract_classical_features(params, self.sensory_modules)
 
     def _preprocess_cortex(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams for cortex input.
-
-        Uses unified sensory modules when configured (multi-objective),
-        otherwise falls back to the same legacy 2-feature input as the QSNN.
-        """
-        if self.sensory_modules is not None:
-            return extract_classical_features(params, self.sensory_modules)
-        return self._preprocess_legacy(params)
+        """Preprocess BrainParams for cortex input via sensory modules."""
+        return extract_classical_features(params, self.sensory_modules)
 
     # ──────────────────────────────────────────────────────────────────
     # Exploration schedule

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
@@ -13,7 +13,7 @@ pursuit. See logbook 008 for full evaluation.
 
 Architecture::
 
-    Sensory Input (2-dim legacy)         Multi-sensory Input (8+ dim)
+    Sensory Input (from sensory_modules)  Multi-sensory Input (cortex_sensory_modules)
            |                                       |
            v                                       v
     QSNN Reflex                          QSNN Cortex
@@ -188,8 +188,8 @@ MODE_LOGIT_SCALE = 2.0
 class HybridQuantumCortexBrainConfig(BrainConfig):
     """Configuration for the HybridQuantumCortexBrain architecture.
 
-    Supports a QSNN reflex layer (legacy 2-feature) combined with a QSNN cortex
-    layer (grouped sensory QLIF neurons) and a classical critic.
+    Supports a QSNN reflex layer combined with a QSNN cortex layer
+    (grouped sensory QLIF neurons) and a classical critic.
     """
 
     # QSNN reflex params

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
@@ -463,6 +463,24 @@ class HybridQuantumCortexBrainConfig(BrainConfig):
 
     # ── Validators ──
 
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("cortex_sensory_modules")
+    @classmethod
+    def validate_cortex_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate cortex_sensory_modules is non-empty."""
+        if not v:
+            msg = "cortex_sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
+
     @field_validator("num_sensory_neurons")
     @classmethod
     def validate_num_sensory_neurons(cls, v: int) -> int:
@@ -563,17 +581,6 @@ class HybridQuantumCortexBrainConfig(BrainConfig):
         return v
 
     @model_validator(mode="after")
-    def validate_cortex_modules_for_stage(self) -> HybridQuantumCortexBrainConfig:
-        """Validate cortex_sensory_modules non-empty when training_stage >= 2."""
-        if self.training_stage >= STAGE_CORTEX_ONLY and not self.cortex_sensory_modules:
-            msg = (
-                "cortex_sensory_modules must be non-empty when training_stage >= 2, "
-                f"got {self.cortex_sensory_modules}"
-            )
-            raise ValueError(msg)
-        return self
-
-    @model_validator(mode="after")
     def validate_cortex_output_neurons(self) -> HybridQuantumCortexBrainConfig:
         """Validate cortex_output_neurons >= num_motor_neurons + num_modes + 1."""
         required = self.num_motor_neurons + self.num_modes + 1
@@ -637,8 +644,10 @@ class HybridQuantumCortexBrain(ClassicalBrain):
         self.cortex_input_dim = get_classical_feature_dimension(self.cortex_sensory_modules)
         self.num_cortex_groups = len(self.cortex_sensory_modules)
         # TODO(stage4): Replace with per-module classical_dim lookup when adding
-        # thermotaxis (classical_dim=3). Currently all stage 1-3 modules have
-        # classical_dim=2, so this is safe until multi-sensory scaling.
+        # modules with classical_dim != 2 (e.g. thermotaxis=3, STAM=9).
+        # Currently all modules used with the cortex QSNN have classical_dim=2.
+        # The grouped QLIF slicing in _cortex_sensory_forward* assumes uniform
+        # width — variable widths would require per-module offset computation.
         self.features_per_module = 2
 
         # Data tracking

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
@@ -73,7 +73,6 @@ from quantumnematode.brain.arch._hybrid_common import (
     fuse,
     init_critic_mlp,
     normalize_reward,
-    preprocess_legacy,
     update_cortex_learning_rates,
 )
 from quantumnematode.brain.arch._qlif_layers import (
@@ -244,8 +243,7 @@ class HybridQuantumCortexBrainConfig(BrainConfig):
     )
 
     # Cortex QSNN params
-    cortex_sensory_modules: list[ModuleName] | None = Field(
-        default=None,
+    cortex_sensory_modules: list[ModuleName] = Field(
         description="List of sensory modules for cortex grouped QLIF processing.",
     )
     cortex_neurons_per_group: int = Field(
@@ -458,10 +456,9 @@ class HybridQuantumCortexBrainConfig(BrainConfig):
         description="Path to pre-trained critic weights (.pt file) for stage 3/4.",
     )
 
-    # Sensory modules for reflex (legacy mode uses None)
-    sensory_modules: list[ModuleName] | None = Field(
-        default=None,
-        description="List of sensory modules for reflex feature extraction (None = legacy mode).",
+    # Sensory modules for reflex (required)
+    sensory_modules: list[ModuleName] = Field(
+        description="List of sensory modules for reflex feature extraction.",
     )
 
     # ── Validators ──
@@ -631,26 +628,18 @@ class HybridQuantumCortexBrain(ClassicalBrain):
         set_global_seed(self.seed)
         logger.info(f"HybridQuantumCortexBrain using seed: {self.seed}")
 
-        # Reflex sensory modules (always legacy 2-feature for reflex)
+        # Reflex sensory modules
         self.sensory_modules = config.sensory_modules
-        if config.sensory_modules is not None:
-            self.reflex_input_dim = get_classical_feature_dimension(config.sensory_modules)
-        else:
-            self.reflex_input_dim = 2
+        self.reflex_input_dim = get_classical_feature_dimension(config.sensory_modules)
 
         # Cortex sensory modules
         self.cortex_sensory_modules = config.cortex_sensory_modules
-        if self.cortex_sensory_modules is not None:
-            self.cortex_input_dim = get_classical_feature_dimension(self.cortex_sensory_modules)
-            self.num_cortex_groups = len(self.cortex_sensory_modules)
-            # TODO(stage4): Replace with per-module classical_dim lookup when adding
-            # thermotaxis (classical_dim=3). Currently all stage 1-3 modules have
-            # classical_dim=2, so this is safe until multi-sensory scaling.
-            self.features_per_module = 2
-        else:
-            self.cortex_input_dim = 2
-            self.num_cortex_groups = 1
-            self.features_per_module = self.cortex_input_dim
+        self.cortex_input_dim = get_classical_feature_dimension(self.cortex_sensory_modules)
+        self.num_cortex_groups = len(self.cortex_sensory_modules)
+        # TODO(stage4): Replace with per-module classical_dim lookup when adding
+        # thermotaxis (classical_dim=3). Currently all stage 1-3 modules have
+        # classical_dim=2, so this is safe until multi-sensory scaling.
+        self.features_per_module = 2
 
         # Data tracking
         self.history_data = BrainHistoryData()
@@ -1810,19 +1799,13 @@ class HybridQuantumCortexBrain(ClassicalBrain):
     # Preprocessing
     # ──────────────────────────────────────────────────────────────────
 
-    def _preprocess_legacy(self, params: BrainParams) -> np.ndarray:
-        """Extract legacy 2-feature input (gradient_strength, relative_angle)."""
-        return preprocess_legacy(params)
-
     def preprocess(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams to extract reflex features (always legacy 2-feature)."""
-        return self._preprocess_legacy(params)
+        """Preprocess BrainParams to extract reflex features."""
+        return extract_classical_features(params, self.sensory_modules)
 
     def _preprocess_cortex(self, params: BrainParams) -> np.ndarray:
         """Preprocess BrainParams for cortex input via sensory modules."""
-        if self.cortex_sensory_modules is not None:
-            return extract_classical_features(params, self.cortex_sensory_modules)
-        return self._preprocess_legacy(params)
+        return extract_classical_features(params, self.cortex_sensory_modules)
 
     # ──────────────────────────────────────────────────────────────────
     # Exploration schedule

--- a/packages/quantum-nematode/quantumnematode/brain/arch/mlpppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/mlpppo.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
     from quantumnematode.brain.weights import WeightComponent
     from quantumnematode.initializers._initializer import ParameterInitializer
 
+from pydantic import field_validator
+
 from quantumnematode.brain.actions import DEFAULT_ACTIONS, Action, ActionData
 from quantumnematode.brain.arch import BrainData, BrainParams, ClassicalBrain
 from quantumnematode.brain.arch._brain import BrainHistoryData
@@ -77,14 +79,15 @@ class MLPPPOBrainConfig(BrainConfig):
 
     Uses modular feature extraction via sensory_modules (required).
 
-    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
-    ``input_dim`` is auto-computed as ``len(sensory_modules) * 2``.
+    Each module contributes a variable number of features (typically 2:
+    [strength, angle], but some modules like thermotaxis contribute 3).
+    ``input_dim`` is auto-computed as ``sum(classical_dim per module)``.
 
     Example config:
         >>> config = MLPPPOBrainConfig(
         ...     sensory_modules=[ModuleName.FOOD_CHEMOTAXIS, ModuleName.NOCICEPTION],
         ... )
-        >>> # input_dim will be 4 (2 modules * 2 features each)
+        >>> # input_dim will be 4 (2 modules with classical_dim=2 each)
     """
 
     # Network architecture
@@ -110,6 +113,15 @@ class MLPPPOBrainConfig(BrainConfig):
 
     # Sensory feature extraction (required)
     sensory_modules: list[ModuleName]
+
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
 
     # Learning rate scheduling (optional)
     # Supports warmup followed by optional decay for more stable early learning.
@@ -172,7 +184,7 @@ class MLPPPOBrain(ClassicalBrain):
         logger.info(
             f"Using classical feature extraction with modules: "
             f"{[m.value for m in config.sensory_modules]} "
-            f"(input_dim={self.input_dim}, features=[strength, angle] per module)",
+            f"(input_dim={self.input_dim})",
         )
 
         # Feature expansion for ablation experiments

--- a/packages/quantum-nematode/quantumnematode/brain/arch/mlpppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/mlpppo.py
@@ -12,7 +12,7 @@ Key Features:
 - **Multiple Epochs**: Performs multiple gradient steps per rollout for sample efficiency
 
 Architecture:
-- Input: 2D state features (gradient strength, relative direction to goal)
+- Input: State features from configurable sensory modules
 - Actor: MLP producing action probabilities via softmax
 - Critic: MLP producing value estimate (single scalar)
 - Output: Action selection from categorical distribution
@@ -51,7 +51,6 @@ from quantumnematode.brain.modules import (
     extract_classical_features,
     get_classical_feature_dimension,
 )
-from quantumnematode.env import Direction
 from quantumnematode.logging_config import logger
 from quantumnematode.utils.seeding import ensure_seed, get_rng, set_global_seed
 
@@ -76,19 +75,12 @@ EPISODE_LOG_INTERVAL = 25
 class MLPPPOBrainConfig(BrainConfig):
     """Configuration for the MLPPPOBrain architecture.
 
-    Supports two modes for input feature extraction:
+    Uses modular feature extraction via sensory_modules (required).
 
-    1. **Legacy mode** (default): Uses 2 features (gradient_strength, relative_angle)
-       - Set `sensory_modules=None` (default)
-       - If `input_dim` is omitted, MLPPPOBrain defaults to 2 in legacy mode
+    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
+    ``input_dim`` is auto-computed as ``len(sensory_modules) * 2``.
 
-    2. **Unified sensory mode**: Uses modular feature extraction from brain/modules.py
-       - Set `sensory_modules` to a list of ModuleName values
-       - Uses extract_classical_features() which outputs semantic-preserving ranges
-       - Each module contributes 2 features [strength, angle] in [0,1] and [-1,1]
-       - `input_dim` is auto-computed as `len(sensory_modules) * 2`
-
-    Example unified mode config:
+    Example config:
         >>> config = MLPPPOBrainConfig(
         ...     sensory_modules=[ModuleName.FOOD_CHEMOTAXIS, ModuleName.NOCICEPTION],
         ... )
@@ -116,11 +108,8 @@ class MLPPPOBrainConfig(BrainConfig):
     # Rollout buffer
     rollout_buffer_size: int = DEFAULT_ROLLOUT_BUFFER_SIZE
 
-    # Unified sensory feature extraction (optional)
-    # When set, uses extract_classical_features() which outputs:
-    # - strength: [0, 1] where 0 = no signal (matches legacy semantics)
-    # - angle: [-1, 1] where 0 = aligned with agent heading
-    sensory_modules: list[ModuleName] | None = None
+    # Sensory feature extraction (required)
+    sensory_modules: list[ModuleName]
 
     # Learning rate scheduling (optional)
     # Supports warmup followed by optional decay for more stable early learning.
@@ -173,29 +162,18 @@ class MLPPPOBrain(ClassicalBrain):
         # Store sensory modules for feature extraction
         self.sensory_modules = config.sensory_modules
 
-        # Determine input dimension
-        if config.sensory_modules is not None:
-            # Unified sensory mode: use classical feature extraction
-            # Each module contributes 2 features [strength, angle]
-            computed_dim = get_classical_feature_dimension(config.sensory_modules)
-            if input_dim is not None and input_dim != computed_dim:
-                logger.warning(
-                    f"input_dim={input_dim} overridden by sensory_modules "
-                    f"(computed: {computed_dim})",
-                )
-            self.input_dim = computed_dim
-            logger.info(
-                f"Using classical feature extraction with modules: "
-                f"{[m.value for m in config.sensory_modules]} "
-                f"(input_dim={self.input_dim}, features=[strength, angle] per module)",
+        # Determine input dimension from sensory modules
+        computed_dim = get_classical_feature_dimension(config.sensory_modules)
+        if input_dim is not None and input_dim != computed_dim:
+            logger.warning(
+                f"input_dim={input_dim} overridden by sensory_modules (computed: {computed_dim})",
             )
-        elif input_dim is not None:
-            # Legacy mode: explicit input_dim
-            self.input_dim = input_dim
-        else:
-            # Default legacy mode: 2 features
-            self.input_dim = 2
-            logger.info("Using legacy 2-feature preprocessing (gradient_strength, rel_angle)")
+        self.input_dim = computed_dim
+        logger.info(
+            f"Using classical feature extraction with modules: "
+            f"{[m.value for m in config.sensory_modules]} "
+            f"(input_dim={self.input_dim}, features=[strength, angle] per module)",
+        )
 
         # Feature expansion for ablation experiments
         self._raw_input_dim = self.input_dim
@@ -365,41 +343,13 @@ class MLPPPOBrain(ClassicalBrain):
             logger.info("Custom parameter initializer provided but using orthogonal init")
 
     def preprocess(self, params: BrainParams) -> np.ndarray:
+        """Preprocess BrainParams to extract features for the neural network.
+
+        Uses extract_classical_features() which outputs semantic-preserving ranges:
+        - strength: [0, 1] where 0 = no signal
+        - angle: [-1, 1] where 0 = aligned with agent heading
         """
-        Preprocess BrainParams to extract features for the neural network.
-
-        Two modes:
-        1. **Unified sensory mode** (when sensory_modules is set):
-           Uses extract_classical_features() which outputs semantic-preserving ranges:
-           - strength: [0, 1] where 0 = no signal (matches legacy)
-           - angle: [-1, 1] where 0 = aligned with agent heading
-
-        2. **Legacy mode** (default):
-           Matches original MLPReinforceBrain preprocessing:
-           - Gradient strength (float, [0, 1])
-           - Normalized relative angle to goal ([-1, 1])
-        """
-        # Unified sensory mode: use classical feature extraction
-        if self.sensory_modules is not None:
-            raw_features = extract_classical_features(params, self.sensory_modules)
-        else:
-            # Legacy mode: 2-feature preprocessing
-            grad_strength = float(params.gradient_strength or 0.0)
-            grad_direction = float(params.gradient_direction or 0.0)
-            direction_map = {
-                Direction.UP: np.pi / 2,
-                Direction.DOWN: -np.pi / 2,
-                Direction.LEFT: np.pi,
-                Direction.RIGHT: 0.0,
-            }
-            agent_facing_angle = direction_map.get(
-                params.agent_direction or Direction.UP,
-                np.pi / 2,
-            )
-            relative_angle = (grad_direction - agent_facing_angle + np.pi) % (2 * np.pi) - np.pi
-            rel_angle_norm = relative_angle / np.pi
-            raw_features = np.array([grad_strength, rel_angle_norm], dtype=np.float32)
-
+        raw_features = extract_classical_features(params, self.sensory_modules)
         return self._apply_feature_expansion(raw_features)
 
     def _apply_feature_expansion(self, raw_features: np.ndarray) -> np.ndarray:

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qliflstm.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qliflstm.py
@@ -613,6 +613,15 @@ class QLIFLSTMBrainConfig(BrainConfig):
         description="List of sensory modules for feature extraction.",
     )
 
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
+
     # Device
     device_type: DeviceType = Field(
         default=DeviceType.CPU,

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qliflstm.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qliflstm.py
@@ -74,7 +74,6 @@ from quantumnematode.brain.modules import (
     extract_classical_features,
     get_classical_feature_dimension,
 )
-from quantumnematode.env import Direction
 from quantumnematode.logging_config import logger
 from quantumnematode.utils.seeding import ensure_seed, get_rng, set_global_seed
 
@@ -609,10 +608,9 @@ class QLIFLSTMBrainConfig(BrainConfig):
         description="Use QLIF quantum gates (True) or classical sigmoid (False).",
     )
 
-    # Sensory feature extraction
-    sensory_modules: list[ModuleName] | None = Field(
-        default=None,
-        description="List of sensory modules for feature extraction (None = legacy mode).",
+    # Sensory feature extraction (required)
+    sensory_modules: list[ModuleName] = Field(
+        description="List of sensory modules for feature extraction.",
     )
 
     # Device
@@ -722,18 +720,12 @@ class QLIFLSTMBrain(ClassicalBrain):
         # Sensory modules
         self.sensory_modules = config.sensory_modules
 
-        if config.sensory_modules is not None:
-            self.input_dim = get_classical_feature_dimension(config.sensory_modules)
-            logger.info(
-                f"Using unified sensory modules: "
-                f"{[m.value for m in config.sensory_modules]} "
-                f"(input_dim={self.input_dim})",
-            )
-        else:
-            self.input_dim = 2
-            logger.info(
-                "Using legacy 2-feature preprocessing (gradient_strength, rel_angle)",
-            )
+        self.input_dim = get_classical_feature_dimension(config.sensory_modules)
+        logger.info(
+            f"Using sensory modules: "
+            f"{[m.value for m in config.sensory_modules]} "
+            f"(input_dim={self.input_dim})",
+        )
 
         # Data tracking
         self.history_data = BrainHistoryData()
@@ -878,39 +870,8 @@ class QLIFLSTMBrain(ClassicalBrain):
     # ──────────────────────────────────────────────────────────────────
 
     def preprocess(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams to extract features.
-
-        Two modes:
-        1. **Unified sensory mode** (when sensory_modules is set)
-        2. **Legacy mode** (default): gradient strength + relative angle
-
-        Returns
-        -------
-        np.ndarray
-            Feature vector (dtype=np.float32). In unified sensory mode, returns
-            the output of ``extract_classical_features(params, sensory_modules)``.
-            In legacy mode, returns a 2-element array ``[grad_strength,
-            rel_angle_norm]`` with gradient strength and normalized relative angle.
-        """
-        if self.sensory_modules is not None:
-            return extract_classical_features(params, self.sensory_modules)
-
-        grad_strength = float(params.gradient_strength or 0.0)
-        grad_direction = float(params.gradient_direction or 0.0)
-        direction_map = {
-            Direction.UP: np.pi / 2,
-            Direction.DOWN: -np.pi / 2,
-            Direction.LEFT: np.pi,
-            Direction.RIGHT: 0.0,
-        }
-        agent_facing_angle = direction_map.get(
-            params.agent_direction or Direction.UP,
-            np.pi / 2,
-        )
-        relative_angle = (grad_direction - agent_facing_angle + np.pi) % (2 * np.pi) - np.pi
-        rel_angle_norm = relative_angle / np.pi
-
-        return np.array([grad_strength, rel_angle_norm], dtype=np.float32)
+        """Preprocess BrainParams to extract features via sensory modules."""
+        return extract_classical_features(params, self.sensory_modules)
 
     def _get_actor_input(
         self,

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
@@ -76,7 +76,7 @@ class QRCBrainConfig(BrainConfig):
     """Configuration for the QRCBrain architecture.
 
     Uses modular feature extraction via sensory_modules (required).
-    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
+    Each module contributes a variable number of features (typically 2).
 
     Example config:
         >>> config = QRCBrainConfig(
@@ -155,6 +155,15 @@ class QRCBrainConfig(BrainConfig):
     sensory_modules: list[ModuleName] = Field(
         description="List of sensory modules for feature extraction.",
     )
+
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
 
     @field_validator("num_reservoir_qubits")
     @classmethod

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
@@ -360,14 +360,17 @@ class QRCBrain(ClassicalBrain):
         # Data re-uploading: encode inputs before each reservoir layer
         for _layer in range(self.reservoir_depth):
             # Input encoding: dense encoding across all qubits
+            # NOTE: Parity-based gate assignment (even→RY, odd→RZ) assumes all
+            # sensory modules have classical_dim=2. If modules with odd widths
+            # are added, this should be updated to use per-module gate mapping.
             for i, feature in enumerate(features):
                 angle = float(feature) * np.pi
                 for q in range(self.num_qubits):
                     if i % 2 == 0:
-                        # Even-indexed features (e.g., gradient_strength): RY (amplitude)
+                        # Even-indexed features (strength): RY (amplitude)
                         qc.ry(angle, q)
                     else:
-                        # Odd-indexed features (e.g., relative_angle): RZ (phase)
+                        # Odd-indexed features (angle): RZ (phase)
                         qc.rz(angle, q)
 
             # Reservoir layer: structured rotations (fractional angles)

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
@@ -106,8 +106,8 @@ class QRCBrainConfig(BrainConfig):
         Smoothing factor for baseline running average (default 0.05).
     entropy_coef : float
         Entropy regularization coefficient for exploration (default 0.01).
-    sensory_modules : list[ModuleName] | None
-        List of sensory modules for feature extraction (default None = legacy mode).
+    sensory_modules : list[ModuleName]
+        List of sensory modules for feature extraction (required).
     """
 
     num_reservoir_qubits: int = Field(

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qrc.py
@@ -50,7 +50,6 @@ from quantumnematode.brain.modules import (
     extract_classical_features,
     get_classical_feature_dimension,
 )
-from quantumnematode.env import Direction
 from quantumnematode.logging_config import logger
 from quantumnematode.utils.seeding import ensure_seed, get_rng, set_global_seed
 
@@ -76,18 +75,10 @@ MIN_SHOTS = 100
 class QRCBrainConfig(BrainConfig):
     """Configuration for the QRCBrain architecture.
 
-    Supports two modes for input feature extraction:
+    Uses modular feature extraction via sensory_modules (required).
+    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
 
-    1. **Legacy mode** (default): Uses 2 features (gradient_strength, relative_angle)
-       - Set `sensory_modules=None` (default)
-
-    2. **Unified sensory mode**: Uses modular feature extraction from brain/modules.py
-       - Set `sensory_modules` to a list of ModuleName values
-       - Uses extract_classical_features() which outputs semantic-preserving ranges
-       - Each module contributes 2 features [strength, angle] in [0,1] and [-1,1]
-       - Required for multi-sensory scenarios (predator evasion + foraging)
-
-    Example unified mode config:
+    Example config:
         >>> config = QRCBrainConfig(
         ...     sensory_modules=[ModuleName.FOOD_CHEMOTAXIS, ModuleName.NOCICEPTION],
         ... )
@@ -160,13 +151,9 @@ class QRCBrainConfig(BrainConfig):
         description="Entropy regularization coefficient for exploration.",
     )
 
-    # Unified sensory feature extraction (optional)
-    # When set, uses extract_classical_features() which outputs:
-    # - strength: [0, 1] where 0 = no signal (matches legacy semantics)
-    # - angle: [-1, 1] where 0 = aligned with agent heading
-    sensory_modules: list[ModuleName] | None = Field(
-        default=None,
-        description="List of sensory modules for feature extraction (None = legacy mode).",
+    # Sensory feature extraction (required)
+    sensory_modules: list[ModuleName] = Field(
+        description="List of sensory modules for feature extraction.",
     )
 
     @field_validator("num_reservoir_qubits")
@@ -270,18 +257,12 @@ class QRCBrain(ClassicalBrain):
         self.sensory_modules = config.sensory_modules
 
         # Determine input dimension based on sensory modules
-        if config.sensory_modules is not None:
-            # Unified sensory mode: use classical feature extraction
-            self.input_dim = get_classical_feature_dimension(config.sensory_modules)
-            logger.info(
-                f"Using unified sensory modules: "
-                f"{[m.value for m in config.sensory_modules]} "
-                f"(input_dim={self.input_dim})",
-            )
-        else:
-            # Legacy mode: 2 features (gradient_strength, relative_angle)
-            self.input_dim = 2
-            logger.info("Using legacy 2-feature preprocessing (gradient_strength, rel_angle)")
+        self.input_dim = get_classical_feature_dimension(config.sensory_modules)
+        logger.info(
+            f"Using sensory modules: "
+            f"{[m.value for m in config.sensory_modules]} "
+            f"(input_dim={self.input_dim})",
+        )
 
         # Initialize data tracking
         self.history_data = BrainHistoryData()
@@ -435,48 +416,11 @@ class QRCBrain(ClassicalBrain):
     def preprocess(self, params: BrainParams) -> np.ndarray:
         """Preprocess BrainParams to extract features for the reservoir.
 
-        Two modes:
-        1. **Unified sensory mode** (when sensory_modules is set):
-           Uses extract_classical_features() which outputs semantic-preserving ranges:
-           - strength: [0, 1] where 0 = no signal
-           - angle: [-1, 1] where 0 = aligned with agent heading
-
-        2. **Legacy mode** (default):
-           Computes gradient strength normalized to [0, 1] and relative angle
-           normalized to [-1, 1].
-
-        Parameters
-        ----------
-        params : BrainParams
-            Brain parameters containing sensory information.
-
-        Returns
-        -------
-        np.ndarray
-            Preprocessed features.
+        Uses extract_classical_features() which outputs semantic-preserving ranges:
+        - strength: [0, 1] where 0 = no signal
+        - angle: [-1, 1] where 0 = aligned with agent heading
         """
-        # Unified sensory mode: use classical feature extraction
-        if self.sensory_modules is not None:
-            return extract_classical_features(params, self.sensory_modules)
-
-        # Legacy mode: 2-feature preprocessing
-        # Use gradient_strength as-is (assumed [0, 1])
-        grad_strength = float(params.gradient_strength or 0.0)
-
-        # Compute relative angle to goal ([-pi, pi])
-        grad_direction = float(params.gradient_direction or 0.0)
-        direction_map = {
-            Direction.UP: np.pi / 2,
-            Direction.DOWN: -np.pi / 2,
-            Direction.LEFT: np.pi,
-            Direction.RIGHT: 0.0,
-        }
-        agent_facing_angle = direction_map.get(params.agent_direction or Direction.UP, np.pi / 2)
-        relative_angle = (grad_direction - agent_facing_angle + np.pi) % (2 * np.pi) - np.pi
-        # Normalize relative angle to [-1, 1]
-        rel_angle_norm = relative_angle / np.pi
-
-        return np.array([grad_strength, rel_angle_norm], dtype=np.float32)
+        return extract_classical_features(params, self.sensory_modules)
 
     def forward(self, reservoir_state: np.ndarray) -> torch.Tensor:
         """Forward pass through the readout network.

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qsnnppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qsnnppo.py
@@ -320,14 +320,8 @@ class QSNNPPOCritic(nn.Module):
 class QSNNPPOBrainConfig(BrainConfig):
     """Configuration for the QSNNPPOBrain architecture.
 
-    Supports two modes for input feature extraction:
-
-    1. **Legacy mode** (default): Uses 2 features (gradient_strength, relative_angle)
-       - Set ``sensory_modules=None`` (default)
-
-    2. **Unified sensory mode**: Uses modular feature extraction from brain/modules.py
-       - Set ``sensory_modules`` to a list of ModuleName values
-       - Each module contributes 2 features [strength, angle]
+    Uses modular feature extraction via sensory_modules (required).
+    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
     """
 
     # QLIF network architecture

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qsnnppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qsnnppo.py
@@ -321,7 +321,7 @@ class QSNNPPOBrainConfig(BrainConfig):
     """Configuration for the QSNNPPOBrain architecture.
 
     Uses modular feature extraction via sensory_modules (required).
-    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
+    Each module contributes a variable number of features (typically 2).
     """
 
     # QLIF network architecture
@@ -449,6 +449,15 @@ class QSNNPPOBrainConfig(BrainConfig):
     sensory_modules: list[ModuleName] = Field(
         description="List of sensory modules for feature extraction.",
     )
+
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
 
     # Learning rate scheduling
     lr_decay_episodes: int | None = Field(

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qsnnppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qsnnppo.py
@@ -68,7 +68,6 @@ from quantumnematode.brain.modules import (
     extract_classical_features,
     get_classical_feature_dimension,
 )
-from quantumnematode.env import Direction
 from quantumnematode.logging_config import logger
 from quantumnematode.utils.seeding import ensure_seed, get_rng, set_global_seed
 
@@ -452,10 +451,9 @@ class QSNNPPOBrainConfig(BrainConfig):
         description="Number of hidden layers in the critic MLP.",
     )
 
-    # Sensory feature extraction
-    sensory_modules: list[ModuleName] | None = Field(
-        default=None,
-        description="List of sensory modules for feature extraction (None = legacy mode).",
+    # Sensory feature extraction (required)
+    sensory_modules: list[ModuleName] = Field(
+        description="List of sensory modules for feature extraction.",
     )
 
     # Learning rate scheduling
@@ -544,7 +542,7 @@ class QSNNPPOBrain(ClassicalBrain):
     paired with a classical MLP critic trained via PPO.
     """
 
-    def __init__(  # noqa: PLR0915
+    def __init__(
         self,
         config: QSNNPPOBrainConfig,
         num_actions: int = 4,
@@ -575,18 +573,12 @@ class QSNNPPOBrain(ClassicalBrain):
         # Sensory modules
         self.sensory_modules = config.sensory_modules
 
-        if config.sensory_modules is not None:
-            self.input_dim = get_classical_feature_dimension(config.sensory_modules)
-            logger.info(
-                f"Using unified sensory modules: "
-                f"{[m.value for m in config.sensory_modules]} "
-                f"(input_dim={self.input_dim})",
-            )
-        else:
-            self.input_dim = 2
-            logger.info(
-                "Using legacy 2-feature preprocessing (gradient_strength, rel_angle)",
-            )
+        self.input_dim = get_classical_feature_dimension(config.sensory_modules)
+        logger.info(
+            f"Using sensory modules: "
+            f"{[m.value for m in config.sensory_modules]} "
+            f"(input_dim={self.input_dim})",
+        )
 
         # Data tracking
         self.history_data = BrainHistoryData()
@@ -878,31 +870,8 @@ class QSNNPPOBrain(ClassicalBrain):
     # ──────────────────────────────────────────────────────────────────
 
     def preprocess(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams to extract features.
-
-        Two modes:
-        1. **Unified sensory mode** (when sensory_modules is set)
-        2. **Legacy mode** (default): gradient strength + relative angle
-        """
-        if self.sensory_modules is not None:
-            return extract_classical_features(params, self.sensory_modules)
-
-        grad_strength = float(params.gradient_strength or 0.0)
-        grad_direction = float(params.gradient_direction or 0.0)
-        direction_map = {
-            Direction.UP: np.pi / 2,
-            Direction.DOWN: -np.pi / 2,
-            Direction.LEFT: np.pi,
-            Direction.RIGHT: 0.0,
-        }
-        agent_facing_angle = direction_map.get(
-            params.agent_direction or Direction.UP,
-            np.pi / 2,
-        )
-        relative_angle = (grad_direction - agent_facing_angle + np.pi) % (2 * np.pi) - np.pi
-        rel_angle_norm = relative_angle / np.pi
-
-        return np.array([grad_strength, rel_angle_norm], dtype=np.float32)
+        """Preprocess BrainParams to extract features via sensory modules."""
+        return extract_classical_features(params, self.sensory_modules)
 
     def _get_critic_input(
         self,

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
@@ -247,15 +247,8 @@ class CriticMLP(nn.Module):
 class QSNNReinforceBrainConfig(BrainConfig):
     """Configuration for the QSNNReinforceBrain architecture.
 
-    Supports two modes for input feature extraction:
-
-    1. **Legacy mode** (default): Uses 2 features (gradient_strength, relative_angle)
-       - Set `sensory_modules=None` (default)
-
-    2. **Unified sensory mode**: Uses modular feature extraction from brain/modules.py
-       - Set `sensory_modules` to a list of ModuleName values
-       - Uses extract_classical_features() which outputs semantic-preserving ranges
-       - Each module contributes 2 features [strength, angle] in [0,1] and [-1,1]
+    Uses modular feature extraction via sensory_modules (required).
+    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
 
     Attributes
     ----------

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
@@ -72,7 +72,6 @@ from quantumnematode.brain.modules import (
     extract_classical_features,
     get_classical_feature_dimension,
 )
-from quantumnematode.env import Direction
 from quantumnematode.logging_config import logger
 from quantumnematode.utils.seeding import ensure_seed, get_rng, set_global_seed
 
@@ -446,10 +445,9 @@ class QSNNReinforceBrainConfig(BrainConfig):
         description="Fraction of max entropy above which entropy bonus is suppressed.",
     )
 
-    # Unified sensory feature extraction (optional)
-    sensory_modules: list[ModuleName] | None = Field(
-        default=None,
-        description="List of sensory modules for feature extraction (None = legacy mode).",
+    # Sensory feature extraction (required)
+    sensory_modules: list[ModuleName] = Field(
+        description="List of sensory modules for feature extraction.",
     )
 
     @field_validator("num_sensory_neurons")
@@ -569,17 +567,13 @@ class QSNNReinforceBrain(ClassicalBrain):
         # Store sensory modules for feature extraction
         self.sensory_modules = config.sensory_modules
 
-        # Determine input dimension based on sensory modules
-        if config.sensory_modules is not None:
-            self.input_dim = get_classical_feature_dimension(config.sensory_modules)
-            logger.info(
-                f"Using unified sensory modules: "
-                f"{[m.value for m in config.sensory_modules]} "
-                f"(input_dim={self.input_dim})",
-            )
-        else:
-            self.input_dim = 2
-            logger.info("Using legacy 2-feature preprocessing (gradient_strength, rel_angle)")
+        # Determine input dimension from sensory modules
+        self.input_dim = get_classical_feature_dimension(config.sensory_modules)
+        logger.info(
+            f"Using sensory modules: "
+            f"{[m.value for m in config.sensory_modules]} "
+            f"(input_dim={self.input_dim})",
+        )
 
         # Initialize data tracking
         self.history_data = BrainHistoryData()
@@ -1781,41 +1775,8 @@ class QSNNReinforceBrain(ClassicalBrain):
                 self.theta_motor.mul_(self.config.theta_motor_max_norm / tm_norm)
 
     def preprocess(self, params: BrainParams) -> np.ndarray:
-        """Preprocess BrainParams to extract features.
-
-        Two modes:
-        1. **Unified sensory mode** (when sensory_modules is set)
-        2. **Legacy mode** (default): gradient strength + relative angle
-
-        Parameters
-        ----------
-        params : BrainParams
-            Brain parameters containing sensory information.
-
-        Returns
-        -------
-        np.ndarray
-            Preprocessed features.
-        """
-        # Unified sensory mode
-        if self.sensory_modules is not None:
-            return extract_classical_features(params, self.sensory_modules)
-
-        # Legacy mode: 2-feature preprocessing
-        grad_strength = float(params.gradient_strength or 0.0)
-
-        grad_direction = float(params.gradient_direction or 0.0)
-        direction_map = {
-            Direction.UP: np.pi / 2,
-            Direction.DOWN: -np.pi / 2,
-            Direction.LEFT: np.pi,
-            Direction.RIGHT: 0.0,
-        }
-        agent_facing_angle = direction_map.get(params.agent_direction or Direction.UP, np.pi / 2)
-        relative_angle = (grad_direction - agent_facing_angle + np.pi) % (2 * np.pi) - np.pi
-        rel_angle_norm = relative_angle / np.pi
-
-        return np.array([grad_strength, rel_angle_norm], dtype=np.float32)
+        """Preprocess BrainParams to extract features via sensory modules."""
+        return extract_classical_features(params, self.sensory_modules)
 
     def _log_motor_dynamics(
         self,

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
@@ -248,7 +248,7 @@ class QSNNReinforceBrainConfig(BrainConfig):
     """Configuration for the QSNNReinforceBrain architecture.
 
     Uses modular feature extraction via sensory_modules (required).
-    Each module contributes 2 features [strength, angle] in [0,1] and [-1,1].
+    Each module contributes a variable number of features (typically 2).
 
     Attributes
     ----------
@@ -442,6 +442,15 @@ class QSNNReinforceBrainConfig(BrainConfig):
     sensory_modules: list[ModuleName] = Field(
         description="List of sensory modules for feature extraction.",
     )
+
+    @field_validator("sensory_modules")
+    @classmethod
+    def validate_sensory_modules(cls, v: list[ModuleName]) -> list[ModuleName]:
+        """Validate sensory_modules is non-empty."""
+        if not v:
+            msg = "sensory_modules must be non-empty"
+            raise ValueError(msg)
+        return v
 
     @field_validator("num_sensory_neurons")
     @classmethod

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qsnnreinforce.py
@@ -276,8 +276,8 @@ class QSNNReinforceBrainConfig(BrainConfig):
         Entropy regularization coefficient (default 0.01).
     weight_clip : float
         Maximum absolute weight value for stability (default 5.0).
-    sensory_modules : list[ModuleName] | None
-        List of sensory modules for feature extraction (None = legacy mode).
+    sensory_modules : list[ModuleName]
+        List of sensory modules for feature extraction (required).
     """
 
     num_sensory_neurons: int = Field(

--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -209,7 +209,7 @@ class BrainContainerConfig(BaseModel):
     """Configuration for the brain architecture."""
 
     name: str
-    config: BrainConfigType | None = None
+    config: BrainConfigType
 
 
 class LearningRateParameters(BaseModel):

--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -147,7 +147,7 @@ def _resolve_brain_config[T: BrainConfigType](
     """Resolve a raw brain config to the expected config class.
 
     Handles three cases:
-    1. None -> return default config
+    1. None -> raise (brain config is required)
     2. Already correct type -> return as-is
     3. Dict-like object -> extract matching fields and construct
 
@@ -171,7 +171,8 @@ def _resolve_brain_config[T: BrainConfigType](
         If the raw_config cannot be converted to the expected type.
     """
     if raw_config is None:
-        return config_cls()
+        msg = f"Brain config is required for '{brain_name}' — no default config available."
+        raise ValueError(msg)
     if isinstance(raw_config, config_cls):
         return raw_config
     if hasattr(raw_config, "__dict__"):

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
@@ -19,7 +19,9 @@ class TestHybridClassicalBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = HybridClassicalBrainConfig()
+        config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
         assert config.reflex_hidden_dim == 16
         assert config.training_stage == 1
         assert config.cortex_hidden_dim == 64
@@ -28,11 +30,11 @@ class TestHybridClassicalBrainConfig:
         assert config.reflex_lr == 0.01
         assert config.ppo_buffer_size == 512
         assert config.reflex_weights_path is None
-        assert config.sensory_modules is None
 
     def test_custom_config(self):
         """Test custom configuration values."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             reflex_hidden_dim=32,
             training_stage=2,
             cortex_hidden_dim=128,
@@ -48,19 +50,31 @@ class TestHybridClassicalBrainConfig:
     def test_validation_training_stage_invalid(self):
         """Test validation rejects invalid training stage."""
         with pytest.raises(ValueError, match="training_stage must be 1, 2, or 3"):
-            HybridClassicalBrainConfig(training_stage=0)
+            HybridClassicalBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                training_stage=0,
+            )
         with pytest.raises(ValueError, match="training_stage must be 1, 2, or 3"):
-            HybridClassicalBrainConfig(training_stage=4)
+            HybridClassicalBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                training_stage=4,
+            )
 
     def test_validation_num_reinforce_epochs(self):
         """Test validation rejects zero reinforce epochs."""
         with pytest.raises(ValueError, match="num_reinforce_epochs must be >= 1"):
-            HybridClassicalBrainConfig(num_reinforce_epochs=0)
+            HybridClassicalBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_reinforce_epochs=0,
+            )
 
     def test_validation_reflex_hidden_dim(self):
         """Test validation rejects zero reflex hidden dim."""
         with pytest.raises(ValueError, match="reflex_hidden_dim must be >= 1"):
-            HybridClassicalBrainConfig(reflex_hidden_dim=0)
+            HybridClassicalBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                reflex_hidden_dim=0,
+            )
 
     def test_config_with_sensory_modules(self):
         """Test config with sensory modules specified."""
@@ -78,6 +92,7 @@ class TestHybridClassicalBrainInit:
     def brain_stage1(self):
         """Create a stage 1 brain for testing."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             seed=42,
         )
@@ -87,6 +102,7 @@ class TestHybridClassicalBrainInit:
     def brain_stage2(self):
         """Create a stage 2 brain for testing."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             seed=42,
         )
@@ -147,6 +163,7 @@ class TestReflexForwardPass:
     def brain(self):
         """Create a brain for reflex forward pass testing."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             seed=42,
         )
@@ -175,6 +192,7 @@ class TestCortexForwardPass:
     def brain(self):
         """Create a stage 2 brain for cortex forward pass testing."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             seed=42,
         )
@@ -200,6 +218,7 @@ class TestFusionMechanism:
     def test_fusion_math(self):
         """Test fusion with forage mode dominant produces high reflex trust."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             seed=42,
         )
@@ -224,6 +243,7 @@ class TestFusionMechanism:
     def test_fusion_low_trust(self):
         """Test fusion with evade mode dominant produces low reflex trust."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             seed=42,
         )
@@ -247,6 +267,7 @@ class TestFusionMechanism:
     def test_stage1_bypass(self):
         """Stage 1 should bypass cortex entirely."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             seed=42,
         )
@@ -266,6 +287,7 @@ class TestStageAwareTraining:
         """Test reflex weights change during stage 1 REINFORCE training."""
         monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             reinforce_window_size=5,
             seed=42,
@@ -294,6 +316,7 @@ class TestStageAwareTraining:
         """Test reflex weights remain unchanged during stage 2 PPO training."""
         monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             ppo_buffer_size=5,
             ppo_minibatches=1,
@@ -323,6 +346,7 @@ class TestReinforceUpdate:
         """Test REINFORCE update completes without error."""
         monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             reinforce_window_size=3,
             num_reinforce_epochs=1,
@@ -343,6 +367,7 @@ class TestPPOBuffer:
         """Test PPO buffer fills and triggers update correctly."""
         monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             ppo_buffer_size=4,
             ppo_minibatches=1,
@@ -390,6 +415,7 @@ class TestEpisodeReset:
         """Test state and buffers are cleared after episode."""
         monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             seed=42,
         )
@@ -436,7 +462,7 @@ class TestBrainRegistration:
         from quantumnematode.utils.brain_factory import setup_brain_model
         from quantumnematode.utils.config_loader import ParameterInitializerConfig
 
-        config = HybridClassicalBrainConfig(seed=42)
+        config = HybridClassicalBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], seed=42)
         brain = setup_brain_model(
             brain_type=BrainType.HYBRID_CLASSICAL,
             brain_config=config,
@@ -457,7 +483,11 @@ class TestWeightPersistence:
     def test_save_and_load_round_trip(self, tmp_path, monkeypatch):
         """Test reflex weights survive a save/load round trip."""
         monkeypatch.chdir(tmp_path)
-        config1 = HybridClassicalBrainConfig(training_stage=1, seed=42)
+        config1 = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            training_stage=1,
+            seed=42,
+        )
         brain1 = HybridClassicalBrain(config=config1, num_actions=4)
         brain1._save_reflex_weights("test_session")
 
@@ -466,6 +496,7 @@ class TestWeightPersistence:
 
         # Load into new brain
         config2 = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             reflex_weights_path=str(save_path),
             seed=43,
@@ -483,6 +514,7 @@ class TestWeightPersistence:
     def test_load_missing_file_raises(self):
         """Test loading from missing file raises FileNotFoundError."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             reflex_weights_path="/nonexistent/path/reflex_weights.pt",
         )
@@ -492,6 +524,7 @@ class TestWeightPersistence:
     def test_stage2_without_weights_logs_warning(self, caplog):
         """Test stage 2 without weights path logs a warning."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             seed=42,
         )
@@ -502,7 +535,11 @@ class TestWeightPersistence:
     def test_save_reflex_weights(self, tmp_path, monkeypatch):
         """Test saving reflex weights creates correct file."""
         monkeypatch.chdir(tmp_path)
-        config = HybridClassicalBrainConfig(training_stage=1, seed=42)
+        config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            training_stage=1,
+            seed=42,
+        )
         brain = HybridClassicalBrain(config=config, num_actions=4)
         brain._save_reflex_weights("test_session")
 
@@ -519,7 +556,11 @@ class TestWeightPersistence:
     def test_save_and_load_cortex_round_trip(self, tmp_path, monkeypatch):
         """Test cortex weights survive a save/load round trip."""
         monkeypatch.chdir(tmp_path)
-        config = HybridClassicalBrainConfig(training_stage=2, seed=42)
+        config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            training_stage=2,
+            seed=42,
+        )
         brain1 = HybridClassicalBrain(config=config, num_actions=4)
         brain1._save_cortex_weights("test_session")
 
@@ -528,6 +569,7 @@ class TestWeightPersistence:
 
         # Load into new brain
         config2 = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=3,
             cortex_weights_path=str(save_path),
             seed=43,
@@ -551,6 +593,7 @@ class TestWeightPersistence:
     def test_load_cortex_missing_file_raises(self):
         """Test loading cortex from missing file raises FileNotFoundError."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=3,
             cortex_weights_path="/nonexistent/path/cortex_weights.pt",
         )
@@ -561,6 +604,7 @@ class TestWeightPersistence:
         """Test cortex weights are auto-saved during stage 2 training."""
         monkeypatch.chdir(tmp_path)
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             ppo_buffer_size=4,
             ppo_minibatches=1,
@@ -586,6 +630,7 @@ class TestCortexLRScheduling:
     def test_lr_warmup(self):
         """Test LR warmup from low to base value."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             cortex_actor_lr=0.001,
             cortex_lr_warmup_episodes=10,
@@ -609,6 +654,7 @@ class TestCortexLRScheduling:
     def test_lr_decay(self):
         """Test LR decay after warmup."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             cortex_actor_lr=0.001,
             cortex_lr_warmup_episodes=10,
@@ -639,6 +685,7 @@ class TestCortexLRScheduling:
     def test_no_lr_scheduling(self):
         """Test that LR is flat when no scheduling configured."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             cortex_actor_lr=0.001,
             seed=42,
@@ -652,6 +699,7 @@ class TestCortexLRScheduling:
     def test_lr_update_changes_optimizer(self):
         """Test that _update_cortex_learning_rate changes optimizer LR."""
         config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             cortex_actor_lr=0.001,
             cortex_lr_warmup_episodes=10,
@@ -676,7 +724,11 @@ class TestBrainCopy:
 
     def test_copy_preserves_weights(self):
         """Test copied brain has identical weights."""
-        config = HybridClassicalBrainConfig(training_stage=1, seed=42)
+        config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            training_stage=1,
+            seed=42,
+        )
         brain = HybridClassicalBrain(config=config, num_actions=4)
         copy = brain.copy()
 
@@ -691,7 +743,11 @@ class TestBrainCopy:
 
     def test_copy_is_independent(self):
         """Test copied brain is independent of original."""
-        config = HybridClassicalBrainConfig(training_stage=1, seed=42)
+        config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            training_stage=1,
+            seed=42,
+        )
         brain = HybridClassicalBrain(config=config, num_actions=4)
         copy = brain.copy()
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
@@ -147,9 +147,9 @@ class TestHybridClassicalBrainInit:
         assert last_layer.out_features == 1
 
     def test_cortex_actor_input_dim(self, brain_stage1):
-        """Test cortex actor input dimension matches legacy mode."""
+        """Test cortex actor input dimension matches sensory module count."""
         first_layer = next(iter(brain_stage1.cortex_actor.children()))
-        assert first_layer.in_features == 2  # legacy mode
+        assert first_layer.in_features == 2  # 1 module * 2 features
 
     def test_action_set(self, brain_stage1):
         """Test action set has correct length."""
@@ -200,7 +200,7 @@ class TestCortexForwardPass:
 
     def test_cortex_forward_output_split(self, brain):
         """Test cortex forward splits into action biases and mode logits."""
-        sensory_t = torch.randn(2)  # legacy 2-feature input
+        sensory_t = torch.randn(2)  # 1 module * 2 features
         action_biases, mode_logits = brain._cortex_forward(sensory_t)
         assert action_biases.shape == (4,)
         assert mode_logits.shape == (3,)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridclassical.py
@@ -125,6 +125,17 @@ class TestHybridClassicalBrainInit:
         # Linear(2, 16) = 2*16+16 = 48, Linear(16, 4) = 16*4+4 = 68 → 116
         assert total == 116
 
+    def test_reflex_mlp_multi_module(self):
+        """Test reflex MLP input dimension scales with multiple sensory modules."""
+        config = HybridClassicalBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS, ModuleName.NOCICEPTION],
+            training_stage=1,
+            seed=42,
+        )
+        brain = HybridClassicalBrain(config=config, num_actions=4)
+        first_layer = next(iter(brain.reflex_mlp.children()))
+        assert first_layer.in_features == 4  # 2 modules * 2 features each
+
     def test_reflex_requires_grad_stage1(self, brain_stage1):
         """Test reflex weights require gradient in stage 1."""
         for param in brain_stage1.reflex_mlp.parameters():
@@ -272,7 +283,7 @@ class TestFusionMechanism:
             seed=42,
         )
         brain = HybridClassicalBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
         actions = brain.run_brain(params, top_only=False, top_randomize=False)
         assert len(actions) == 1
         assert isinstance(actions[0], ActionData)
@@ -293,7 +304,7 @@ class TestStageAwareTraining:
             seed=42,
         )
         brain = HybridClassicalBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         weights_before = {
             name: p.clone().detach() for name, p in brain.reflex_mlp.named_parameters()
@@ -323,7 +334,7 @@ class TestStageAwareTraining:
             seed=42,
         )
         brain = HybridClassicalBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         weights_before = {
             name: p.clone().detach() for name, p in brain.reflex_mlp.named_parameters()
@@ -353,7 +364,7 @@ class TestReinforceUpdate:
             seed=42,
         )
         brain = HybridClassicalBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(4):
             brain.run_brain(params, top_only=False, top_randomize=False)
@@ -375,7 +386,7 @@ class TestPPOBuffer:
             seed=42,
         )
         brain = HybridClassicalBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(5):
             brain.run_brain(params, top_only=False, top_randomize=False)
@@ -420,7 +431,7 @@ class TestEpisodeReset:
             seed=42,
         )
         brain = HybridClassicalBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Run an episode
         for i in range(3):
@@ -613,7 +624,7 @@ class TestWeightPersistence:
         )
         brain = HybridClassicalBrain(config=config, num_actions=4)
         brain.set_session_id("auto_save_test")
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(5):
             brain.run_brain(params, top_only=False, top_randomize=False)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
@@ -319,7 +319,7 @@ class TestFusionMechanism:
             seed=42,
         )
         brain = HybridQuantumBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
         actions = brain.run_brain(params, top_only=False, top_randomize=False)
         assert len(actions) == 1
         assert isinstance(actions[0], ActionData)
@@ -342,7 +342,7 @@ class TestStageAwareTraining:
             seed=42,
         )
         brain = HybridQuantumBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         w_sh_before = brain.W_sh.clone().detach()
 
@@ -368,7 +368,7 @@ class TestStageAwareTraining:
             seed=42,
         )
         brain = HybridQuantumBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         w_sh_before = brain.W_sh.clone().detach()
 
@@ -398,7 +398,7 @@ class TestReinforceUpdate:
             seed=42,
         )
         brain = HybridQuantumBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(4):
             brain.run_brain(params, top_only=False, top_randomize=False)
@@ -422,7 +422,7 @@ class TestPPOBuffer:
             seed=42,
         )
         brain = HybridQuantumBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(5):
             brain.run_brain(params, top_only=False, top_randomize=False)
@@ -469,7 +469,7 @@ class TestEpisodeReset:
             seed=42,
         )
         brain = HybridQuantumBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Run an episode
         for i in range(3):
@@ -717,7 +717,7 @@ class TestWeightPersistence:
         )
         brain = HybridQuantumBrain(config=config, num_actions=4)
         brain.set_session_id("auto_save_test")
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(5):
             brain.run_brain(params, top_only=False, top_randomize=False)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
@@ -181,9 +181,9 @@ class TestHybridQuantumBrainInit:
         assert last_layer.out_features == 1
 
     def test_cortex_actor_input_dim(self, brain_stage1):
-        """Test cortex actor input dimension matches legacy mode."""
+        """Test cortex actor input dimension matches sensory module count."""
         first_layer = next(iter(brain_stage1.cortex_actor.children()))
-        assert first_layer.in_features == 2  # legacy mode
+        assert first_layer.in_features == 2  # 1 module * 2 features
 
     def test_action_set(self, brain_stage1):
         """Test action set has correct length."""
@@ -241,7 +241,7 @@ class TestCortexForwardPass:
 
     def test_cortex_forward_output_split(self, brain):
         """Test cortex forward splits into action biases and mode logits."""
-        sensory_t = torch.randn(2)  # legacy 2-feature input
+        sensory_t = torch.randn(2)  # 1 module * 2 features
         action_biases, mode_logits = brain._cortex_forward(sensory_t)
         assert action_biases.shape == (4,)
         assert mode_logits.shape == (3,)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantum.py
@@ -19,7 +19,9 @@ class TestHybridQuantumBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = HybridQuantumBrainConfig()
+        config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
         assert config.num_sensory_neurons == 8
         assert config.num_hidden_neurons == 16
         assert config.num_motor_neurons == 4
@@ -33,11 +35,11 @@ class TestHybridQuantumBrainConfig:
         assert config.qsnn_lr == 0.01
         assert config.ppo_buffer_size == 512
         assert config.qsnn_weights_path is None
-        assert config.sensory_modules is None
 
     def test_custom_config(self):
         """Test custom configuration values."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=6,
             num_hidden_neurons=12,
             training_stage=2,
@@ -55,48 +57,60 @@ class TestHybridQuantumBrainConfig:
     def test_validation_training_stage_invalid(self):
         """Test validation rejects invalid training stage."""
         with pytest.raises(ValueError, match="training_stage must be 1, 2, or 3"):
-            HybridQuantumBrainConfig(training_stage=0)
+            HybridQuantumBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], training_stage=0)
         with pytest.raises(ValueError, match="training_stage must be 1, 2, or 3"):
-            HybridQuantumBrainConfig(training_stage=4)
+            HybridQuantumBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], training_stage=4)
 
     def test_validation_shots_too_low(self):
         """Test validation rejects shots below minimum."""
         with pytest.raises(ValueError, match="shots must be >= 100"):
-            HybridQuantumBrainConfig(shots=50)
+            HybridQuantumBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], shots=50)
 
     def test_validation_num_sensory_neurons(self):
         """Test validation rejects zero sensory neurons."""
         with pytest.raises(ValueError, match="num_sensory_neurons must be >= 1"):
-            HybridQuantumBrainConfig(num_sensory_neurons=0)
+            HybridQuantumBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_sensory_neurons=0,
+            )
 
     def test_validation_num_hidden_neurons(self):
         """Test validation rejects zero hidden neurons."""
         with pytest.raises(ValueError, match="num_hidden_neurons must be >= 1"):
-            HybridQuantumBrainConfig(num_hidden_neurons=0)
+            HybridQuantumBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_hidden_neurons=0,
+            )
 
     def test_validation_num_motor_neurons(self):
         """Test validation rejects fewer than 2 motor neurons."""
         with pytest.raises(ValueError, match="num_motor_neurons must be >= 2"):
-            HybridQuantumBrainConfig(num_motor_neurons=1)
+            HybridQuantumBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_motor_neurons=1,
+            )
 
     def test_validation_membrane_tau(self):
         """Test validation rejects membrane_tau outside (0, 1]."""
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            HybridQuantumBrainConfig(membrane_tau=0.0)
+            HybridQuantumBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], membrane_tau=0.0)
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            HybridQuantumBrainConfig(membrane_tau=1.5)
+            HybridQuantumBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], membrane_tau=1.5)
 
     def test_validation_threshold(self):
         """Test validation rejects threshold outside (0, 1)."""
         with pytest.raises(ValueError, match="threshold must be in"):
-            HybridQuantumBrainConfig(threshold=0.0)
+            HybridQuantumBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], threshold=0.0)
         with pytest.raises(ValueError, match="threshold must be in"):
-            HybridQuantumBrainConfig(threshold=1.0)
+            HybridQuantumBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], threshold=1.0)
 
     def test_validation_num_reinforce_epochs(self):
         """Test validation rejects zero reinforce epochs."""
         with pytest.raises(ValueError, match="num_reinforce_epochs must be >= 1"):
-            HybridQuantumBrainConfig(num_reinforce_epochs=0)
+            HybridQuantumBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_reinforce_epochs=0,
+            )
 
     def test_config_with_sensory_modules(self):
         """Test config with sensory modules specified."""
@@ -114,6 +128,7 @@ class TestHybridQuantumBrainInit:
     def brain_stage1(self):
         """Create a stage 1 brain for testing."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -125,6 +140,7 @@ class TestHybridQuantumBrainInit:
     def brain_stage2(self):
         """Create a stage 2 brain for testing."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -181,6 +197,7 @@ class TestQSNNForwardPass:
     def brain(self):
         """Create a brain for QSNN forward pass testing."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -214,6 +231,7 @@ class TestCortexForwardPass:
     def brain(self):
         """Create a stage 2 brain for cortex forward pass testing."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -241,6 +259,7 @@ class TestFusionMechanism:
     def test_fusion_math(self):
         """Test fusion with forage mode dominant produces high QSNN trust."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -267,6 +286,7 @@ class TestFusionMechanism:
     def test_fusion_low_trust(self):
         """Test fusion with evade mode dominant produces low QSNN trust."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -292,6 +312,7 @@ class TestFusionMechanism:
     def test_stage1_bypass(self):
         """Stage 1 should bypass cortex entirely."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -313,6 +334,7 @@ class TestStageAwareTraining:
         """Test QSNN weights change during stage 1 REINFORCE training."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -337,6 +359,7 @@ class TestStageAwareTraining:
         """Test QSNN weights remain unchanged during stage 2 PPO training."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -366,6 +389,7 @@ class TestReinforceUpdate:
         """Test REINFORCE update completes without error."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -388,6 +412,7 @@ class TestPPOBuffer:
         """Test PPO buffer fills and triggers update correctly."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -437,6 +462,7 @@ class TestEpisodeReset:
         """Test QSNN state and buffers are cleared after episode."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -488,6 +514,7 @@ class TestBrainRegistration:
         from quantumnematode.utils.config_loader import ParameterInitializerConfig
 
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             shots=100,
             num_qsnn_timesteps=1,
             seed=42,
@@ -512,6 +539,7 @@ class TestWeightPersistence:
     def test_save_and_load_round_trip(self, tmp_path):
         """Test weights survive a save/load round trip."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -535,6 +563,7 @@ class TestWeightPersistence:
 
         # Load into new brain
         config2 = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -554,6 +583,7 @@ class TestWeightPersistence:
     def test_load_missing_file_raises(self):
         """Test loading from missing file raises FileNotFoundError."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -575,6 +605,7 @@ class TestWeightPersistence:
         torch.save(weights_dict, save_path)
 
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -586,6 +617,7 @@ class TestWeightPersistence:
     def test_stage2_without_weights_logs_warning(self, caplog):
         """Test stage 2 without weights path logs a warning."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -599,6 +631,7 @@ class TestWeightPersistence:
         """Test saving QSNN weights creates correct file."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -620,6 +653,7 @@ class TestWeightPersistence:
         """Test cortex weights survive a save/load round trip."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -633,6 +667,7 @@ class TestWeightPersistence:
 
         # Load into new brain
         config2 = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=3,
             shots=100,
             num_qsnn_timesteps=1,
@@ -658,6 +693,7 @@ class TestWeightPersistence:
     def test_load_cortex_missing_file_raises(self):
         """Test loading cortex from missing file raises FileNotFoundError."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=3,
             shots=100,
             num_qsnn_timesteps=1,
@@ -670,6 +706,7 @@ class TestWeightPersistence:
         """Test cortex weights are auto-saved during stage 2 training."""
         monkeypatch.chdir(tmp_path)
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -697,6 +734,7 @@ class TestCortexLRScheduling:
     def test_lr_warmup(self):
         """Test LR warmup from low to base value."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -722,6 +760,7 @@ class TestCortexLRScheduling:
     def test_lr_decay(self):
         """Test LR decay after warmup."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -754,6 +793,7 @@ class TestCortexLRScheduling:
     def test_no_lr_scheduling(self):
         """Test that LR is flat when no scheduling configured."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -769,6 +809,7 @@ class TestCortexLRScheduling:
     def test_lr_update_changes_optimizer(self):
         """Test that _update_cortex_learning_rate changes optimizer LR."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=2,
             shots=100,
             num_qsnn_timesteps=1,
@@ -792,6 +833,7 @@ class TestCortexLRScheduling:
     def test_config_with_lr_scheduling(self):
         """Test config accepts LR scheduling parameters."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             cortex_lr_warmup_episodes=50,
             cortex_lr_warmup_start=0.0001,
             cortex_lr_decay_episodes=200,
@@ -809,6 +851,7 @@ class TestBrainCopy:
     def test_copy_preserves_weights(self):
         """Test copied brain has identical weights."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,
@@ -825,6 +868,7 @@ class TestBrainCopy:
     def test_copy_is_independent(self):
         """Test copied brain is independent of original."""
         config = HybridQuantumBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             training_stage=1,
             shots=100,
             num_qsnn_timesteps=1,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantumcortex.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantumcortex.py
@@ -28,14 +28,12 @@ def _stage1_config(**overrides: Any) -> HybridQuantumCortexBrainConfig:
         "shots": 100,
         "num_qsnn_timesteps": 1,
         "num_cortex_timesteps": 1,
+        "sensory_modules": [ModuleName.FOOD_CHEMOTAXIS],
+        "cortex_sensory_modules": [ModuleName.FOOD_CHEMOTAXIS],
         "seed": 42,
     }
     defaults.update(overrides)
-    return HybridQuantumCortexBrainConfig(
-        cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
-        sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
-        **defaults,
-    )
+    return HybridQuantumCortexBrainConfig(**defaults)
 
 
 def _stage2_config(**overrides: Any) -> HybridQuantumCortexBrainConfig:
@@ -139,19 +137,22 @@ class TestHybridQuantumCortexBrainConfig:
                 num_modes=1,
             )
 
-    def test_validation_cortex_modules_required_stage2(self):
-        """Test validation requires non-empty cortex_sensory_modules for stage >= 2."""
+    def test_validation_cortex_modules_non_empty(self):
+        """Test validation rejects empty cortex_sensory_modules."""
         with pytest.raises(ValueError, match="cortex_sensory_modules must be non-empty"):
             HybridQuantumCortexBrainConfig(
                 sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
                 cortex_sensory_modules=[],
-                training_stage=2,
+                training_stage=1,
             )
-        with pytest.raises(ValueError, match="cortex_sensory_modules must be non-empty"):
+
+    def test_validation_sensory_modules_non_empty(self):
+        """Test validation rejects empty sensory_modules."""
+        with pytest.raises(ValueError, match="sensory_modules must be non-empty"):
             HybridQuantumCortexBrainConfig(
-                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
-                cortex_sensory_modules=[],
-                training_stage=3,
+                sensory_modules=[],
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                training_stage=1,
             )
 
     def test_validation_shots_too_low(self):
@@ -362,7 +363,7 @@ class TestActionSelection:
     def test_stage1_produces_valid_action(self):
         """Test stage 1 brain produces valid ActionData."""
         brain = HybridQuantumCortexBrain(config=_stage1_config(), num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
         result = brain.run_brain(params, top_only=False, top_randomize=False)
         assert len(result) == 1
         assert isinstance(result[0], ActionData)
@@ -370,7 +371,7 @@ class TestActionSelection:
     def test_stage2_produces_valid_action(self):
         """Test stage 2 brain produces valid ActionData."""
         brain = HybridQuantumCortexBrain(config=_stage2_config(), num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
         result = brain.run_brain(params, top_only=False, top_randomize=False)
         assert len(result) == 1
         assert isinstance(result[0], ActionData)
@@ -389,7 +390,7 @@ class TestStageAwareTraining:
         monkeypatch.chdir(tmp_path)
         config = _stage1_config(reinforce_window_size=5)
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         w_sh_before = brain.W_sh.clone().detach()
 
@@ -405,7 +406,7 @@ class TestStageAwareTraining:
         monkeypatch.chdir(tmp_path)
         config = _stage2_config()
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         w_sh_before = brain.W_sh.clone().detach()
 
@@ -435,7 +436,7 @@ class TestStageAwareTraining:
             seed=42,
         )
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         w_sh_before = brain.W_sh.clone().detach()
 
@@ -556,7 +557,7 @@ class TestWeightPersistence:
         monkeypatch.chdir(tmp_path)
         config = _stage2_config()
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(6):
             brain.run_brain(params, top_only=False, top_randomize=False)
@@ -588,7 +589,7 @@ class TestReinforceGAE:
         monkeypatch.chdir(tmp_path)
         config = _stage2_config()
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for i in range(6):
             brain.run_brain(params, top_only=False, top_randomize=False)
@@ -599,7 +600,7 @@ class TestReinforceGAE:
         monkeypatch.chdir(tmp_path)
         config = _stage2_config(use_gae_advantages=False)
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Should complete without error
         for i in range(6):
@@ -619,7 +620,7 @@ class TestEpisodeReset:
         """Test episode reset clears buffers and refractory states."""
         config = _stage2_config()
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Run some steps
         for _ in range(3):
@@ -738,7 +739,7 @@ class TestSmokeTest:
             num_reinforce_epochs=1,
         )
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for _ep in range(3):
             brain.prepare_episode()
@@ -763,7 +764,7 @@ class TestSmokeTest:
             num_cortex_reinforce_epochs=1,
         )
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         for _ep in range(3):
             brain.prepare_episode()
@@ -794,7 +795,7 @@ class TestStage2CortexLearns:
         monkeypatch.chdir(tmp_path)
         config = _stage2_config(ppo_buffer_size=5)
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         group_w_before = [w.clone().detach() for w in brain.cortex_group_weights]
         hidden_w_before = brain.W_cortex_sh.clone().detach()
@@ -822,7 +823,7 @@ class TestStage2CortexLearns:
         monkeypatch.chdir(tmp_path)
         config = _stage2_config(ppo_buffer_size=5)
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         critic_before = {name: p.clone().detach() for name, p in brain.critic.named_parameters()}
 
@@ -854,7 +855,7 @@ class TestCortexLRScheduling:
             cortex_lr_warmup_start=0.001,
         )
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Run first episode to establish warmup start
         brain.prepare_episode()
@@ -888,7 +889,7 @@ class TestCortexLRScheduling:
 
         initial_lr = brain.cortex_optimizer.param_groups[0]["lr"]
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
         for _ep in range(3):
             brain.prepare_episode()
             for step in range(6):
@@ -986,7 +987,7 @@ class TestRefractoryReset:
         """Test refractory states are zeroed on prepare_episode."""
         config = _stage2_config()
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Run some steps to potentially populate refractory state
         for _ in range(5):
@@ -1009,7 +1010,7 @@ class TestRefractoryReset:
         monkeypatch.chdir(tmp_path)
         config = _stage2_config(ppo_buffer_size=5, num_cortex_reinforce_epochs=2)
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Fill buffer and trigger update (6 steps, last is episode_done)
         for i in range(6):
@@ -1038,7 +1039,7 @@ class TestMultiEpochCaching:
             num_cortex_reinforce_epochs=2,
         )
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         w_before = brain.W_cortex_sh.clone().detach()
 
@@ -1058,7 +1059,7 @@ class TestMultiEpochCaching:
             num_cortex_reinforce_epochs=1,
         )
         brain = HybridQuantumCortexBrain(config=config, num_actions=4)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=0.0)
 
         # Should complete without error
         for i in range(6):

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantumcortex.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_hybridquantumcortex.py
@@ -31,7 +31,11 @@ def _stage1_config(**overrides: Any) -> HybridQuantumCortexBrainConfig:
         "seed": 42,
     }
     defaults.update(overrides)
-    return HybridQuantumCortexBrainConfig(**defaults)
+    return HybridQuantumCortexBrainConfig(
+        cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        **defaults,
+    )
 
 
 def _stage2_config(**overrides: Any) -> HybridQuantumCortexBrainConfig:
@@ -41,6 +45,7 @@ def _stage2_config(**overrides: Any) -> HybridQuantumCortexBrainConfig:
         "shots": 100,
         "num_qsnn_timesteps": 1,
         "num_cortex_timesteps": 1,
+        "sensory_modules": [ModuleName.FOOD_CHEMOTAXIS],
         "cortex_sensory_modules": [
             ModuleName.FOOD_CHEMOTAXIS,
             ModuleName.NOCICEPTION,
@@ -63,7 +68,10 @@ class TestHybridQuantumCortexBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = HybridQuantumCortexBrainConfig()
+        config = HybridQuantumCortexBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
         assert config.num_sensory_neurons == 8
         assert config.num_hidden_neurons == 16
         assert config.num_motor_neurons == 4
@@ -82,64 +90,103 @@ class TestHybridQuantumCortexBrainConfig:
     def test_validation_training_stage_valid(self):
         """Test all valid training stages are accepted."""
         for stage in (1, 2, 3, 4):
-            modules = [ModuleName.FOOD_CHEMOTAXIS] if stage >= 2 else None
             config = HybridQuantumCortexBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
                 training_stage=stage,
-                cortex_sensory_modules=modules,
             )
             assert config.training_stage == stage
 
     def test_validation_training_stage_invalid(self):
         """Test validation rejects invalid training stage."""
         with pytest.raises(ValueError, match="training_stage must be 1, 2, 3, or 4"):
-            HybridQuantumCortexBrainConfig(training_stage=0)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                training_stage=0,
+            )
         with pytest.raises(ValueError, match="training_stage must be 1, 2, 3, or 4"):
-            HybridQuantumCortexBrainConfig(training_stage=5)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                training_stage=5,
+            )
 
     def test_validation_cortex_neurons_per_group(self):
         """Test validation rejects cortex_neurons_per_group < 2."""
         with pytest.raises(ValueError, match="cortex_neurons_per_group must be >= 2"):
-            HybridQuantumCortexBrainConfig(cortex_neurons_per_group=1)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                cortex_neurons_per_group=1,
+            )
 
     def test_validation_cortex_hidden_neurons(self):
         """Test validation rejects cortex_hidden_neurons < 4."""
         with pytest.raises(ValueError, match="cortex_hidden_neurons must be >= 4"):
-            HybridQuantumCortexBrainConfig(cortex_hidden_neurons=3)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                cortex_hidden_neurons=3,
+            )
 
     def test_validation_num_modes(self):
         """Test validation rejects num_modes < 2."""
         with pytest.raises(ValueError, match="num_modes must be >= 2"):
-            HybridQuantumCortexBrainConfig(num_modes=1)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_modes=1,
+            )
 
     def test_validation_cortex_modules_required_stage2(self):
-        """Test validation requires cortex_sensory_modules for stage >= 2."""
-        with pytest.raises(ValueError, match="cortex_sensory_modules must be non-empty"):
-            HybridQuantumCortexBrainConfig(training_stage=2)
+        """Test validation requires non-empty cortex_sensory_modules for stage >= 2."""
         with pytest.raises(ValueError, match="cortex_sensory_modules must be non-empty"):
             HybridQuantumCortexBrainConfig(
-                training_stage=3,
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
                 cortex_sensory_modules=[],
+                training_stage=2,
+            )
+        with pytest.raises(ValueError, match="cortex_sensory_modules must be non-empty"):
+            HybridQuantumCortexBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                cortex_sensory_modules=[],
+                training_stage=3,
             )
 
     def test_validation_shots_too_low(self):
         """Test validation rejects shots below minimum."""
         with pytest.raises(ValueError, match="shots must be >= 100"):
-            HybridQuantumCortexBrainConfig(shots=50)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                shots=50,
+            )
 
     def test_validation_membrane_tau(self):
         """Test validation rejects membrane_tau outside (0, 1]."""
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            HybridQuantumCortexBrainConfig(membrane_tau=0.0)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                membrane_tau=0.0,
+            )
 
     def test_validation_threshold(self):
         """Test validation rejects threshold outside (0, 1)."""
         with pytest.raises(ValueError, match="threshold must be in"):
-            HybridQuantumCortexBrainConfig(threshold=0.0)
+            HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                threshold=0.0,
+            )
 
     def test_validation_cortex_output_neurons_too_small(self):
         """Test validation rejects cortex_output_neurons < num_motor + num_modes + 1."""
         with pytest.raises(ValueError, match="cortex_output_neurons must be >="):
             HybridQuantumCortexBrainConfig(
+                cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
                 num_motor_neurons=4,
                 num_modes=3,
                 cortex_output_neurons=7,  # needs 4+3+1=8
@@ -148,6 +195,8 @@ class TestHybridQuantumCortexBrainConfig:
     def test_validation_cortex_output_neurons_exact_minimum(self):
         """Test cortex_output_neurons == num_motor + num_modes + 1 is accepted."""
         config = HybridQuantumCortexBrainConfig(
+            cortex_sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_motor_neurons=4,
             num_modes=3,
             cortex_output_neurons=8,
@@ -375,6 +424,7 @@ class TestStageAwareTraining:
             shots=100,
             num_qsnn_timesteps=1,
             num_cortex_timesteps=1,
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             cortex_sensory_modules=[
                 ModuleName.FOOD_CHEMOTAXIS,
                 ModuleName.NOCICEPTION,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_mlpppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_mlpppo.py
@@ -240,8 +240,8 @@ class TestMLPPPOBrain:
     def test_preprocess(self, brain):
         """Test state preprocessing."""
         params = BrainParams(
-            gradient_strength=0.8,
-            gradient_direction=1.5,
+            food_gradient_strength=0.8,
+            food_gradient_direction=1.5,
             agent_position=(2, 3),
             agent_direction=Direction.UP,
         )
@@ -292,8 +292,8 @@ class TestMLPPPOBrain:
     def test_run_brain(self, brain):
         """Test running the brain for decision making."""
         params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_position=(1, 1),
             agent_direction=Direction.UP,
         )
@@ -315,8 +315,8 @@ class TestMLPPPOBrain:
     def test_learn_adds_to_buffer(self, brain):
         """Test that learn adds experience to buffer."""
         params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_position=(1, 1),
             agent_direction=Direction.UP,
         )
@@ -334,8 +334,8 @@ class TestMLPPPOBrain:
     def test_learn_triggers_update_when_buffer_full(self, brain):
         """Test that PPO update is triggered when buffer is full."""
         params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_position=(1, 1),
             agent_direction=Direction.UP,
         )
@@ -352,8 +352,8 @@ class TestMLPPPOBrain:
     def test_ppo_update(self, brain):
         """Test PPO update mechanics."""
         params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_position=(1, 1),
             agent_direction=Direction.UP,
         )
@@ -443,8 +443,8 @@ class TestMLPPPOBrainIntegration:
 
         for step in range(10):
             params = BrainParams(
-                gradient_strength=rng.random(),
-                gradient_direction=rng.random() * 2 * np.pi,
+                food_gradient_strength=rng.random(),
+                food_gradient_direction=rng.random() * 2 * np.pi,
                 agent_position=(step, step),
                 agent_direction=Direction.UP,
             )
@@ -489,8 +489,8 @@ class TestMLPPPOBrainIntegration:
 
             for step in range(15):
                 params = BrainParams(
-                    gradient_strength=rng.random(),
-                    gradient_direction=rng.random() * 2 * np.pi,
+                    food_gradient_strength=rng.random(),
+                    food_gradient_direction=rng.random() * 2 * np.pi,
                     agent_position=(step, step),
                     agent_direction=Direction.UP,
                 )
@@ -523,7 +523,7 @@ class TestMLPPPOBrainIntegration:
             device=DeviceType.CPU,
         )
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Collect experience and trigger update
         for i in range(25):
@@ -551,7 +551,7 @@ class TestMLPPPOBrainIntegration:
         torch.manual_seed(42)
         brain2 = MLPPPOBrain(config=config, input_dim=2, num_actions=4, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Set same seed for action sampling
         torch.manual_seed(123)
@@ -582,7 +582,7 @@ class TestMLPPPOBrainIntegration:
         )
 
         # Train on experiences where this state leads to positive reward
-        params = BrainParams(gradient_strength=1.0, gradient_direction=0.0)
+        params = BrainParams(food_gradient_strength=1.0, food_gradient_direction=0.0)
 
         for _episode in range(5):
             for step in range(25):
@@ -819,7 +819,7 @@ class TestMLPPPOClipping:
 
     def test_clipping_prevents_large_updates(self, brain):
         """Test that clipping limits policy changes."""
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Get initial policy output
         state = brain.preprocess(params)
@@ -957,8 +957,8 @@ class TestFeatureExpansion:
     def test_expansion_run_brain(self):
         """run_brain should work with all expansion modes."""
         params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_position=(1, 1),
             agent_direction=Direction.UP,
         )
@@ -1089,8 +1089,8 @@ class TestFeatureGating:
         )
         brain = MLPPPOBrain(config=config, num_actions=4, device=DeviceType.CPU)
         params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_position=(1, 1),
             agent_direction=Direction.UP,
         )

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_mlpppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_mlpppo.py
@@ -5,6 +5,7 @@ from typing import Literal
 import numpy as np
 import pytest
 import torch
+from pydantic import ValidationError
 from quantumnematode.brain.actions import Action, ActionData
 from quantumnematode.brain.arch import BrainParams
 from quantumnematode.brain.arch.dtypes import DeviceType
@@ -56,6 +57,11 @@ class TestMLPPPOBrainConfig:
         assert config.gamma == 0.95
         assert config.clip_epsilon == 0.1
         assert config.rollout_buffer_size == 256
+
+    def test_validation_sensory_modules_non_empty(self):
+        """Test validation rejects empty sensory_modules."""
+        with pytest.raises(ValidationError):
+            MLPPPOBrainConfig(sensory_modules=[])
 
 
 class TestRolloutBuffer:

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_mlpppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_mlpppo.py
@@ -18,7 +18,9 @@ class TestMLPPPOBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = MLPPPOBrainConfig()
+        config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
 
         assert config.actor_hidden_dim == 64
         assert config.critic_hidden_dim == 64
@@ -37,6 +39,7 @@ class TestMLPPPOBrainConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             actor_hidden_dim=128,
             critic_hidden_dim=128,
             num_hidden_layers=3,
@@ -187,6 +190,7 @@ class TestMLPPPOBrain:
     def config(self) -> MLPPPOBrainConfig:
         """Create a test configuration."""
         return MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             actor_hidden_dim=32,
             critic_hidden_dim=32,
             num_hidden_layers=2,
@@ -418,6 +422,7 @@ class TestMLPPPOBrainIntegration:
     def test_full_episode_workflow(self):
         """Test a complete episode workflow."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             actor_hidden_dim=16,
             critic_hidden_dim=16,
             learning_rate=0.01,
@@ -462,6 +467,7 @@ class TestMLPPPOBrainIntegration:
     def test_multiple_episodes(self):
         """Test running multiple episodes."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             actor_hidden_dim=16,
             critic_hidden_dim=16,
             learning_rate=0.001,
@@ -501,6 +507,7 @@ class TestMLPPPOBrainIntegration:
     def test_gradient_clipping(self):
         """Test that gradient clipping is applied."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             actor_hidden_dim=16,
             critic_hidden_dim=16,
             learning_rate=1.0,  # Very high LR to potentially cause large gradients
@@ -531,7 +538,11 @@ class TestMLPPPOBrainIntegration:
 
     def test_deterministic_action_selection(self):
         """Test that action selection is deterministic with same seed."""
-        config = MLPPPOBrainConfig(actor_hidden_dim=16, critic_hidden_dim=16)
+        config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            actor_hidden_dim=16,
+            critic_hidden_dim=16,
+        )
 
         # Create two brains with same weights
         torch.manual_seed(42)
@@ -555,6 +566,7 @@ class TestMLPPPOBrainIntegration:
     def test_value_estimates_remain_finite_with_learning(self):
         """Test that value estimates remain finite during training."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             actor_hidden_dim=32,
             critic_hidden_dim=32,
             learning_rate=0.01,
@@ -591,7 +603,10 @@ class TestLRScheduling:
 
     def test_lr_scheduling_disabled_by_default(self):
         """Test that LR scheduling is disabled when no warmup episodes set."""
-        config = MLPPPOBrainConfig(learning_rate=0.001)
+        config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            learning_rate=0.001,
+        )
         brain = MLPPPOBrain(
             config=config,
             input_dim=2,
@@ -605,6 +620,7 @@ class TestLRScheduling:
     def test_lr_warmup_enabled(self):
         """Test that LR warmup can be enabled via config."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             learning_rate=0.001,
             lr_warmup_episodes=50,
             lr_warmup_start=0.0001,
@@ -624,6 +640,7 @@ class TestLRScheduling:
     def test_lr_warmup_default_start(self):
         """Test that lr_warmup_start defaults to 10% of base LR."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             learning_rate=0.001,
             lr_warmup_episodes=50,
             # lr_warmup_start not set
@@ -640,6 +657,7 @@ class TestLRScheduling:
     def test_lr_warmup_progression(self):
         """Test that LR increases linearly during warmup phase."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             learning_rate=0.001,
             lr_warmup_episodes=100,
             lr_warmup_start=0.0001,
@@ -671,6 +689,7 @@ class TestLRScheduling:
     def test_lr_decay_after_warmup(self):
         """Test that LR decays after warmup when decay is configured."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             learning_rate=0.001,
             lr_warmup_episodes=50,
             lr_warmup_start=0.0001,
@@ -708,6 +727,7 @@ class TestLRScheduling:
     def test_lr_decay_default_end(self):
         """Test that lr_decay_end defaults to 10% of base LR."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             learning_rate=0.001,
             lr_warmup_episodes=50,
             lr_decay_episodes=100,
@@ -725,6 +745,7 @@ class TestLRScheduling:
     def test_update_learning_rate_modifies_optimizer(self):
         """Test that _update_learning_rate actually updates the optimizer."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             learning_rate=0.001,
             lr_warmup_episodes=100,
             lr_warmup_start=0.0001,
@@ -751,7 +772,10 @@ class TestLRScheduling:
 
     def test_lr_scheduling_no_update_when_disabled(self):
         """Test that _update_learning_rate does nothing when scheduling disabled."""
-        config = MLPPPOBrainConfig(learning_rate=0.001)
+        config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            learning_rate=0.001,
+        )
         brain = MLPPPOBrain(
             config=config,
             input_dim=2,
@@ -774,6 +798,7 @@ class TestMLPPPOClipping:
     def brain(self):
         """Create a brain for clipping tests."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             actor_hidden_dim=16,
             critic_hidden_dim=16,
             clip_epsilon=0.2,
@@ -848,7 +873,9 @@ class TestFeatureExpansion:
 
     def test_config_defaults(self):
         """Feature expansion and gating should default to none/false."""
-        config = MLPPPOBrainConfig()
+        config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
         assert config.feature_expansion == "none"
         assert config.feature_gating is False
 
@@ -974,6 +1001,7 @@ class TestFeatureGating:
     def test_gating_without_expansion_raises(self):
         """Gating with no expansion should raise ValueError."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             feature_gating=True,
             feature_expansion="none",
             actor_hidden_dim=16,
@@ -1072,15 +1100,17 @@ class TestFeatureGating:
     def test_gating_gradient_flows(self):
         """Gate weights should receive non-zero gradients when expanded features are non-zero."""
         config = MLPPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             feature_expansion="polynomial",
             feature_gating=True,
             actor_hidden_dim=16,
             num_hidden_layers=2,
         )
-        brain = MLPPPOBrain(config=config, input_dim=3, num_actions=4, device=DeviceType.CPU)
+        brain = MLPPPOBrain(config=config, num_actions=4, device=DeviceType.CPU)
 
         # Non-zero input so polynomial products are non-zero
-        x = torch.tensor([0.5, 0.3, 0.8, 0.15, 0.40, 0.24], dtype=torch.float32)
+        # 2 raw features + 1 pairwise product = 3 total with polynomial expansion
+        x = torch.tensor([0.5, 0.3, 0.15], dtype=torch.float32)
         logits = brain.forward_actor(x)
         loss = logits.sum()
         loss.backward()

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qliflstm.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qliflstm.py
@@ -450,8 +450,8 @@ class TestQLIFLSTMBrain:
     def params(self) -> BrainParams:
         """Create test BrainParams."""
         return BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_direction=Direction.UP,
         )
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qliflstm.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qliflstm.py
@@ -26,7 +26,9 @@ class TestQLIFLSTMBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = QLIFLSTMBrainConfig()
+        config = QLIFLSTMBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
         assert config.lstm_hidden_dim == 32
         assert config.shots == 1024
         assert config.membrane_tau == 0.9
@@ -51,6 +53,7 @@ class TestQLIFLSTMBrainConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = QLIFLSTMBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             lstm_hidden_dim=16,
             shots=512,
             gamma=0.95,
@@ -66,29 +69,29 @@ class TestQLIFLSTMBrainConfig:
     def test_invalid_lstm_hidden_dim(self):
         """Test validation rejects too small hidden dim."""
         with pytest.raises(ValueError, match="lstm_hidden_dim must be >= 2"):
-            QLIFLSTMBrainConfig(lstm_hidden_dim=1)
+            QLIFLSTMBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], lstm_hidden_dim=1)
 
     def test_invalid_shots(self):
         """Test validation rejects too few shots."""
         with pytest.raises(ValueError, match="shots must be >= 100"):
-            QLIFLSTMBrainConfig(shots=50)
+            QLIFLSTMBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], shots=50)
 
     def test_invalid_membrane_tau(self):
         """Test validation rejects out-of-range membrane_tau."""
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            QLIFLSTMBrainConfig(membrane_tau=0.0)
+            QLIFLSTMBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], membrane_tau=0.0)
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            QLIFLSTMBrainConfig(membrane_tau=1.5)
+            QLIFLSTMBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], membrane_tau=1.5)
 
     def test_invalid_num_epochs(self):
         """Test validation rejects zero epochs."""
         with pytest.raises(ValueError, match="num_epochs must be >= 1"):
-            QLIFLSTMBrainConfig(num_epochs=0)
+            QLIFLSTMBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], num_epochs=0)
 
     def test_invalid_bptt_chunk_length(self):
         """Test validation rejects too small chunk length."""
         with pytest.raises(ValueError, match="bptt_chunk_length must be >= 4"):
-            QLIFLSTMBrainConfig(bptt_chunk_length=2)
+            QLIFLSTMBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], bptt_chunk_length=2)
 
     def test_sensory_modules_config(self):
         """Test sensory module configuration."""
@@ -429,6 +432,7 @@ class TestQLIFLSTMBrain:
     def config(self) -> QLIFLSTMBrainConfig:
         """Create a small test configuration (classical mode)."""
         return QLIFLSTMBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             lstm_hidden_dim=8,
             use_quantum_gates=False,
             rollout_buffer_size=8,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qrc.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qrc.py
@@ -16,7 +16,7 @@ class TestQRCBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = QRCBrainConfig()
+        config = QRCBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
 
         assert config.num_reservoir_qubits == 8
         assert config.reservoir_depth == 3
@@ -31,6 +31,7 @@ class TestQRCBrainConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=4,
             reservoir_depth=2,
             reservoir_seed=123,
@@ -50,11 +51,6 @@ class TestQRCBrainConfig:
         assert config.gamma == 0.95
         assert config.learning_rate == 0.005
 
-    def test_config_sensory_modules_default(self):
-        """Test that sensory_modules defaults to None (legacy mode)."""
-        config = QRCBrainConfig()
-        assert config.sensory_modules is None
-
     def test_config_with_sensory_modules(self):
         """Test configuration with sensory modules."""
         config = QRCBrainConfig(
@@ -69,27 +65,27 @@ class TestQRCBrainConfig:
     def test_validation_num_reservoir_qubits(self):
         """Test validation for num_reservoir_qubits."""
         with pytest.raises(ValueError, match="num_reservoir_qubits must be >= 2"):
-            QRCBrainConfig(num_reservoir_qubits=1)
+            QRCBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], num_reservoir_qubits=1)
 
     def test_validation_reservoir_depth(self):
         """Test validation for reservoir_depth."""
         with pytest.raises(ValueError, match="reservoir_depth must be >= 1"):
-            QRCBrainConfig(reservoir_depth=0)
+            QRCBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], reservoir_depth=0)
 
     def test_validation_readout_hidden(self):
         """Test validation for readout_hidden."""
         with pytest.raises(ValueError, match="readout_hidden must be >= 1"):
-            QRCBrainConfig(readout_hidden=0)
+            QRCBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], readout_hidden=0)
 
     def test_validation_shots(self):
         """Test validation for shots."""
         with pytest.raises(ValueError, match="shots must be >= 100"):
-            QRCBrainConfig(shots=50)
+            QRCBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], shots=50)
 
     def test_validation_readout_type(self):
         """Test validation for readout_type."""
         with pytest.raises(ValueError, match="readout_type must be one of"):
-            QRCBrainConfig(readout_type="invalid")
+            QRCBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], readout_type="invalid")
 
 
 class TestQRCBrainReservoirCircuit:
@@ -99,6 +95,7 @@ class TestQRCBrainReservoirCircuit:
     def small_config(self) -> QRCBrainConfig:
         """Create a small test configuration for faster tests."""
         return QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=2,
             reservoir_seed=42,
@@ -155,12 +152,14 @@ class TestQRCBrainReservoirCircuit:
     def test_reservoir_reproducibility(self):
         """Same seed should produce identical reservoir circuits and outputs."""
         config1 = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=2,
             reservoir_seed=42,
             shots=200,
         )
         config2 = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=2,
             reservoir_seed=42,
@@ -197,11 +196,13 @@ class TestQRCBrainReservoirCircuit:
     def test_different_seeds_different_circuits(self):
         """Different seeds should produce different reservoir circuits."""
         config1 = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=2,
             reservoir_seed=42,
         )
         config2 = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=2,
             reservoir_seed=123,
@@ -238,6 +239,7 @@ class TestQRCBrainInputEncoding:
     def brain(self) -> QRCBrain:
         """Create a test QRC brain."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=4,
             reservoir_depth=2,
             shots=100,
@@ -247,26 +249,26 @@ class TestQRCBrainInputEncoding:
     def test_preprocess(self, brain):
         """Test state preprocessing extracts correct features."""
         params = BrainParams(
-            gradient_strength=0.8,
-            gradient_direction=1.5,
+            food_gradient_strength=0.8,
+            food_gradient_direction=1.5,
             agent_position=(2, 3),
             agent_direction=Direction.UP,
         )
 
         features = brain.preprocess(params)
         assert isinstance(features, np.ndarray)
-        assert len(features) == 2  # gradient_strength, relative_angle
+        assert len(features) == 2  # food strength, food relative angle
         assert features.dtype == np.float32
-        assert features[0] == 0.8  # gradient_strength
+        assert features[0] == pytest.approx(0.8)  # food strength
         assert -1.0 <= features[1] <= 1.0  # Normalized relative angle
 
     def test_preprocess_none_values(self, brain):
-        """Test preprocessing with None values defaults correctly."""
+        """Test preprocessing with no food signal defaults correctly."""
         params = BrainParams()
         features = brain.preprocess(params)
 
         assert len(features) == 2
-        assert features[0] == 0.0  # gradient_strength defaults to 0
+        assert features[0] == 0.0  # food strength defaults to 0
 
     def test_input_encoding_angle_calculation(self, brain):
         """Test RY angle calculation for input encoding."""
@@ -333,28 +335,6 @@ class TestQRCBrainSensoryModules:
         assert 0.0 <= features[2] <= 1.0  # predator strength [0, 1]
         assert -1.0 <= features[3] <= 1.0  # predator angle [-1, 1]
 
-    def test_legacy_mode_when_no_sensory_modules(self):
-        """Test that brain uses legacy preprocessing when sensory_modules is None."""
-        config = QRCBrainConfig(
-            num_reservoir_qubits=4,
-            reservoir_depth=2,
-            shots=100,
-            # No sensory_modules - legacy mode
-        )
-        brain = QRCBrain(config=config, num_actions=4, device=DeviceType.CPU)
-
-        assert brain.sensory_modules is None
-        assert brain.input_dim == 2  # Legacy mode: gradient_strength + relative_angle
-
-        params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
-            agent_direction=Direction.UP,
-        )
-        features = brain.preprocess(params)
-
-        assert len(features) == 2
-
 
 class TestQRCBrainReadoutNetwork:
     """Test cases for readout network architecture."""
@@ -362,6 +342,7 @@ class TestQRCBrainReadoutNetwork:
     def test_mlp_readout_architecture(self):
         """Test MLP readout has correct layer dimensions."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,  # 2^3 = 8 input dim
             readout_hidden=16,
             readout_type="mlp",
@@ -382,6 +363,7 @@ class TestQRCBrainReadoutNetwork:
     def test_linear_readout_architecture(self):
         """Test linear readout has correct layer dimensions."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,  # 2^3 = 8 input dim
             readout_type="linear",
         )
@@ -405,6 +387,7 @@ class TestQRCBrainLearning:
     def brain(self) -> QRCBrain:
         """Create a test QRC brain."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=1,
             readout_hidden=8,
@@ -486,6 +469,7 @@ class TestQRCBrainCopy:
     def brain(self) -> QRCBrain:
         """Create a test QRC brain."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=1,
             readout_hidden=8,
@@ -549,6 +533,7 @@ class TestQRCBrainIntegration:
     def test_full_episode_workflow(self):
         """Test a complete episode workflow."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=1,
             readout_hidden=8,
@@ -585,6 +570,7 @@ class TestQRCBrainIntegration:
     def test_baseline_updates(self):
         """Test that baseline is updated during learning."""
         config = QRCBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_reservoir_qubits=3,
             reservoir_depth=1,
             shots=100,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qrc.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qrc.py
@@ -547,8 +547,8 @@ class TestQRCBrainIntegration:
 
         for step in range(10):
             params = BrainParams(
-                gradient_strength=rng.random(),
-                gradient_direction=rng.random() * 2 * np.pi,
+                food_gradient_strength=rng.random(),
+                food_gradient_direction=rng.random() * 2 * np.pi,
                 agent_position=(step, step),
                 agent_direction=Direction.UP,
             )
@@ -578,7 +578,7 @@ class TestQRCBrainIntegration:
         )
         brain = QRCBrain(config=config, num_actions=4, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Initial baseline
         initial_baseline = brain.baseline

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnppo.py
@@ -25,7 +25,9 @@ class TestQSNNPPOBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = QSNNPPOBrainConfig()
+        config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
         assert config.num_sensory_neurons == 8
         assert config.num_hidden_neurons == 16
         assert config.num_motor_neurons == 4
@@ -50,6 +52,7 @@ class TestQSNNPPOBrainConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=4,
             num_hidden_neurons=8,
             num_motor_neurons=2,
@@ -71,36 +74,36 @@ class TestQSNNPPOBrainConfig:
     def test_invalid_num_sensory_neurons(self):
         """Test validation rejects invalid sensory neuron count."""
         with pytest.raises(ValueError, match="num_sensory_neurons must be >= 1"):
-            QSNNPPOBrainConfig(num_sensory_neurons=0)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], num_sensory_neurons=0)
 
     def test_invalid_num_motor_neurons(self):
         """Test validation rejects too few motor neurons."""
         with pytest.raises(ValueError, match="num_motor_neurons must be >= 2"):
-            QSNNPPOBrainConfig(num_motor_neurons=1)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], num_motor_neurons=1)
 
     def test_invalid_membrane_tau(self):
         """Test validation rejects out-of-range membrane_tau."""
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            QSNNPPOBrainConfig(membrane_tau=0.0)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], membrane_tau=0.0)
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            QSNNPPOBrainConfig(membrane_tau=1.5)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], membrane_tau=1.5)
 
     def test_invalid_threshold(self):
         """Test validation rejects out-of-range threshold."""
         with pytest.raises(ValueError, match="threshold must be in"):
-            QSNNPPOBrainConfig(threshold=0.0)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], threshold=0.0)
         with pytest.raises(ValueError, match="threshold must be in"):
-            QSNNPPOBrainConfig(threshold=1.0)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], threshold=1.0)
 
     def test_invalid_shots(self):
         """Test validation rejects too few shots."""
         with pytest.raises(ValueError, match="shots must be >= 100"):
-            QSNNPPOBrainConfig(shots=50)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], shots=50)
 
     def test_invalid_num_epochs(self):
         """Test validation rejects zero epochs."""
         with pytest.raises(ValueError, match="num_epochs must be >= 1"):
-            QSNNPPOBrainConfig(num_epochs=0)
+            QSNNPPOBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], num_epochs=0)
 
     def test_sensory_modules_config(self):
         """Test sensory module configuration."""
@@ -340,6 +343,7 @@ class TestQSNNPPOBrainInit:
     def config(self) -> QSNNPPOBrainConfig:
         """Create a small test configuration."""
         return QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=4,
             num_hidden_neurons=4,
             num_motor_neurons=2,
@@ -407,6 +411,7 @@ class TestQSNNPPOBrainInit:
         from quantumnematode.brain.actions import Action
 
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -428,6 +433,7 @@ class TestQSNNPPOBrainInit:
     def test_lr_scheduler_created(self):
         """Test LR scheduler created when lr_decay_episodes is set."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -448,37 +454,16 @@ class TestQSNNPPOBrainPreprocess:
 
     @pytest.fixture
     def brain(self) -> QSNNPPOBrain:
-        """Create a test brain with legacy preprocessing."""
+        """Create a test brain with sensory module preprocessing."""
         config = QSNNPPOBrainConfig(
             num_sensory_neurons=4,
             num_hidden_neurons=4,
             num_motor_neurons=2,
             shots=100,
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             seed=42,
         )
         return QSNNPPOBrain(config=config, num_actions=2, device=DeviceType.CPU)
-
-    def test_legacy_preprocess(self, brain: QSNNPPOBrain):
-        """Test legacy 2-feature preprocessing."""
-        params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
-            agent_direction=Direction.UP,
-        )
-        features = brain.preprocess(params)
-        assert isinstance(features, np.ndarray)
-        assert len(features) == 2
-        assert features.dtype == np.float32
-
-    def test_legacy_preprocess_zero_strength(self, brain: QSNNPPOBrain):
-        """Test preprocessing with zero gradient strength."""
-        params = BrainParams(
-            gradient_strength=0.0,
-            gradient_direction=0.0,
-            agent_direction=Direction.UP,
-        )
-        features = brain.preprocess(params)
-        assert features[0] == 0.0  # gradient_strength
 
     def test_sensory_module_preprocess(self):
         """Test preprocessing with unified sensory modules."""
@@ -535,6 +520,7 @@ class TestQSNNPPOBrainForwardPass:
     def brain(self) -> QSNNPPOBrain:
         """Create a small test brain."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -610,6 +596,7 @@ class TestQSNNPPOBrainLearning:
     def brain(self) -> QSNNPPOBrain:
         """Create a test brain for learning tests."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -791,6 +778,7 @@ class TestQSNNPPOBrainEpisode:
     def brain(self) -> QSNNPPOBrain:
         """Create a test brain."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -825,6 +813,7 @@ class TestQSNNPPOBrainEpisode:
     def test_lr_scheduler_step(self):
         """Test LR scheduler steps on episode end."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -872,6 +861,7 @@ class TestQSNNPPOBrainReproducibility:
     def test_deterministic_with_seed(self):
         """Test that identical seeds produce identical actions."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -901,6 +891,7 @@ class TestQSNNPPOBrainReproducibility:
     def test_different_seeds_produce_different_weights(self):
         """Test that different seeds produce different initial weights."""
         config1 = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -908,6 +899,7 @@ class TestQSNNPPOBrainReproducibility:
             seed=42,
         )
         config2 = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -933,6 +925,7 @@ class TestQSNNPPOBrainIntegration:
     def brain(self) -> QSNNPPOBrain:
         """Create a brain for integration tests."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=4,
             num_hidden_neurons=4,
             num_motor_neurons=2,
@@ -1058,6 +1051,7 @@ class TestQSNNPPOBrainErrors:
     def test_copy_not_implemented(self):
         """Test copy raises NotImplementedError."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1071,6 +1065,7 @@ class TestQSNNPPOBrainErrors:
     def test_build_brain_not_implemented(self):
         """Test build_brain raises NotImplementedError."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1084,6 +1079,7 @@ class TestQSNNPPOBrainErrors:
     def test_action_set_setter_validates_length(self):
         """Test action_set setter validates length."""
         config = QSNNPPOBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnppo.py
@@ -533,8 +533,8 @@ class TestQSNNPPOBrainForwardPass:
     def test_run_brain_returns_action(self, brain: QSNNPPOBrain):
         """Test run_brain returns valid action data."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -548,8 +548,8 @@ class TestQSNNPPOBrainForwardPass:
     def test_run_brain_stores_pending_data(self, brain: QSNNPPOBrain):
         """Test run_brain stores pending data for learn()."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
         brain.run_brain(params, top_only=True, top_randomize=True)
@@ -561,8 +561,8 @@ class TestQSNNPPOBrainForwardPass:
     def test_action_probabilities_sum_to_one(self, brain: QSNNPPOBrain):
         """Test action probabilities sum to 1."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
         brain.run_brain(params, top_only=True, top_randomize=True)
@@ -574,8 +574,8 @@ class TestQSNNPPOBrainForwardPass:
     def test_history_tracking(self, brain: QSNNPPOBrain):
         """Test that actions are tracked in history."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
         brain.run_brain(params, top_only=True, top_randomize=True)
@@ -612,8 +612,8 @@ class TestQSNNPPOBrainLearning:
     def test_learn_adds_to_buffer(self, brain: QSNNPPOBrain):
         """Test learn() adds experiences to buffer."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -625,8 +625,8 @@ class TestQSNNPPOBrainLearning:
     def test_buffer_triggers_ppo_update(self, brain: QSNNPPOBrain):
         """Test PPO update triggers when buffer is full."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -640,8 +640,8 @@ class TestQSNNPPOBrainLearning:
     def test_episode_done_does_not_trigger_update(self, brain: QSNNPPOBrain):
         """Test buffer persists across episodes until full."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -655,8 +655,8 @@ class TestQSNNPPOBrainLearning:
     def test_ppo_update_changes_actor_weights(self, brain: QSNNPPOBrain):
         """Test PPO update modifies actor weights."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -673,8 +673,8 @@ class TestQSNNPPOBrainLearning:
     def test_ppo_update_changes_critic_weights(self, brain: QSNNPPOBrain):
         """Test PPO update modifies critic weights."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -754,8 +754,8 @@ class TestQSNNPPOBrainLearning:
     def test_rewards_stored_in_history(self, brain: QSNNPPOBrain):
         """Test rewards are recorded in history."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -834,8 +834,8 @@ class TestQSNNPPOBrainEpisode:
     def test_multiple_episodes(self, brain: QSNNPPOBrain):
         """Test running multiple complete episodes."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -878,8 +878,8 @@ class TestQSNNPPOBrainReproducibility:
         )
 
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -941,8 +941,8 @@ class TestQSNNPPOBrainIntegration:
     def test_full_training_episode(self, brain: QSNNPPOBrain):
         """Test a complete training episode workflow."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 
@@ -963,13 +963,13 @@ class TestQSNNPPOBrainIntegration:
         """Test training across multiple episodes."""
         params_list = [
             BrainParams(
-                gradient_strength=0.3,
-                gradient_direction=0.0,
+                food_gradient_strength=0.3,
+                food_gradient_direction=0.0,
                 agent_direction=Direction.UP,
             ),
             BrainParams(
-                gradient_strength=0.8,
-                gradient_direction=1.5,
+                food_gradient_strength=0.8,
+                food_gradient_direction=1.5,
                 agent_direction=Direction.RIGHT,
             ),
         ]
@@ -987,8 +987,8 @@ class TestQSNNPPOBrainIntegration:
     def test_varying_reward_signals(self, brain: QSNNPPOBrain):
         """Test brain handles varying reward magnitudes."""
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             agent_direction=Direction.UP,
         )
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnreinforce.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnreinforce.py
@@ -42,7 +42,9 @@ class TestQSNNReinforceBrainConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+        )
 
         assert config.num_sensory_neurons == 6
         assert config.num_hidden_neurons == 8
@@ -58,6 +60,7 @@ class TestQSNNReinforceBrainConfig:
     def test_custom_config(self):
         """Test custom configuration values."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=8,
             num_hidden_neurons=6,
             num_motor_neurons=5,
@@ -81,11 +84,6 @@ class TestQSNNReinforceBrainConfig:
         assert config.gamma == 0.95
         assert config.learning_rate == 0.005
 
-    def test_config_sensory_modules_default(self):
-        """Test that sensory_modules defaults to None (legacy mode)."""
-        config = QSNNReinforceBrainConfig()
-        assert config.sensory_modules is None
-
     def test_config_with_sensory_modules(self):
         """Test configuration with sensory modules."""
         config = QSNNReinforceBrainConfig(
@@ -100,43 +98,55 @@ class TestQSNNReinforceBrainConfig:
     def test_validation_num_sensory_neurons(self):
         """Test validation for num_sensory_neurons."""
         with pytest.raises(ValueError, match="num_sensory_neurons must be >= 1"):
-            QSNNReinforceBrainConfig(num_sensory_neurons=0)
+            QSNNReinforceBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_sensory_neurons=0,
+            )
 
     def test_validation_num_hidden_neurons(self):
         """Test validation for num_hidden_neurons."""
         with pytest.raises(ValueError, match="num_hidden_neurons must be >= 1"):
-            QSNNReinforceBrainConfig(num_hidden_neurons=0)
+            QSNNReinforceBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_hidden_neurons=0,
+            )
 
     def test_validation_num_motor_neurons(self):
         """Test validation for num_motor_neurons."""
         with pytest.raises(ValueError, match="num_motor_neurons must be >= 2"):
-            QSNNReinforceBrainConfig(num_motor_neurons=1)
+            QSNNReinforceBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_motor_neurons=1,
+            )
 
     def test_validation_membrane_tau_lower_bound(self):
         """Test validation for membrane_tau lower bound."""
         with pytest.raises(ValueError, match="membrane_tau must be in"):
-            QSNNReinforceBrainConfig(membrane_tau=0.0)
+            QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], membrane_tau=0.0)
 
     def test_validation_membrane_tau_upper_bound(self):
         """Test validation for membrane_tau at upper bound."""
         # Upper bound is inclusive (0, 1]
-        config = QSNNReinforceBrainConfig(membrane_tau=1.0)
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            membrane_tau=1.0,
+        )
         assert config.membrane_tau == 1.0
 
     def test_validation_threshold_lower_bound(self):
         """Test validation for threshold lower bound."""
         with pytest.raises(ValueError, match="threshold must be in"):
-            QSNNReinforceBrainConfig(threshold=0.0)
+            QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], threshold=0.0)
 
     def test_validation_threshold_upper_bound(self):
         """Test validation for threshold upper bound."""
         with pytest.raises(ValueError, match="threshold must be in"):
-            QSNNReinforceBrainConfig(threshold=1.0)
+            QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], threshold=1.0)
 
     def test_validation_shots(self):
         """Test validation for shots."""
         with pytest.raises(ValueError, match="shots must be >= 100"):
-            QSNNReinforceBrainConfig(shots=50)
+            QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS], shots=50)
 
 
 class TestQSNNReinforceBrainQLIFCircuit:
@@ -146,6 +156,7 @@ class TestQSNNReinforceBrainQLIFCircuit:
     def small_config(self) -> QSNNReinforceBrainConfig:
         """Create a small test configuration for faster tests."""
         return QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -270,6 +281,7 @@ class TestQSNNReinforceBrainSensoryEncoding:
     def brain(self) -> QSNNReinforceBrain:
         """Create a test QSNN brain."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=4,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -314,6 +326,7 @@ class TestQSNNReinforceBrainForwardPass:
     def brain(self) -> QSNNReinforceBrain:
         """Create a test QSNN brain."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=4,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -385,6 +398,7 @@ class TestQSNNReinforceBrainEligibilityTrace:
     def brain(self) -> QSNNReinforceBrain:
         """Create a test QSNN brain with local learning."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -486,6 +500,7 @@ class TestQSNNReinforceBrainLocalLearning:
     def brain(self) -> QSNNReinforceBrain:
         """Create a test QSNN brain."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -680,6 +695,7 @@ class TestQSNNReinforceBrainRefractoryPeriod:
     def brain(self) -> QSNNReinforceBrain:
         """Create a test QSNN brain."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -713,12 +729,14 @@ class TestQSNNReinforceBrainReproducibility:
     def test_same_seed_same_weights(self):
         """Same seed should produce identical initial weights."""
         config1 = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             seed=42,
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
         )
         config2 = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             seed=42,
             num_sensory_neurons=2,
             num_hidden_neurons=2,
@@ -734,12 +752,14 @@ class TestQSNNReinforceBrainReproducibility:
     def test_different_seed_different_weights(self):
         """Different seeds should produce different initial weights."""
         config1 = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             seed=42,
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
         )
         config2 = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             seed=123,
             num_sensory_neurons=2,
             num_hidden_neurons=2,
@@ -763,6 +783,7 @@ class TestQSNNReinforceBrainCopy:
     def brain(self) -> QSNNReinforceBrain:
         """Create a test QSNN brain."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -848,20 +869,6 @@ class TestQSNNReinforceBrainSensoryModules:
         assert len(features) == 4  # 2 modules * 2 features each
         assert features.dtype == np.float32
 
-    def test_legacy_mode_when_no_sensory_modules(self):
-        """Test that brain uses legacy preprocessing when sensory_modules is None."""
-        config = QSNNReinforceBrainConfig(
-            num_sensory_neurons=4,
-            num_hidden_neurons=2,
-            num_motor_neurons=2,
-            shots=100,
-            # No sensory_modules - legacy mode
-        )
-        brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-
-        assert brain.sensory_modules is None
-        assert brain.input_dim == 2  # Legacy mode: gradient_strength + relative_angle
-
 
 class TestQSNNReinforceBrainIntegration:
     """Integration tests for QSNN brain with full simulation workflow."""
@@ -869,6 +876,7 @@ class TestQSNNReinforceBrainIntegration:
     def test_full_episode_workflow(self):
         """Test a complete episode workflow."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=4,
             num_hidden_neurons=2,
             num_motor_neurons=4,
@@ -905,6 +913,7 @@ class TestQSNNReinforceBrainIntegration:
     def test_multiple_episodes(self):
         """Test running multiple episodes."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=4,
             num_hidden_neurons=2,
             num_motor_neurons=4,
@@ -932,6 +941,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def brain(self) -> QSNNReinforceBrain:
         """Create a test QSNN brain in surrogate gradient mode."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -957,6 +967,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_hebbian_mode_weights_no_grad(self):
         """Test that weights do NOT have requires_grad in Hebbian mode."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1214,6 +1225,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_lr_scheduler_not_created_for_hebbian(self):
         """Test that Hebbian mode does NOT create an LR scheduler."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1297,6 +1309,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_intra_episode_reinforce_triggers(self):
         """Test that intra-episode REINFORCE fires every update_interval steps."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1323,6 +1336,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_intra_episode_reinforce_changes_weights(self):
         """Test that intra-episode REINFORCE updates actually modify weights."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1354,6 +1368,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_intra_episode_reinforce_multiple_windows(self):
         """Test that multiple intra-episode updates fire across an episode."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1383,6 +1398,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_intra_episode_reinforce_final_window_at_episode_end(self):
         """Test that remaining steps after last intra-episode update are learned at episode end."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1408,6 +1424,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_intra_episode_reinforce_not_triggered_at_episode_end(self):
         """Test that intra-episode update does NOT fire when episode_done=True on boundary."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1439,6 +1456,7 @@ class TestQSNNWeightInitialization:
     def test_w_sh_random_gaussian_shape(self):
         """Test that W_sh has correct shape after random Gaussian initialization."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=6,
             num_hidden_neurons=4,
             num_motor_neurons=4,
@@ -1451,6 +1469,7 @@ class TestQSNNWeightInitialization:
     def test_w_hm_random_gaussian_shape(self):
         """Test that W_hm has correct shape after random Gaussian initialization."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=6,
             num_hidden_neurons=8,
             num_motor_neurons=4,
@@ -1463,6 +1482,7 @@ class TestQSNNWeightInitialization:
     def test_weight_scale_approximately_correct(self):
         """Test that randn * WEIGHT_INIT_SCALE produces weights near expected magnitude."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=6,
             num_hidden_neurons=8,
             num_motor_neurons=4,
@@ -1484,6 +1504,7 @@ class TestQSNNWeightInitialization:
     def test_weight_columns_have_varied_norms(self):
         """Test that random Gaussian init produces columns with varied norms (symmetry breaking)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=16,
             num_hidden_neurons=32,
             num_motor_neurons=4,
@@ -1504,6 +1525,7 @@ class TestQSNNWeightInitialization:
     def test_theta_hidden_initialized_at_pi_over_4(self):
         """Test that theta_hidden is initialized at pi/4 for moderate warm start."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=6,
             num_hidden_neurons=8,
             num_motor_neurons=4,
@@ -1519,6 +1541,7 @@ class TestQSNNWeightInitialization:
     def test_theta_motor_initialized_at_zero(self):
         """Test that theta_motor remains initialized at zero (no action bias)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=6,
             num_hidden_neurons=8,
             num_motor_neurons=4,
@@ -1534,6 +1557,7 @@ class TestQSNNWeightInitialization:
     def test_w_hm_column_diversity_positive_at_init(self):
         """Test that random Gaussian init produces positive W_hm column diversity."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=6,
             num_hidden_neurons=8,
             num_motor_neurons=4,
@@ -1554,6 +1578,7 @@ class TestAdaptiveEntropyBonus:
     def brain(self):
         """Create a QSNN brain in surrogate gradient mode for testing."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=4,
             num_motor_neurons=4,
@@ -1652,17 +1677,21 @@ class TestMultiTimestepIntegration:
 
     def test_config_default_integration_steps(self):
         """Test that QSNNReinforceBrainConfig defaults to DEFAULT_NUM_INTEGRATION_STEPS."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         assert config.num_integration_steps == DEFAULT_NUM_INTEGRATION_STEPS
 
     def test_config_custom_integration_steps(self):
         """Test that num_integration_steps can be set to a custom value."""
-        config = QSNNReinforceBrainConfig(num_integration_steps=5)
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            num_integration_steps=5,
+        )
         assert config.num_integration_steps == 5
 
     def test_brain_stores_integration_steps(self):
         """Test that QSNNReinforceBrain stores the num_integration_steps from config."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1675,6 +1704,7 @@ class TestMultiTimestepIntegration:
     def test_multi_timestep_produces_valid_probabilities(self):
         """Test that _multi_timestep produces valid averaged motor probabilities."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1694,6 +1724,7 @@ class TestMultiTimestepIntegration:
     def test_multi_timestep_differentiable_returns_tensor(self):
         """Test that _multi_timestep_differentiable returns a torch tensor."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1712,6 +1743,7 @@ class TestMultiTimestepIntegration:
     def test_single_step_equivalent_to_original(self):
         """Test that num_integration_steps=1 behaves like original single-timestep."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             seed=42,
             num_sensory_neurons=2,
             num_hidden_neurons=2,
@@ -1733,6 +1765,7 @@ class TestMultiTimestepIntegration:
     def test_run_brain_uses_multi_timestep(self):
         """Test that run_brain works with multi-timestep integration."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1750,6 +1783,7 @@ class TestMultiTimestepIntegration:
     def test_surrogate_update_with_multi_timestep(self):
         """Test that surrogate gradient update works with multi-timestep integration."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1781,6 +1815,7 @@ class TestMultiTimestepIntegration:
     def test_copy_preserves_integration_steps(self):
         """Test that copy() preserves num_integration_steps."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1806,17 +1841,21 @@ class TestPPOClipping:
 
     def test_config_clip_epsilon_default(self):
         """Test that QSNNReinforceBrainConfig defaults clip_epsilon to 0.2."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         assert config.clip_epsilon == 0.2
 
     def test_config_clip_epsilon_custom(self):
         """Test that clip_epsilon can be set to a custom value."""
-        config = QSNNReinforceBrainConfig(clip_epsilon=0.1)
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            clip_epsilon=0.1,
+        )
         assert config.clip_epsilon == 0.1
 
     def test_old_log_probs_stored_during_run_brain(self):
         """Test that run_brain stores old_log_probs for PPO clipping."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1835,6 +1874,7 @@ class TestPPOClipping:
     def test_old_log_probs_not_stored_in_hebbian_mode(self):
         """Test that old_log_probs are NOT stored in Hebbian (local learning) mode."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1850,6 +1890,7 @@ class TestPPOClipping:
     def test_old_log_probs_cleared_on_episode_reset(self):
         """Test that episode_old_log_probs is cleared on episode reset."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1868,6 +1909,7 @@ class TestPPOClipping:
     def test_old_log_probs_cleared_on_intra_episode_update(self):
         """Test that episode_old_log_probs is cleared after intra-episode REINFORCE."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1888,6 +1930,7 @@ class TestPPOClipping:
     def test_old_log_probs_sync_with_actions_and_features(self):
         """Test that old_log_probs, actions, and features stay in sync."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1906,6 +1949,7 @@ class TestPPOClipping:
     def test_ppo_clipping_still_learns(self):
         """Test that PPO clipping doesn't prevent learning (weights still change)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -1942,17 +1986,21 @@ class TestThetaMotorNormClamping:
 
     def test_config_theta_motor_max_norm_default(self):
         """Test that QSNNReinforceBrainConfig defaults theta_motor_max_norm to 1.0."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         assert config.theta_motor_max_norm == 1.0
 
     def test_config_theta_motor_max_norm_custom(self):
         """Test that theta_motor_max_norm can be set to a custom value."""
-        config = QSNNReinforceBrainConfig(theta_motor_max_norm=0.5)
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            theta_motor_max_norm=0.5,
+        )
         assert config.theta_motor_max_norm == 0.5
 
     def test_theta_motor_initialized_to_zero(self):
         """Test that theta_motor is initialized to zeros (no initial bias)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=4,
@@ -1964,6 +2012,7 @@ class TestThetaMotorNormClamping:
     def test_theta_motor_norm_clamped_surrogate_mode(self):
         """Test that theta_motor norm is clamped after surrogate gradient update."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=4,
@@ -1994,6 +2043,7 @@ class TestThetaMotorNormClamping:
     def test_theta_motor_norm_clamped_hebbian_mode(self):
         """Test that theta_motor norm is clamped after Hebbian local learning update."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=4,
@@ -2022,6 +2072,7 @@ class TestThetaMotorNormClamping:
     def test_theta_motor_below_max_norm_unchanged(self):
         """Test that theta_motor below max_norm is not scaled down."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=4,
@@ -2054,27 +2105,34 @@ class TestRewardNormalization:
 
     def test_config_reward_norm_alpha_default(self):
         """Test that QSNNReinforceBrainConfig defaults reward_norm_alpha to 0.01."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         assert config.reward_norm_alpha == 0.01
 
     def test_config_reward_norm_alpha_custom(self):
         """Test that reward_norm_alpha can be set to a custom value."""
-        config = QSNNReinforceBrainConfig(reward_norm_alpha=0.05)
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            reward_norm_alpha=0.05,
+        )
         assert config.reward_norm_alpha == 0.05
 
     def test_config_use_reward_normalization_default(self):
         """Test that use_reward_normalization defaults to True."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         assert config.use_reward_normalization is True
 
     def test_config_use_reward_normalization_disabled(self):
         """Test that use_reward_normalization can be disabled."""
-        config = QSNNReinforceBrainConfig(use_reward_normalization=False)
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            use_reward_normalization=False,
+        )
         assert config.use_reward_normalization is False
 
     def test_running_stats_initialized(self):
         """Test that running reward stats are initialized correctly."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2087,6 +2145,7 @@ class TestRewardNormalization:
     def test_normalize_reward_updates_running_stats(self):
         """Test that _normalize_reward updates running mean and variance."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2103,6 +2162,7 @@ class TestRewardNormalization:
     def test_normalize_reward_returns_normalized_value(self):
         """Test that _normalize_reward returns a normalized reward."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2125,6 +2185,7 @@ class TestRewardNormalization:
     def test_normalized_rewards_stored_in_episode_rewards(self):
         """Test that normalized (not raw) rewards are stored in episode_rewards."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2145,6 +2206,7 @@ class TestRewardNormalization:
     def test_raw_rewards_stored_in_history(self):
         """Test that raw (not normalized) rewards are stored in history_data."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2164,6 +2226,7 @@ class TestRewardNormalization:
     def test_disabled_normalization_stores_raw_rewards(self):
         """Test that disabling normalization stores raw rewards in episode_rewards."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2182,6 +2245,7 @@ class TestRewardNormalization:
     def test_running_stats_persist_across_episodes(self):
         """Test that running reward stats persist across episode resets."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2206,6 +2270,7 @@ class TestRewardNormalization:
     def test_copy_preserves_running_stats(self):
         """Test that copy() preserves running reward normalization stats."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2226,6 +2291,7 @@ class TestRewardNormalization:
     def test_normalization_with_varied_rewards_still_learns(self):
         """Test that normalization doesn't prevent learning (weights still change)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2266,7 +2332,7 @@ class TestQSNNCritic:
 
     def test_config_critic_defaults(self):
         """Test critic config fields default to False/correct values."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         assert config.use_critic is False
         assert config.critic_hidden_dim == DEFAULT_CRITIC_HIDDEN_DIM
         assert config.critic_num_layers == DEFAULT_CRITIC_NUM_LAYERS
@@ -2277,6 +2343,7 @@ class TestQSNNCritic:
     def test_critic_not_created_when_disabled(self):
         """Test critic is None when use_critic=False."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2291,6 +2358,7 @@ class TestQSNNCritic:
     def test_critic_created_when_enabled(self):
         """Test critic is created with correct architecture when use_critic=True."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2338,6 +2406,7 @@ class TestQSNNCritic:
     def test_episode_values_stored_when_critic_enabled(self):
         """Test episode_values are populated during run_brain with critic."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2359,6 +2428,7 @@ class TestQSNNCritic:
     def test_episode_values_not_stored_when_critic_disabled(self):
         """Test episode_values stay empty when use_critic=False."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2375,6 +2445,7 @@ class TestQSNNCritic:
     def test_episode_values_cleared_on_reset(self):
         """Test episode_values cleared when episode resets."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2394,6 +2465,7 @@ class TestQSNNCritic:
     def test_episode_values_in_sync_with_actions(self):
         """Test episode_values length matches episode_actions."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2413,6 +2485,7 @@ class TestQSNNCritic:
     def test_compute_gae_shapes(self):
         """Test _compute_gae returns correct shapes."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2435,6 +2508,7 @@ class TestQSNNCritic:
     def test_compute_gae_terminal_vs_bootstrap(self):
         """Test GAE with bootstrap=0 (terminal) vs non-zero (window boundary)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2458,6 +2532,7 @@ class TestQSNNCritic:
     def test_critic_update_does_not_affect_actor(self):
         """Test that critic update leaves actor weights unchanged."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2488,6 +2563,7 @@ class TestQSNNCritic:
     def test_full_episode_with_critic(self):
         """Test a complete episode with critic enabled runs without error."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2515,6 +2591,7 @@ class TestQSNNCritic:
         V(s_{N+1}) and executes the deferred update, then clears buffers.
         """
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2560,6 +2637,7 @@ class TestQSNNCritic:
         call after the window boundary, not immediately in learn().
         """
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2592,6 +2670,7 @@ class TestQSNNCritic:
     def test_copy_preserves_critic_weights(self):
         """Test copy() creates independent critic with same weights."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2629,6 +2708,7 @@ class TestQSNNCritic:
     def test_copy_no_critic_when_disabled(self):
         """Test copy() does not create critic when use_critic=False."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2672,6 +2752,7 @@ class TestQSNNCritic:
         GAE + advantage normalization handles variance reduction instead.
         """
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2697,6 +2778,7 @@ class TestQSNNCritic:
     def test_disabled_critic_identical_behavior(self):
         """Test use_critic=False produces same code path as before (no GAE)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2726,6 +2808,7 @@ class TestQSNNCritic:
     def test_deferred_bootstrap_computes_correct_value(self):
         """Test deferred bootstrap: flag set at boundary, update runs in next run_brain()."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2761,6 +2844,7 @@ class TestQSNNCritic:
     def test_deferred_bootstrap_not_set_without_critic(self):
         """Test vanilla REINFORCE path does not set deferred flag."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2786,6 +2870,7 @@ class TestQSNNCritic:
     def test_reward_normalization_skipped_with_critic(self):
         """Test raw rewards are stored when critic is active (normalization skipped)."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2810,6 +2895,7 @@ class TestQSNNCritic:
     def test_reward_normalization_still_works_without_critic(self):
         """Test REINFORCE path still normalizes rewards when critic is disabled."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2833,6 +2919,7 @@ class TestQSNNCritic:
     def test_critic_uses_huber_loss(self):
         """Test critic update with extreme targets doesn't crash and params stay finite."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2860,6 +2947,7 @@ class TestQSNNCritic:
     def test_deferred_update_cleared_on_episode_reset(self):
         """Test _pending_critic_update is cleared when episode resets."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -2930,6 +3018,7 @@ class TestQSNNCritic:
     def test_hidden_spikes_stored_in_episode_buffer(self):
         """Test hidden spike rates are stored during run_brain with critic."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=4,
             num_motor_neurons=2,
@@ -2951,6 +3040,7 @@ class TestQSNNCritic:
     def test_hidden_spikes_not_stored_when_critic_disabled(self):
         """Test hidden spike rates buffer stays empty when critic disabled."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=4,
             num_motor_neurons=2,
@@ -2967,6 +3057,7 @@ class TestQSNNCritic:
     def test_critic_input_concatenation(self):
         """Test critic input batch is features + hidden spikes concatenated."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=3,
             num_motor_neurons=2,
@@ -2989,6 +3080,7 @@ class TestQSNNCritic:
     def test_explained_variance_computation(self):
         """Test explained variance is logged during critic update."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=2,
             num_motor_neurons=2,
@@ -3036,28 +3128,38 @@ class TestMultiEpochReinforce:
 
     def test_config_num_reinforce_epochs_default(self):
         """Test num_reinforce_epochs defaults to 1."""
-        config = QSNNReinforceBrainConfig()
+        config = QSNNReinforceBrainConfig(sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         assert config.num_reinforce_epochs == DEFAULT_NUM_REINFORCE_EPOCHS
         assert config.num_reinforce_epochs == 1
 
     def test_config_num_reinforce_epochs_custom(self):
         """Test num_reinforce_epochs can be set to custom value."""
-        config = QSNNReinforceBrainConfig(num_reinforce_epochs=3)
+        config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+            num_reinforce_epochs=3,
+        )
         assert config.num_reinforce_epochs == 3
 
     def test_validation_num_reinforce_epochs_zero(self):
         """Test that num_reinforce_epochs=0 is rejected."""
         with pytest.raises(ValueError, match="num_reinforce_epochs must be >= 1"):
-            QSNNReinforceBrainConfig(num_reinforce_epochs=0)
+            QSNNReinforceBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_reinforce_epochs=0,
+            )
 
     def test_validation_num_reinforce_epochs_negative(self):
         """Test that negative num_reinforce_epochs is rejected."""
         with pytest.raises(ValueError, match="num_reinforce_epochs must be >= 1"):
-            QSNNReinforceBrainConfig(num_reinforce_epochs=-1)
+            QSNNReinforceBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
+                num_reinforce_epochs=-1,
+            )
 
     def test_single_epoch_completes_without_error(self):
         """Test that num_reinforce_epochs=1 (default) completes a full episode."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=3,
             num_motor_neurons=2,
@@ -3078,6 +3180,7 @@ class TestMultiEpochReinforce:
     def test_multi_epoch_completes_without_error(self):
         """Test that num_reinforce_epochs=3 completes a full episode."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=3,
             num_motor_neurons=2,
@@ -3098,6 +3201,7 @@ class TestMultiEpochReinforce:
     def test_multi_epoch_changes_weights(self):
         """Test that multi-epoch REINFORCE modifies weights after episode."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=3,
             num_motor_neurons=2,
@@ -3129,6 +3233,7 @@ class TestMultiEpochReinforce:
 
         def run_episode(num_epochs, seed):
             config = QSNNReinforceBrainConfig(
+                sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
                 num_sensory_neurons=2,
                 num_hidden_neurons=3,
                 num_motor_neurons=2,
@@ -3165,6 +3270,7 @@ class TestMultiEpochReinforce:
     def test_multi_epoch_intra_episode_update(self):
         """Test multi-epoch works with intra-episode update_interval windowing."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=3,
             num_motor_neurons=2,
@@ -3186,6 +3292,7 @@ class TestMultiEpochReinforce:
     def test_cache_cleared_after_update(self):
         """Test _cached_spike_probs is empty after episode end."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=3,
             num_motor_neurons=2,
@@ -3209,6 +3316,7 @@ class TestMultiEpochReinforce:
     def test_cache_cleared_on_intra_episode_update(self):
         """Test _cached_spike_probs is cleared after intra-episode window update."""
         config = QSNNReinforceBrainConfig(
+            sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
             num_sensory_neurons=2,
             num_hidden_neurons=3,
             num_motor_neurons=2,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnreinforce.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_qsnnreinforce.py
@@ -347,8 +347,8 @@ class TestQSNNReinforceBrainForwardPass:
     def test_run_brain_returns_action(self, brain):
         """Test run_brain returns valid action."""
         params = BrainParams(
-            gradient_strength=0.6,
-            gradient_direction=0.3,
+            food_gradient_strength=0.6,
+            food_gradient_direction=0.3,
             agent_position=(1, 1),
             agent_direction=Direction.UP,
         )
@@ -363,7 +363,7 @@ class TestQSNNReinforceBrainForwardPass:
 
     def test_run_brain_tracks_episode_data(self, brain):
         """Test run_brain tracks episode data."""
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
 
@@ -371,7 +371,7 @@ class TestQSNNReinforceBrainForwardPass:
 
     def test_exploration_floor_prevents_deterministic_policy(self, brain):
         """Test that epsilon mixing prevents any action probability from reaching 0."""
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
 
@@ -383,7 +383,7 @@ class TestQSNNReinforceBrainForwardPass:
 
     def test_exploration_floor_probabilities_sum_to_one(self, brain):
         """Test that action probabilities still sum to 1.0 after epsilon mixing."""
-        params = BrainParams(gradient_strength=0.8, gradient_direction=0.1)
+        params = BrainParams(food_gradient_strength=0.8, food_gradient_direction=0.1)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
 
@@ -414,7 +414,7 @@ class TestQSNNReinforceBrainEligibilityTrace:
         assert torch.allclose(brain.eligibility_hm, torch.zeros_like(brain.eligibility_hm))
 
         # run_brain triggers _timestep then accumulates eligibility after action selection
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
 
         # At least one eligibility matrix should have non-zero values
@@ -476,7 +476,7 @@ class TestQSNNReinforceBrainEligibilityTrace:
     def test_eligibility_reset_on_episode_end(self, brain):
         """Test eligibility traces reset when episode ends."""
         # Run a step to accumulate some eligibility
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
         brain.learn(params, reward=1.0, episode_done=True)
 
@@ -517,7 +517,7 @@ class TestQSNNReinforceBrainLocalLearning:
         initial_w_hm = brain.W_hm.clone()
 
         # Run episode with positive reward
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         for _ in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
             brain.learn(params, reward=1.0, episode_done=False)
@@ -890,8 +890,8 @@ class TestQSNNReinforceBrainIntegration:
 
         for step in range(10):
             params = BrainParams(
-                gradient_strength=rng.random(),
-                gradient_direction=rng.random() * 2 * np.pi,
+                food_gradient_strength=rng.random(),
+                food_gradient_direction=rng.random() * 2 * np.pi,
                 agent_position=(step, step),
                 agent_direction=Direction.UP,
             )
@@ -921,7 +921,7 @@ class TestQSNNReinforceBrainIntegration:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=4, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         for _episode in range(3):
             brain.prepare_episode()
@@ -1067,7 +1067,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         initial_w_hm = brain.W_hm.clone().detach()
 
         # Run a short episode with varied rewards for meaningful advantages
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         rewards = [0.1, 2.0, -1.0, 3.0, 0.5]
         for step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -1090,7 +1090,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         initial_theta_m = brain.theta_motor.clone().detach()
 
         # Run a short episode with varied rewards
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         for step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
             brain.learn(params, reward=1.0, episode_done=(step == 4))
@@ -1104,7 +1104,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
 
     def test_surrogate_mode_stores_features(self, brain):
         """Test that run_brain stores features for gradient recomputation."""
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
 
@@ -1113,7 +1113,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
 
     def test_surrogate_mode_episode_features_cleared_on_reset(self, brain):
         """Test that episode_features is cleared on episode reset."""
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert len(brain.episode_features) == 1
 
@@ -1122,7 +1122,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
 
     def test_surrogate_mode_full_episode(self, brain):
         """Test complete episode workflow in surrogate gradient mode."""
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.prepare_episode()
         for step in range(10):
@@ -1191,7 +1191,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         """Test that _episode_count increments after each episode."""
         assert brain._episode_count == 0
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         for step in range(3):
             brain.run_brain(params, top_only=True, top_randomize=True)
             brain.learn(params, reward=1.0, episode_done=(step == 2))
@@ -1207,7 +1207,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
     def test_logit_scale_used_in_run_brain(self, brain):
         """Test that LOGIT_SCALE constant is used (not hardcoded 10.0)."""
         # Run brain and check that action probs are valid
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert brain.current_probabilities is not None
         assert np.isclose(np.sum(brain.current_probabilities), 1.0, atol=1e-6)
@@ -1240,7 +1240,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         initial_lr = brain.optimizer.param_groups[0]["lr"]
 
         # Run several episodes to trigger scheduler steps
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         for _episode in range(10):
             brain.prepare_episode()
             for step in range(3):
@@ -1320,7 +1320,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         # Run 5 steps (= update_interval), not episode_done
         for _step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -1348,7 +1348,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         initial_w_sh = brain.W_sh.clone().detach()
         initial_w_hm = brain.W_hm.clone().detach()
 
@@ -1379,7 +1379,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 10 steps: updates at step 3, 6, 9
         for step in range(10):
@@ -1409,7 +1409,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 7 steps: intra-episode update at step 5, then 2 remaining steps
         for step in range(7):
@@ -1435,7 +1435,7 @@ class TestQSNNReinforceBrainSurrogateGradient:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run exactly 5 steps with episode_done=True on the last step
         # The intra-episode update should NOT fire (episode_done=True),
@@ -1597,7 +1597,7 @@ class TestAdaptiveEntropyBonus:
     def test_no_boost_when_entropy_above_floor(self, brain):
         """Test that entropy_coef is unchanged when entropy is above the floor."""
         # Run a few steps to have episode data
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.prepare_episode()
         for step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -1774,7 +1774,7 @@ class TestMultiTimestepIntegration:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         actions = brain.run_brain(params, top_only=True, top_randomize=True)
 
         assert len(actions) == 1
@@ -1799,7 +1799,7 @@ class TestMultiTimestepIntegration:
         initial_w_hm = brain.W_hm.clone().detach()
 
         # Run a short episode with varied rewards for meaningful advantages
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         rewards = [0.1, 2.0, -1.0, 3.0, 0.5]
         for step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -1863,7 +1863,7 @@ class TestPPOClipping:
             use_local_learning=False,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
 
         assert len(brain.episode_old_log_probs) == 1
@@ -1882,7 +1882,7 @@ class TestPPOClipping:
             use_local_learning=True,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
 
         assert len(brain.episode_old_log_probs) == 0
@@ -1899,7 +1899,7 @@ class TestPPOClipping:
             learning_rate=0.1,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert len(brain.episode_old_log_probs) == 1
 
@@ -1920,7 +1920,7 @@ class TestPPOClipping:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         for _step in range(3):
             brain.run_brain(params, top_only=True, top_randomize=True)
             brain.learn(params, reward=0.5, episode_done=False)
@@ -1938,7 +1938,7 @@ class TestPPOClipping:
             use_local_learning=False,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         for _ in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
 
@@ -1960,7 +1960,7 @@ class TestPPOClipping:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         initial_w_sh = brain.W_sh.clone().detach()
         initial_w_hm = brain.W_hm.clone().detach()
@@ -2027,7 +2027,7 @@ class TestThetaMotorNormClamping:
         with torch.no_grad():
             brain.theta_motor.fill_(2.0)  # norm = 4.0, well above max_norm=0.5
 
-        params = BrainParams(gradient_strength=0.8, gradient_direction=0.5)
+        params = BrainParams(food_gradient_strength=0.8, food_gradient_direction=0.5)
 
         # Run several steps then trigger episode-end update
         for step in range(5):
@@ -2058,7 +2058,7 @@ class TestThetaMotorNormClamping:
         with torch.no_grad():
             brain.theta_motor.fill_(2.0)
 
-        params = BrainParams(gradient_strength=0.8, gradient_direction=0.5)
+        params = BrainParams(food_gradient_strength=0.8, food_gradient_direction=0.5)
 
         # Run a step and trigger learning
         brain.run_brain(params, top_only=True, top_randomize=True)
@@ -2083,7 +2083,7 @@ class TestThetaMotorNormClamping:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=4, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
 
         brain.learn(params, reward=1.0, episode_done=True)
@@ -2195,7 +2195,7 @@ class TestRewardNormalization:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
         brain.learn(params, reward=10.0, episode_done=False)
 
@@ -2216,7 +2216,7 @@ class TestRewardNormalization:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
         brain.learn(params, reward=10.0, episode_done=False)
 
@@ -2236,7 +2236,7 @@ class TestRewardNormalization:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         brain.run_brain(params, top_only=True, top_randomize=True)
         brain.learn(params, reward=10.0, episode_done=False)
 
@@ -2256,7 +2256,7 @@ class TestRewardNormalization:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run a full episode with large rewards
         for step in range(5):
@@ -2306,7 +2306,7 @@ class TestRewardNormalization:
         initial_w_sh = brain.W_sh.clone().detach()
         initial_w_hm = brain.W_hm.clone().detach()
 
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
         rewards = [0.1, 5.0, -3.0, 2.0, 0.5]
         for step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -2415,7 +2415,7 @@ class TestQSNNCritic:
             use_critic=True,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert len(brain.episode_values) == 1
@@ -2437,7 +2437,7 @@ class TestQSNNCritic:
             use_critic=False,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert len(brain.episode_values) == 0
@@ -2454,7 +2454,7 @@ class TestQSNNCritic:
             use_critic=True,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert len(brain.episode_values) == 1
@@ -2474,7 +2474,7 @@ class TestQSNNCritic:
             use_critic=True,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         for _ in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -2573,7 +2573,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         for step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -2602,7 +2602,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 3 steps: triggers deferred update flag at step 3
         for _step in range(3):
@@ -2648,7 +2648,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 2 steps to trigger deferred update flag
         for _step in range(2):
@@ -2763,7 +2763,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run a full episode with mixed rewards
         rewards = [0.1, -5.0, 2.0, -0.3, 1.0]
@@ -2789,7 +2789,7 @@ class TestQSNNCritic:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Populate episode data manually
         for _ in range(3):
@@ -2819,7 +2819,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         assert brain._pending_critic_update is False
 
@@ -2855,7 +2855,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 3 steps to hit the update_interval boundary
         for _step in range(3):
@@ -2880,7 +2880,7 @@ class TestQSNNCritic:
             use_reward_normalization=True,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run a step with a known reward
         brain.run_brain(params, top_only=True, top_randomize=True)
@@ -2905,7 +2905,7 @@ class TestQSNNCritic:
             use_reward_normalization=True,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run a step with a known reward
         brain.run_brain(params, top_only=True, top_randomize=True)
@@ -2929,7 +2929,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Populate episode data with extreme rewards (simulating death penalty)
         for step in range(5):
@@ -2958,7 +2958,7 @@ class TestQSNNCritic:
             learning_rate=0.01,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 3 steps to set the deferred flag
         for _step in range(3):
@@ -3027,7 +3027,7 @@ class TestQSNNCritic:
             use_critic=True,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert len(brain.episode_hidden_spikes) == 1
@@ -3049,7 +3049,7 @@ class TestQSNNCritic:
             use_critic=False,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         brain.run_brain(params, top_only=True, top_randomize=True)
         assert len(brain.episode_hidden_spikes) == 0
@@ -3171,7 +3171,7 @@ class TestMultiEpochReinforce:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         for step in range(10):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -3192,7 +3192,7 @@ class TestMultiEpochReinforce:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         for step in range(10):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -3213,7 +3213,7 @@ class TestMultiEpochReinforce:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         w_sh_before = brain.W_sh.clone()
         w_hm_before = brain.W_hm.clone()
@@ -3245,7 +3245,7 @@ class TestMultiEpochReinforce:
                 seed=seed,
             )
             brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-            params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+            params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
             w_sh_init = brain.W_sh.clone()
             w_hm_init = brain.W_hm.clone()
@@ -3282,7 +3282,7 @@ class TestMultiEpochReinforce:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 9 steps (3 windows of 3) + episode end at step 9
         for step in range(10):
@@ -3304,7 +3304,7 @@ class TestMultiEpochReinforce:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         for step in range(5):
             brain.run_brain(params, top_only=True, top_randomize=True)
@@ -3328,7 +3328,7 @@ class TestMultiEpochReinforce:
             seed=42,
         )
         brain = QSNNReinforceBrain(config=config, num_actions=2, device=DeviceType.CPU)
-        params = BrainParams(gradient_strength=0.5, gradient_direction=1.0)
+        params = BrainParams(food_gradient_strength=0.5, food_gradient_direction=1.0)
 
         # Run 3 steps to trigger intra-episode update
         for _step in range(3):
@@ -3354,8 +3354,8 @@ class TestMultiEpochReinforce:
         )
         brain = QSNNReinforceBrain(config=config, num_actions=4, device=DeviceType.CPU)
         params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=1.0,
+            food_gradient_strength=0.5,
+            food_gradient_direction=1.0,
             predator_gradient_strength=0.3,
             predator_gradient_direction=2.5,
         )

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_weight_persistence.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_weight_persistence.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 from quantumnematode.brain.arch.dtypes import DeviceType
 from quantumnematode.brain.arch.mlpppo import MLPPPOBrain, MLPPPOBrainConfig
+from quantumnematode.brain.modules import ModuleName
 from quantumnematode.brain.weights import (
     WeightPersistence,
     load_weights,
@@ -33,6 +34,7 @@ def mlpppo_config() -> MLPPPOBrainConfig:
         critic_hidden_dim=16,
         num_hidden_layers=1,
         rollout_buffer_size=32,
+        sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
     )
 
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/test_ppo_features.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/test_ppo_features.py
@@ -1,4 +1,4 @@
-"""Tests for MLPPPOBrain unified feature extraction integration."""
+"""Tests for MLPPPOBrain feature extraction integration."""
 
 import numpy as np
 import pytest
@@ -6,60 +6,6 @@ from quantumnematode.brain.arch import BrainParams
 from quantumnematode.brain.arch.mlpppo import MLPPPOBrain, MLPPPOBrainConfig
 from quantumnematode.brain.modules import ModuleName
 from quantumnematode.env import Direction
-
-
-class TestPPOBrainLegacyMode:
-    """Test MLPPPOBrain in legacy mode (backward compatibility)."""
-
-    def test_legacy_mode_default_input_dim(self):
-        """Test that legacy mode defaults to 2 features."""
-        config = MLPPPOBrainConfig()
-        brain = MLPPPOBrain(config=config)
-
-        assert brain.input_dim == 2
-        assert brain.sensory_modules is None
-
-    def test_legacy_mode_explicit_input_dim(self):
-        """Test that explicit input_dim is respected in legacy mode."""
-        config = MLPPPOBrainConfig()
-        brain = MLPPPOBrain(config=config, input_dim=5)
-
-        assert brain.input_dim == 5
-        assert brain.sensory_modules is None
-
-    def test_legacy_preprocess_output_shape(self):
-        """Test that legacy preprocessing returns 2 features."""
-        config = MLPPPOBrainConfig()
-        brain = MLPPPOBrain(config=config)
-
-        params = BrainParams(
-            gradient_strength=0.5,
-            gradient_direction=0.0,
-            agent_direction=Direction.UP,
-        )
-
-        features = brain.preprocess(params)
-
-        assert features.shape == (2,)
-        assert features.dtype == np.float32
-
-    def test_legacy_preprocess_values(self):
-        """Test that legacy preprocessing computes correct values."""
-        config = MLPPPOBrainConfig()
-        brain = MLPPPOBrain(config=config)
-
-        params = BrainParams(
-            gradient_strength=0.8,
-            gradient_direction=np.pi / 2,  # Pointing up
-            agent_direction=Direction.UP,  # Facing up (aligned)
-        )
-
-        features = brain.preprocess(params)
-
-        # First feature: gradient_strength
-        assert features[0] == pytest.approx(0.8)
-        # Second feature: rel_angle_norm (should be ~0 when aligned)
-        assert abs(features[1]) < 0.1
 
 
 class TestPPOBrainUnifiedMode:
@@ -185,22 +131,6 @@ class TestPPOBrainRunWithUnifiedFeatures:
         assert len(actions) == 1
         assert actions[0].action is not None
         assert 0 <= actions[0].probability <= 1
-
-    def test_run_brain_legacy_mode_still_works(self):
-        """Test that run_brain still works in legacy mode."""
-        config = MLPPPOBrainConfig()
-        brain = MLPPPOBrain(config=config, input_dim=2, num_actions=4)
-
-        params = BrainParams(
-            gradient_strength=0.7,
-            gradient_direction=np.pi / 4,
-            agent_direction=Direction.RIGHT,
-        )
-
-        actions = brain.run_brain(params, top_only=True, top_randomize=False)
-
-        assert len(actions) == 1
-        assert actions[0].action is not None
 
 
 class TestPPOBrainWithScientificModuleNames:

--- a/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_plasticity.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_plasticity.py
@@ -46,7 +46,7 @@ class TestPlasticityConfig:
     def test_valid_config_loads(self) -> None:
         """Valid config with all required fields loads successfully."""
         config = PlasticityConfig(
-            brain={"name": "mlpppo"},  # type: ignore[arg-type]
+            brain={"name": "mlpppo", "config": {"sensory_modules": ["food_chemotaxis"]}},  # type: ignore[arg-type]
             plasticity=PlasticityProtocolConfig(
                 training_episodes_per_phase=10,
                 eval_episodes=5,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_plasticity.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_plasticity.py
@@ -252,8 +252,9 @@ class TestStateSnapshotRestore:
         """
         import torch
         from quantumnematode.brain.arch.mlpppo import MLPPPOBrain, MLPPPOBrainConfig
+        from quantumnematode.brain.modules import ModuleName
 
-        config = MLPPPOBrainConfig(seed=42)
+        config = MLPPPOBrainConfig(seed=42, sensory_modules=[ModuleName.FOOD_CHEMOTAXIS])
         brain = MLPPPOBrain(config)
 
         # Run a fake backward pass to populate optimizer momentum buffers

--- a/scripts/qrh_mi_analysis.py
+++ b/scripts/qrh_mi_analysis.py
@@ -49,6 +49,7 @@ from quantumnematode.brain.arch.qrh import (
     QRHBrainConfig,
     _compute_feature_dim,
 )
+from quantumnematode.brain.modules import ModuleName
 from quantumnematode.env import Direction
 from quantumnematode.utils.seeding import set_global_seed
 from sklearn.feature_selection import mutual_info_classif
@@ -318,6 +319,7 @@ def extract_classical_features(
         Feature matrix, shape (num_samples, hidden_dim).
     """
     config = MLPPPOBrainConfig(
+        sensory_modules=[ModuleName.FOOD_CHEMOTAXIS],
         seed=seed,
         actor_hidden_dim=64,
         critic_hidden_dim=64,


### PR DESCRIPTION
## Summary

- **Make `sensory_modules` required** (no `None` default) on 8 brain config classes: MLPPPOBrainConfig, QRCBrainConfig, QSNNReinforceBrainConfig, QSNNPPOBrainConfig, QLIFLSTMBrainConfig, HybridQuantumBrainConfig, HybridClassicalBrainConfig, HybridQuantumCortexBrainConfig (+ `cortex_sensory_modules`)
- **Delete `preprocess_legacy()`** from `_hybrid_common.py` and all `_preprocess_legacy()` wrappers in hybrid brains
- **Remove all `if sensory_modules is None` fallback branches** — all brains now use `extract_classical_features()` exclusively
- **Update 11 YAML configs** that relied on the legacy default to explicitly specify `sensory_modules`
- **Fix `HybridClassicalBrain._init_reflex()`** which had `DEFAULT_REFLEX_INPUT_DIM=2` hardcoded instead of using `self.input_dim` (would crash with multi-module configs)
- **Update `config_loader.py`** — `None` brain config now raises `ValueError` instead of constructing an empty default

Ref: `tmp/legacy-deprecation-tracker.md` item 5

## Test plan

- [x] `uv run pre-commit run -a` — all 10 hooks pass (ruff, pyright, etc.)
- [x] `uv run pytest -m "not nightly" -x -q` — all 1923 tests pass
- [x] Smoke-tested 5 brain types via `run_simulation.py` (MLPPPO foraging, MLPPPO pursuit, HybridQuantum, HybridClassical, QLIFLSTM, HybridQuantumCortex)
- [x] Verified no residual `preprocess_legacy`, `sensory_modules is None`, or stale "legacy" references in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Brain configs now require explicit sensory-module lists; legacy two-feature fallback removed across brain types.
* **Chores**
  * Scenario and sample configs updated to explicitly enable sensory inputs (e.g., food_chemotaxis, nociception) for training.
* **Tests**
  * Test suite updated to use module-specific sensory inputs and renamed sensory fields; legacy-mode tests removed and validation tightened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->