### PR TITLE
fix: Fix multi-agent exploration bonus and effects-phase reward signals

### DIFF
--- a/packages/quantum-nematode/quantumnematode/agent/multi_agent.py
+++ b/packages/quantum-nematode/quantumnematode/agent/multi_agent.py
@@ -493,6 +493,10 @@ class MultiAgentSimulation:
             if not alive:
                 break
 
+            # Reset per-step reward accumulator (effects + calculator rewards)
+            for aid in reward_per_agent:
+                reward_per_agent[aid] = 0.0
+
             # ── 1. PERCEPTION + DECISION ─────────────────────────
             actions: dict[str, ActionData] = {}
             for agent in alive:
@@ -532,9 +536,6 @@ class MultiAgentSimulation:
                 agent.path.append((pos[0], pos[1]))
                 agent.food_history.append(list(self.env.foods))
                 agent._food_handler.track_step()
-
-                # Update visited cells
-                self.env.agents[aid].visited_cells.add(pos)
 
             # ── 2b. AGGREGATION PHEROMONE EMISSION ───────────────
             if pheromones_enabled and self.env.pheromone_field_aggregation is not None:
@@ -653,8 +654,8 @@ class MultiAgentSimulation:
             # ── 6. LEARNING ──────────────────────────────────────
             for agent in self._alive_agents:
                 aid = agent.agent_id
-                # Compute reward for this step
-                reward_per_agent[aid] = agent.calculate_reward(
+                # Compute reward for this step (adds to effects-phase rewards)
+                reward_per_agent[aid] += agent.calculate_reward(
                     reward_config,
                     agent.env,
                     agent.path,


### PR DESCRIPTION
## Summary

Two reward signal fixes in the multi-agent step loop. Both are bugs where the multi-agent orchestrator's step ordering differs from the single-agent runner, causing incorrect reward signals.

### Fix #119: Exploration bonus suppressed

`visited_cells.add(pos)` was called during the movement phase (step 2) before the reward calculator's `_calculate_exploration_bonus()` checked it (step 6). Every agent's current position was already in `visited_cells` by the time the bonus was computed, so exploration bonus never fired.

**Fix**: Remove the early `visited_cells.add(pos)` from movement. The reward calculator already handles this inside `_calculate_exploration_bonus()` after awarding the bonus — matching the single-agent runner's behavior.

**Impact**: ~5.0 exploration bonus per episode was missing (0.05 × ~100 new cells per agent). This is 10× the step penalty, making it a significant missing learning signal.

### Fix #120: Effects-phase rewards overwritten

`reward_per_agent[aid] = calculate_reward(...)` in the learning section (step 6) overwrote temperature/oxygen rewards accumulated during the effects phase (step 5). The `=` discarded any `temp_reward` or `o2_reward` added earlier.

**Fix**: Change `=` to `+=` and add per-step reset of `reward_per_agent` at the start of each step. Effects-phase rewards are now preserved and combined with the calculator's output — matching the single-agent runner's accumulation pattern.

**Impact**: Affects thermotaxis/aerotaxis multi-agent environments. Current foraging-only evaluations unaffected (no temp/o2 rewards).

## Verification

- Episode 1 agents with 0 food now get reward 4-10 (exploration bonus ~5.0 for ~100 new cells)
- Pre-fix: episode 1 rewards were near 0 (only step penalties + distance reward)
- Agents reach food target completion by episode 5 in 10-episode sanity check
- Competition events detected (0.7/ep)

## Test plan

- [x] `uv run pytest -m "not nightly"` — 2074 passed
- [x] `uv run pre-commit run -a` — all hooks pass
- [x] Sanity check: 10 episodes, rewards non-trivial and increasing, exploration bonus magnitude matches expectation

Closes #119, closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reward accumulation to properly combine multiple reward sources within each episode step (replacing previous overwrite behavior), with automatic resets between steps for accurate agent performance tracking.
  * Refined agent movement and state management procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->