### PR TITLE
refactor: STAM to dynamic channel management

### DIFF
--- a/packages/quantum-nematode/quantumnematode/agent/agent.py
+++ b/packages/quantum-nematode/quantumnematode/agent/agent.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from pydantic import BaseModel
 
-from quantumnematode.agent.stam import STAMBuffer
+from quantumnematode.agent.stam import STAMBuffer, STAMChannelDef
 from quantumnematode.agent.tracker import EpisodeTracker
 from quantumnematode.brain.actions import ActionData  # noqa: TC001 - needed at runtime
 from quantumnematode.brain.arch import Brain, BrainParams, QuantumBrain
@@ -62,6 +62,54 @@ _ACTION_TO_IDX: dict[str, int] = {
     "forward-left": 4,
     "forward-right": 5,
 }
+
+# Type alias for STAM channel value fetchers
+ChannelFetcher = Any  # Callable[[tuple[int, int], int], float] — (position, step) -> float
+
+
+def _build_channel_fetchers(
+    env: DynamicForagingEnvironment,
+    channels: tuple[STAMChannelDef, ...],
+) -> list[ChannelFetcher]:
+    """Build value-fetcher callables for each active STAM channel.
+
+    Each fetcher takes (position, current_step) and returns a float scalar.
+
+    Parameters
+    ----------
+    env : DynamicForagingEnvironment
+        Environment to read values from.
+    channels : tuple[STAMChannelDef, ...]
+        Active channel definitions.
+
+    Returns
+    -------
+    list[ChannelFetcher]
+        One callable per channel, in the same order as channels.
+    """
+    fetcher_map: dict[str, ChannelFetcher] = {
+        "food": lambda pos, _step: env.get_food_concentration(position=pos),
+        "temperature": lambda pos, _step: env.get_temperature(pos) or 0.0,
+        "predator": lambda pos, _step: env.get_predator_concentration(position=pos),
+        "oxygen": lambda pos, _step: (
+            env.get_oxygen_concentration(position=pos) if env.aerotaxis.enabled else 0.0
+        ),
+        "pheromone_food": lambda pos, step: env.get_pheromone_food_concentration(
+            position=pos,
+            current_step=step,
+        ),
+        "pheromone_alarm": lambda pos, step: env.get_pheromone_alarm_concentration(
+            position=pos,
+            current_step=step,
+        ),
+        "pheromone_aggregation": lambda pos, step: env.get_pheromone_aggregation_concentration(
+            position=pos,
+            current_step=step,
+        ),
+    }
+    return [fetcher_map[ch.name] for ch in channels]
+
+
 DEFAULT_SATIETY_INITIAL = 200.0
 DEFAULT_SATIETY_DECAY_RATE = 1.0
 DEFAULT_SATIETY_GAIN_PER_FOOD = 0.2
@@ -190,31 +238,18 @@ class QuantumNematodeAgent:
         self.satiety_config = satiety_config or SatietyConfig()
         self.sensing_config: SensingConfig = sensing_config or SensingConfig()
 
-        # Initialize STAM buffer when enabled
+        # Initialize STAM buffer when enabled — channels resolved from env config
         self._stam: STAMBuffer | None = None
+        self._active_channels: tuple[STAMChannelDef, ...] = ()
+        self._channel_fetchers: list[ChannelFetcher] = []
         if self.sensing_config.stam_enabled:
-            from quantumnematode.agent.stam import (
-                CHANNELS_BASE,
-                CHANNELS_PHEROMONE,
-                CHANNELS_PHEROMONE_FULL,
-            )
+            from quantumnematode.agent.stam import resolve_active_channels
 
-            pheromones_enabled = (
-                env is not None and hasattr(env, "pheromones") and env.pheromones.enabled
-            )
-            aggregation_enabled = (
-                pheromones_enabled and env is not None and env.pheromones.aggregation is not None
-            )
-            if aggregation_enabled:
-                num_channels = CHANNELS_PHEROMONE_FULL
-            elif pheromones_enabled:
-                num_channels = CHANNELS_PHEROMONE
-            else:
-                num_channels = CHANNELS_BASE
+            self._active_channels = resolve_active_channels(env)
             self._stam = STAMBuffer(
                 buffer_size=self.sensing_config.stam_buffer_size,
                 decay_rate=self.sensing_config.stam_decay_rate,
-                num_channels=num_channels,
+                num_channels=len(self._active_channels),
             )
         self._previous_position: tuple[int, ...] | None = None
 
@@ -227,6 +262,10 @@ class QuantumNematodeAgent:
             )
         else:
             self.env = env
+
+        # Build channel fetchers now that self.env is set
+        if self._active_channels:
+            self._channel_fetchers = _build_channel_fetchers(self.env, self._active_channels)
 
         _init_pos = self.env.agents[self.agent_id].position
         self.path: list[GridPosition] = [(_init_pos[0], _init_pos[1])]
@@ -393,10 +432,10 @@ class QuantumNematodeAgent:
             return [float(gradient_strength)] * self.brain.num_qubits
         return None
 
-    def _compute_temporal_data(  # noqa: C901, PLR0912, PLR0915
+    def _compute_temporal_data(  # noqa: C901, PLR0912
         self,
         sensing: SensingConfig,
-        temperature: float | None,
+        temperature: float | None,  # noqa: ARG002
         separated_grads: dict[str, Any],
         action: ActionData | None,
     ) -> dict[str, Any]:
@@ -444,28 +483,23 @@ class QuantumNematodeAgent:
 
         # (a) Get scalar concentrations from environment at this agent's position
         agent_pos = self.env.agents[self.agent_id].position
-        food_conc_val = self.env.get_food_concentration(position=agent_pos)
-        pred_conc_val = self.env.get_predator_concentration(position=agent_pos)
-        temp_val = temperature if temperature is not None else 0.0
 
         if sensing.chemotaxis_mode != SensingMode.ORACLE:
-            result["food_concentration"] = food_conc_val
+            result["food_concentration"] = self.env.get_food_concentration(position=agent_pos)
             separated_grads.pop("food_gradient_strength", None)
             separated_grads.pop("food_gradient_direction", None)
 
         if sensing.nociception_mode != SensingMode.ORACLE:
-            result["predator_concentration"] = pred_conc_val
+            result["predator_concentration"] = self.env.get_predator_concentration(
+                position=agent_pos,
+            )
             separated_grads.pop("predator_gradient_strength", None)
             separated_grads.pop("predator_gradient_direction", None)
 
-        # Oxygen scalar concentration (raw percentage, not tanh-normalized)
-        o2_val = 0.0
-        if self.env.aerotaxis.enabled:
-            o2_raw = self.env.get_oxygen_concentration(position=agent_pos)
-            o2_val = o2_raw if o2_raw is not None else 0.0
-            if sensing.aerotaxis_mode != SensingMode.ORACLE:
-                separated_grads.pop("oxygen_gradient_strength", None)
-                separated_grads.pop("oxygen_gradient_direction", None)
+        # Oxygen: suppress oracle keys when in temporal/derivative mode
+        if self.env.aerotaxis.enabled and sensing.aerotaxis_mode != SensingMode.ORACLE:
+            separated_grads.pop("oxygen_gradient_strength", None)
+            separated_grads.pop("oxygen_gradient_direction", None)
 
         # Pheromone temporal concentrations (when not oracle mode)
         step = self._episode_tracker.steps
@@ -501,34 +535,15 @@ class QuantumNematodeAgent:
             )
         self._previous_position = current_pos
 
-        # (c) Record to STAM
+        # (c) Record to STAM — dynamic channel fetchers
         if self._stam is not None:
             action_idx = 0
             if action is not None:
                 action_str = str(action.action) if action.action is not None else "stay"
                 action_idx = _ACTION_TO_IDX.get(action_str, 0)
 
-            # Build scalar array — extend with pheromone channels when enabled
-            scalars = [food_conc_val, temp_val, pred_conc_val, o2_val]
-            if self._stam.num_channels > 4:  # noqa: PLR2004
-                # Pheromone channels (indices 4, 5)
-                pos_2d = (int(current_pos[0]), int(current_pos[1]))
-                pheromone_food_val = self.env.get_pheromone_food_concentration(
-                    position=pos_2d,
-                    current_step=step,
-                )
-                pheromone_alarm_val = self.env.get_pheromone_alarm_concentration(
-                    position=pos_2d,
-                    current_step=step,
-                )
-                scalars.extend([pheromone_food_val, pheromone_alarm_val])
-                # Aggregation pheromone channel (index 6)
-                if self._stam.num_channels > 6:  # noqa: PLR2004
-                    pheromone_agg_val = self.env.get_pheromone_aggregation_concentration(
-                        position=pos_2d,
-                        current_step=step,
-                    )
-                    scalars.append(pheromone_agg_val)
+            pos_2d = (int(current_pos[0]), int(current_pos[1]))
+            scalars = [fetcher(pos_2d, step) for fetcher in self._channel_fetchers]
 
             self._stam.record(
                 np.array(scalars),
@@ -536,35 +551,12 @@ class QuantumNematodeAgent:
                 action_idx,
             )
 
-            # (d) Get temporal derivatives from STAM
-            if sensing.chemotaxis_mode == SensingMode.DERIVATIVE:
-                result["food_dconcentration_dt"] = self._stam.compute_temporal_derivative(0)
-            if sensing.thermotaxis_mode == SensingMode.DERIVATIVE:
-                result["temperature_ddt"] = self._stam.compute_temporal_derivative(1)
-            if sensing.nociception_mode == SensingMode.DERIVATIVE:
-                result["predator_dconcentration_dt"] = self._stam.compute_temporal_derivative(2)
-            if sensing.aerotaxis_mode == SensingMode.DERIVATIVE:
-                result["oxygen_dconcentration_dt"] = self._stam.compute_temporal_derivative(3)
-            # Pheromone derivatives (channels 4, 5)
-            if self._stam.num_channels > 4:  # noqa: PLR2004
-                pheromone_food_mode = getattr(sensing, "pheromone_food_mode", None)
-                pheromone_alarm_mode = getattr(sensing, "pheromone_alarm_mode", None)
-                if pheromone_food_mode == SensingMode.DERIVATIVE:
-                    result["pheromone_food_dconcentration_dt"] = (
-                        self._stam.compute_temporal_derivative(4)
-                    )
-                if pheromone_alarm_mode == SensingMode.DERIVATIVE:
-                    result["pheromone_alarm_dconcentration_dt"] = (
-                        self._stam.compute_temporal_derivative(5)
-                    )
-                # Aggregation pheromone derivative (channel 6)
-                if (
-                    self._stam.num_channels > 6  # noqa: PLR2004
-                    and pheromone_aggregation_mode == SensingMode.DERIVATIVE
-                ):
-                    result["pheromone_aggregation_dconcentration_dt"] = (
-                        self._stam.compute_temporal_derivative(6)
-                    )
+            # (d) Get temporal derivatives from STAM — dynamic per active channel
+            for idx, ch_def in enumerate(self._active_channels):
+                if ch_def.derivative_key and ch_def.sensing_mode_attr:
+                    mode = getattr(sensing, ch_def.sensing_mode_attr, SensingMode.ORACLE)
+                    if mode == SensingMode.DERIVATIVE:
+                        result[ch_def.derivative_key] = self._stam.compute_temporal_derivative(idx)
 
             result["stam_state"] = tuple(self._stam.get_memory_state().tolist())
 
@@ -986,6 +978,8 @@ class QuantumNematodeAgent:
 
         # Update component references to new environment instance
         self._food_handler.env = self.env
+        if self._active_channels:
+            self._channel_fetchers = _build_channel_fetchers(self.env, self._active_channels)
 
         # Reset satiety manager to initial satiety
         self._satiety_manager.reset()

--- a/packages/quantum-nematode/quantumnematode/agent/runners.py
+++ b/packages/quantum-nematode/quantumnematode/agent/runners.py
@@ -197,21 +197,20 @@ class StandardEpisodeRunner(EpisodeRunner):
         )
         # Log temporal sensing diagnostics (once per episode, if STAM active)
         if agent._stam is not None and len(agent._stam) > 0:
-            from quantumnematode.agent.stam import IDX_FOOD, IDX_PRED, IDX_TEMP
-
             stam_state = agent._stam.get_memory_state()
-            food_deriv = agent._stam.compute_temporal_derivative(0)
-            temp_deriv = agent._stam.compute_temporal_derivative(1)
-            pred_deriv = agent._stam.compute_temporal_derivative(2)
+            # Log per-channel weighted means and derivatives dynamically
+            means_parts = []
+            deriv_parts = []
+            for idx, ch_def in enumerate(agent._active_channels):
+                means_parts.append(f"{ch_def.name}={stam_state[idx]:.3f}")
+                deriv = agent._stam.compute_temporal_derivative(idx)
+                deriv_parts.append(f"{ch_def.name}={deriv:.4f}")
             logger.info(
                 f"Temporal sensing summary: "
                 f"STAM entries={len(agent._stam)}, "
-                f"weighted_means=[food={stam_state[IDX_FOOD]:.3f}, "
-                f"temp={stam_state[IDX_TEMP]:.3f}, "
-                f"pred={stam_state[IDX_PRED]:.3f}], "
-                f"derivatives=[food={food_deriv:.4f}, "
-                f"temp={temp_deriv:.4f}, "
-                f"pred={pred_deriv:.4f}], "
+                f"channels={agent._stam.num_channels}, "
+                f"weighted_means=[{', '.join(means_parts)}], "
+                f"derivatives=[{', '.join(deriv_parts)}], "
                 f"action_entropy={stam_state[-1]:.3f}",
             )
 

--- a/packages/quantum-nematode/quantumnematode/agent/stam.py
+++ b/packages/quantum-nematode/quantumnematode/agent/stam.py
@@ -21,8 +21,131 @@ Timescale mapping:
 from __future__ import annotations
 
 from collections import deque
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from quantumnematode.env import DynamicForagingEnvironment
+
+
+@dataclass(frozen=True)
+class STAMChannelDef:
+    """Definition of a single STAM sensory channel.
+
+    Attributes
+    ----------
+    name : str
+        Unique channel identifier (e.g., "food", "pheromone_alarm").
+    derivative_key : str or None
+        Key in the temporal data result dict for dC/dt (e.g., "food_dconcentration_dt").
+    sensing_mode_attr : str or None
+        Attribute name on SensingConfig controlling this channel's mode
+        (e.g., "chemotaxis_mode"). Used to determine if derivative should be computed.
+    """
+
+    name: str
+    derivative_key: str | None = None
+    sensing_mode_attr: str | None = None
+
+
+# ── Channel Registry ────────────────────────────────────────────────────────
+# All possible STAM channels. Active channels are resolved at runtime
+# from environment config via resolve_active_channels().
+
+CHANNEL_REGISTRY: dict[str, STAMChannelDef] = {
+    "food": STAMChannelDef(
+        name="food",
+        derivative_key="food_dconcentration_dt",
+        sensing_mode_attr="chemotaxis_mode",
+    ),
+    "temperature": STAMChannelDef(
+        name="temperature",
+        derivative_key="temperature_ddt",
+        sensing_mode_attr="thermotaxis_mode",
+    ),
+    "predator": STAMChannelDef(
+        name="predator",
+        derivative_key="predator_dconcentration_dt",
+        sensing_mode_attr="nociception_mode",
+    ),
+    "oxygen": STAMChannelDef(
+        name="oxygen",
+        derivative_key="oxygen_dconcentration_dt",
+        sensing_mode_attr="aerotaxis_mode",
+    ),
+    "pheromone_food": STAMChannelDef(
+        name="pheromone_food",
+        derivative_key="pheromone_food_dconcentration_dt",
+        sensing_mode_attr="pheromone_food_mode",
+    ),
+    "pheromone_alarm": STAMChannelDef(
+        name="pheromone_alarm",
+        derivative_key="pheromone_alarm_dconcentration_dt",
+        sensing_mode_attr="pheromone_alarm_mode",
+    ),
+    "pheromone_aggregation": STAMChannelDef(
+        name="pheromone_aggregation",
+        derivative_key="pheromone_aggregation_dconcentration_dt",
+        sensing_mode_attr="pheromone_aggregation_mode",
+    ),
+}
+
+
+def resolve_active_channels(
+    env: DynamicForagingEnvironment | None,
+) -> tuple[STAMChannelDef, ...]:
+    """Determine active STAM channels from environment configuration.
+
+    Channels are included only when their corresponding environment feature
+    is enabled. A foraging-only config gets 1 channel (food); a full config
+    with thermotaxis, predators, aerotaxis, and all pheromones gets 7.
+
+    Parameters
+    ----------
+    env : DynamicForagingEnvironment or None
+        Environment instance. None returns food-only (1 channel).
+
+    Returns
+    -------
+    tuple[STAMChannelDef, ...]
+        Active channel definitions in recording order.
+    """
+    channels: list[STAMChannelDef] = [CHANNEL_REGISTRY["food"]]  # Always present
+
+    if env is not None:
+        if hasattr(env, "thermotaxis") and env.thermotaxis.enabled:
+            channels.append(CHANNEL_REGISTRY["temperature"])
+        if hasattr(env, "predator") and env.predator.enabled:
+            channels.append(CHANNEL_REGISTRY["predator"])
+        if hasattr(env, "aerotaxis") and env.aerotaxis.enabled:
+            channels.append(CHANNEL_REGISTRY["oxygen"])
+        if hasattr(env, "pheromones") and env.pheromones.enabled:
+            channels.append(CHANNEL_REGISTRY["pheromone_food"])
+            channels.append(CHANNEL_REGISTRY["pheromone_alarm"])
+            if env.pheromones.aggregation is not None:
+                channels.append(CHANNEL_REGISTRY["pheromone_aggregation"])
+
+    return tuple(channels)
+
+
+def stam_dim_from_env(env: DynamicForagingEnvironment | None) -> int:
+    """Compute STAM memory dimension for a given environment.
+
+    Convenience function combining resolve_active_channels + compute_memory_dim.
+
+    Parameters
+    ----------
+    env : DynamicForagingEnvironment or None
+        Environment instance.
+
+    Returns
+    -------
+    int
+        STAM memory state dimension.
+    """
+    return compute_memory_dim(len(resolve_active_channels(env)))
 
 
 def compute_memory_dim(num_channels: int) -> int:
@@ -44,23 +167,8 @@ def compute_memory_dim(num_channels: int) -> int:
     return num_channels * 2 + 3
 
 
-# Standard channel configurations
-CHANNELS_BASE = 4  # food, temperature, predator, oxygen
-CHANNELS_PHEROMONE = 6  # + pheromone_food, pheromone_alarm
-CHANNELS_PHEROMONE_FULL = 7  # + pheromone_aggregation
-
-# Channel indices (base 4-channel mode)
-IDX_FOOD = 0
-IDX_TEMP = 1
-IDX_PRED = 2
-IDX_OXYGEN = 3
-
-# Additional channel indices (6-channel pheromone mode)
-IDX_PHEROMONE_FOOD = 4
-IDX_PHEROMONE_ALARM = 5
-
-# Additional channel index (7-channel aggregation mode)
-IDX_PHEROMONE_AGGREGATION = 6
+# Minimum channel count (food is always present)
+MIN_CHANNELS = 1
 
 
 class STAMBuffer:
@@ -77,28 +185,23 @@ class STAMBuffer:
         Exponential decay lambda per step (default 0.1).
         Weight for entry i steps ago: w[i] = exp(-decay_rate * i).
     num_channels : int
-        Number of scalar sensory channels.
-        4 = base (food, temperature, predator, oxygen).
-        6 = with pheromones (+ pheromone_food, pheromone_alarm).
+        Number of scalar sensory channels. Determined dynamically from
+        environment config via resolve_active_channels(). Minimum 1 (food only).
 
     Attributes
     ----------
     MEMORY_DIM : int
         Dimension of the memory state vector (2*num_channels + 3).
-        11 for 4 channels, 15 for 6 channels.
     """
 
     def __init__(
         self,
         buffer_size: int = 30,
         decay_rate: float = 0.1,
-        num_channels: int = CHANNELS_BASE,
+        num_channels: int = MIN_CHANNELS,
     ) -> None:
-        if num_channels < CHANNELS_BASE:
-            msg = (
-                f"STAMBuffer requires at least {CHANNELS_BASE} channels "
-                f"(food, temperature, predator, oxygen). Got {num_channels}."
-            )
+        if num_channels < MIN_CHANNELS:
+            msg = f"STAMBuffer requires at least {MIN_CHANNELS} channel. Got {num_channels}."
             raise ValueError(msg)
 
         self._buffer_size = buffer_size

--- a/packages/quantum-nematode/quantumnematode/agent/stam.py
+++ b/packages/quantum-nematode/quantumnematode/agent/stam.py
@@ -115,13 +115,13 @@ def resolve_active_channels(
     channels: list[STAMChannelDef] = [CHANNEL_REGISTRY["food"]]  # Always present
 
     if env is not None:
-        if hasattr(env, "thermotaxis") and env.thermotaxis.enabled:
+        if env.thermotaxis.enabled:
             channels.append(CHANNEL_REGISTRY["temperature"])
-        if hasattr(env, "predator") and env.predator.enabled:
+        if env.predator.enabled:
             channels.append(CHANNEL_REGISTRY["predator"])
-        if hasattr(env, "aerotaxis") and env.aerotaxis.enabled:
+        if env.aerotaxis.enabled:
             channels.append(CHANNEL_REGISTRY["oxygen"])
-        if hasattr(env, "pheromones") and env.pheromones.enabled:
+        if env.pheromones.enabled:
             channels.append(CHANNEL_REGISTRY["pheromone_food"])
             channels.append(CHANNEL_REGISTRY["pheromone_alarm"])
             if env.pheromones.aggregation is not None:

--- a/packages/quantum-nematode/quantumnematode/agent/stam.py
+++ b/packages/quantum-nematode/quantumnematode/agent/stam.py
@@ -234,9 +234,8 @@ class STAMBuffer:
         ----------
         scalars : np.ndarray
             Scalar readings for each channel, shape (num_channels,).
-            Base order: [food, temperature, predator, oxygen].
-            With pheromones: [food, temp, predator, oxygen, pheromone_food, pheromone_alarm].
-            Disabled channels should pass 0.0.
+            Channel order is determined at runtime by resolve_active_channels().
+            Only active channels are included — no zero-padding for disabled features.
         position_delta : tuple[float, float]
             Step-to-step position change (dx, dy) — proprioceptive movement
             signal. NOT absolute grid coordinates.
@@ -273,8 +272,8 @@ class STAMBuffer:
         Parameters
         ----------
         channel : int
-            Channel index (0=food, 1=temperature, 2=predator, 3=oxygen,
-            4=pheromone_food, 5=pheromone_alarm when pheromones enabled).
+            Channel index into the active channels list (determined at
+            runtime by resolve_active_channels). Index 0 is always food.
 
         Returns
         -------

--- a/packages/quantum-nematode/quantumnematode/brain/modules.py
+++ b/packages/quantum-nematode/quantumnematode/brain/modules.py
@@ -1068,41 +1068,32 @@ def _infer_stam_dim_from_modules(modules: list[ModuleName]) -> int | None:
     # Food is always present (1 channel minimum)
     num_channels = 1
 
-    # Non-pheromone modules that add STAM channels (temporal or oracle)
-    env_channel_modules = {
-        ModuleName.THERMOTAXIS_TEMPORAL: 1,
-        ModuleName.THERMOTAXIS: 1,
-        ModuleName.NOCICEPTION_TEMPORAL: 1,
-        ModuleName.NOCICEPTION: 1,
-        ModuleName.AEROTAXIS_TEMPORAL: 1,
-        ModuleName.AEROTAXIS: 1,
-    }
-
-    for mod, count in env_channel_modules.items():
-        if mod in modules:
-            num_channels += count
-
-    # Pheromone channels: when any pheromone module is present, ALL pheromone
-    # types get STAM channels (resolve_active_channels adds all enabled types).
-    # Count individual pheromone types present.
-    pheromone_modules = {
-        ModuleName.PHEROMONE_FOOD_TEMPORAL,
-        ModuleName.PHEROMONE_ALARM_TEMPORAL,
-        ModuleName.PHEROMONE_AGGREGATION_TEMPORAL,
-        ModuleName.PHEROMONE_FOOD,
-        ModuleName.PHEROMONE_ALARM,
-        ModuleName.PHEROMONE_AGGREGATION,
-    }
-    has_any_pheromone = bool(pheromone_modules & set(modules))
-    if has_any_pheromone:
-        # When pheromones are enabled, food+alarm channels are always present
-        num_channels += 2  # pheromone_food + pheromone_alarm
-        # Aggregation is optional
-        if (
-            ModuleName.PHEROMONE_AGGREGATION_TEMPORAL in modules
-            or ModuleName.PHEROMONE_AGGREGATION in modules
-        ):
+    # Each modality adds at most one STAM channel (collapse oracle/temporal pairs)
+    modality_pairs = [
+        (ModuleName.THERMOTAXIS, ModuleName.THERMOTAXIS_TEMPORAL),
+        (ModuleName.NOCICEPTION, ModuleName.NOCICEPTION_TEMPORAL),
+        (ModuleName.AEROTAXIS, ModuleName.AEROTAXIS_TEMPORAL),
+    ]
+    modules_set = set(modules)
+    for oracle_mod, temporal_mod in modality_pairs:
+        if oracle_mod in modules_set or temporal_mod in modules_set:
             num_channels += 1
+
+    # Pheromone channels: when any pheromone module is present, food+alarm
+    # channels are always added (resolve_active_channels adds all enabled types).
+    pheromone_pairs = [
+        (ModuleName.PHEROMONE_FOOD, ModuleName.PHEROMONE_FOOD_TEMPORAL),
+        (ModuleName.PHEROMONE_ALARM, ModuleName.PHEROMONE_ALARM_TEMPORAL),
+        (ModuleName.PHEROMONE_AGGREGATION, ModuleName.PHEROMONE_AGGREGATION_TEMPORAL),
+    ]
+    has_any_pheromone = any(o in modules_set or t in modules_set for o, t in pheromone_pairs)
+    if has_any_pheromone:
+        num_channels += 2  # pheromone_food + pheromone_alarm always present
+        if (
+            ModuleName.PHEROMONE_AGGREGATION in modules_set
+            or ModuleName.PHEROMONE_AGGREGATION_TEMPORAL in modules_set
+        ):
+            num_channels += 1  # aggregation optional
 
     return compute_memory_dim(num_channels)
 

--- a/packages/quantum-nematode/quantumnematode/brain/modules.py
+++ b/packages/quantum-nematode/quantumnematode/brain/modules.py
@@ -1038,42 +1038,73 @@ def extract_classical_features(
     return np.array(features, dtype=np.float32)
 
 
-def _infer_stam_dim(modules: list[ModuleName]) -> int | None:
-    """Infer STAM memory dimension from sensory modules list.
+def _infer_stam_dim_from_modules(modules: list[ModuleName]) -> int | None:
+    """Infer STAM memory dimension from the sensory modules list.
 
-    Returns the correct STAM dimension based on which pheromone temporal
-    modules are present. Oracle pheromone modules do not add STAM channels
-    (pheromone data goes through the oracle module's to_classical, not STAM).
+    Counts how many STAM-relevant channels are implied by the module list:
+    - Base channels (food is always 1; temperature/predator/oxygen if their
+      temporal modules are present)
+    - Pheromone channels (if pheromone temporal modules present)
+
+    This is a fallback for brain construction where env is not available.
+    Callers with env access should use ``stam_dim_from_env(env)`` instead.
 
     Parameters
     ----------
     modules : list[ModuleName]
-        List of sensory modules to check for STAM and pheromone presence.
+        Sensory modules list.
 
     Returns
     -------
     int or None
-        Inferred STAM memory dimension, or None if STAM is not in the list.
+        Inferred STAM dimension, or None if STAM not in modules.
     """
     if ModuleName.STAM not in modules:
         return None
 
-    from quantumnematode.agent.stam import (
-        CHANNELS_BASE,
-        CHANNELS_PHEROMONE,
-        CHANNELS_PHEROMONE_FULL,
-        compute_memory_dim,
-    )
+    from quantumnematode.agent.stam import compute_memory_dim
 
-    has_pheromone_food = ModuleName.PHEROMONE_FOOD_TEMPORAL in modules
-    has_pheromone_alarm = ModuleName.PHEROMONE_ALARM_TEMPORAL in modules
-    has_pheromone_aggregation = ModuleName.PHEROMONE_AGGREGATION_TEMPORAL in modules
+    # Count channels implied by the module list
+    # Food is always present (1 channel minimum)
+    num_channels = 1
 
-    if has_pheromone_aggregation:
-        return compute_memory_dim(CHANNELS_PHEROMONE_FULL)
-    if has_pheromone_food or has_pheromone_alarm:
-        return compute_memory_dim(CHANNELS_PHEROMONE)
-    return compute_memory_dim(CHANNELS_BASE)
+    # Non-pheromone modules that add STAM channels (temporal or oracle)
+    env_channel_modules = {
+        ModuleName.THERMOTAXIS_TEMPORAL: 1,
+        ModuleName.THERMOTAXIS: 1,
+        ModuleName.NOCICEPTION_TEMPORAL: 1,
+        ModuleName.NOCICEPTION: 1,
+        ModuleName.AEROTAXIS_TEMPORAL: 1,
+        ModuleName.AEROTAXIS: 1,
+    }
+
+    for mod, count in env_channel_modules.items():
+        if mod in modules:
+            num_channels += count
+
+    # Pheromone channels: when any pheromone module is present, ALL pheromone
+    # types get STAM channels (resolve_active_channels adds all enabled types).
+    # Count individual pheromone types present.
+    pheromone_modules = {
+        ModuleName.PHEROMONE_FOOD_TEMPORAL,
+        ModuleName.PHEROMONE_ALARM_TEMPORAL,
+        ModuleName.PHEROMONE_AGGREGATION_TEMPORAL,
+        ModuleName.PHEROMONE_FOOD,
+        ModuleName.PHEROMONE_ALARM,
+        ModuleName.PHEROMONE_AGGREGATION,
+    }
+    has_any_pheromone = bool(pheromone_modules & set(modules))
+    if has_any_pheromone:
+        # When pheromones are enabled, food+alarm channels are always present
+        num_channels += 2  # pheromone_food + pheromone_alarm
+        # Aggregation is optional
+        if (
+            ModuleName.PHEROMONE_AGGREGATION_TEMPORAL in modules
+            or ModuleName.PHEROMONE_AGGREGATION in modules
+        ):
+            num_channels += 1
+
+    return compute_memory_dim(num_channels)
 
 
 def get_classical_feature_dimension(
@@ -1091,18 +1122,16 @@ def get_classical_feature_dimension(
     modules : list[ModuleName]
         List of modules.
     stam_dim_override : int or None, optional
-        Override for STAM module classical_dim. When pheromones are enabled,
-        STAM produces more channels (15 for 6-channel, 17 for 7-channel)
-        instead of the default 11. Pass the actual STAM memory dimension
-        to get the correct total feature dimension.
+        Override for STAM module classical_dim. Callers with env access
+        should pass ``stam_dim_from_env(env)`` from ``quantumnematode.agent.stam``.
+        If not provided, auto-infers from the modules list.
 
     Returns
     -------
     int
         Total number of features across all modules.
     """
-    # Auto-infer STAM dimension from pheromone modules if no override given
-    effective_stam_dim = stam_dim_override or _infer_stam_dim(modules)
+    effective_stam_dim = stam_dim_override or _infer_stam_dim_from_modules(modules)
 
     total = 0
     for module in modules:

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_agent.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_agent.py
@@ -392,13 +392,19 @@ class TestTemporalSensingIntegration:
         params = agent._create_brain_params()
         assert params.food_dconcentration_dt is not None
 
-    def test_stam_state_is_11_floats(self) -> None:
-        """Test that STAM state is an 11-float tuple on BrainParams."""
+    def test_stam_state_matches_active_channels(self) -> None:
+        """Test that STAM state dimension matches active channel count.
+
+        Foraging-only env has 1 channel (food), so MEMORY_DIM = 2*1 + 3 = 5.
+        """
+        from quantumnematode.agent.stam import compute_memory_dim
+
         sensing = SensingConfig(stam_enabled=True)
         agent = self._create_temporal_agent(sensing)
         params = agent._create_brain_params()
         assert params.stam_state is not None
-        assert len(params.stam_state) == 11
+        expected_dim = compute_memory_dim(len(agent._active_channels))
+        assert len(params.stam_state) == expected_dim
         assert all(isinstance(v, float) for v in params.stam_state)
 
     def test_oracle_mode_leaves_temporal_fields_none(self) -> None:
@@ -429,7 +435,7 @@ class TestTemporalSensingIntegration:
         agent._previous_position = None
 
         state = agent._stam.get_memory_state()
-        np.testing.assert_array_equal(state, np.zeros(11, dtype=np.float32))
+        np.testing.assert_array_equal(state, np.zeros(agent._stam.MEMORY_DIM, dtype=np.float32))
 
     def test_mixed_modes_per_modality(self) -> None:
         """Test that different modes can be used for different modalities."""

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_stam.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_stam.py
@@ -12,33 +12,33 @@ class TestSTAMBufferBasics:
 
     def test_initial_state(self) -> None:
         """Test that a new buffer is empty with correct memory dimension."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         assert len(buf) == 0
         assert buf.memory_dimension == 11
 
     def test_record_single_entry(self) -> None:
         """Test that recording a single entry increments the buffer length."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         buf.record(np.array([0.5, 0.3, 0.1, 0.0]), (1.0, 0.0), 0)
         assert len(buf) == 1
 
     def test_record_multiple_entries(self) -> None:
         """Test that recording multiple entries tracks buffer length correctly."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for i in range(5):
             buf.record(np.array([float(i), 0.0, 0.0, 0.0]), (1.0, 0.0), 0)
         assert len(buf) == 5
 
     def test_buffer_size_limit(self) -> None:
         """Test that the buffer does not exceed its configured size limit."""
-        buf = STAMBuffer(buffer_size=5, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=5, decay_rate=0.1, num_channels=4)
         for i in range(10):
             buf.record(np.array([float(i), 0.0, 0.0, 0.0]), (1.0, 0.0), 0)
         assert len(buf) == 5
 
     def test_reset_clears_buffer(self) -> None:
         """Test that reset empties the buffer and zeroes the memory state."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for i in range(5):
             buf.record(np.array([float(i), 0.0, 0.0, 0.0]), (1.0, 0.0), 0)
         buf.reset()
@@ -52,26 +52,26 @@ class TestDecayWeights:
 
     def test_weights_decrease_with_age(self) -> None:
         """Test that decay weights decrease monotonically with age."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for i in range(1, len(buf._weights)):
             assert buf._weights[i] < buf._weights[i - 1]
 
     def test_most_recent_weight_is_one(self) -> None:
         """Test that the most recent entry has a weight of 1.0."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         assert buf._weights[0] == pytest.approx(1.0)
 
     def test_weight_formula(self) -> None:
         """Test that weights follow the exponential decay formula."""
         decay_rate = 0.2
-        buf = STAMBuffer(buffer_size=5, decay_rate=decay_rate)
+        buf = STAMBuffer(buffer_size=5, decay_rate=decay_rate, num_channels=4)
         for i in range(5):
             expected = np.exp(-decay_rate * i)
             assert buf._weights[i] == pytest.approx(expected)
 
     def test_weighted_mean_emphasizes_recent(self) -> None:
         """Test that the weighted mean is biased toward recent entries."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.5)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.5, num_channels=4)
         # Record: old value 0.0, then recent value 1.0
         buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         buf.record(np.array([1.0, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
@@ -85,7 +85,7 @@ class TestTemporalDerivative:
 
     def test_insufficient_history_returns_zero(self) -> None:
         """Test that temporal derivative returns zero with insufficient history."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         assert buf.compute_temporal_derivative(0) == 0.0
 
         buf.record(np.array([0.5, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
@@ -93,7 +93,7 @@ class TestTemporalDerivative:
 
     def test_positive_derivative_increasing_concentration(self) -> None:
         """Test that increasing concentration produces a positive derivative."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         # Older: 0.2, newer: 0.8 → concentration increased → positive derivative
         buf.record(np.array([0.2, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         buf.record(np.array([0.8, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
@@ -102,7 +102,7 @@ class TestTemporalDerivative:
 
     def test_negative_derivative_decreasing_concentration(self) -> None:
         """Test that decreasing concentration produces a negative derivative."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         # Older: 0.8, newer: 0.2 → concentration decreased → negative derivative
         buf.record(np.array([0.8, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         buf.record(np.array([0.2, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
@@ -111,7 +111,7 @@ class TestTemporalDerivative:
 
     def test_zero_derivative_stationary(self) -> None:
         """Test that stationary concentration produces a zero derivative."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for _ in range(5):
             buf.record(np.array([0.5, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         deriv = buf.compute_temporal_derivative(0)
@@ -119,7 +119,7 @@ class TestTemporalDerivative:
 
     def test_derivative_per_channel(self) -> None:
         """Test that derivatives are computed independently per channel."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         # Food increasing, temp decreasing, predator constant
         buf.record(np.array([0.2, 0.8, 0.5, 0.0]), (0.0, 0.0), 0)
         buf.record(np.array([0.8, 0.2, 0.5, 0.0]), (0.0, 0.0), 0)
@@ -129,7 +129,7 @@ class TestTemporalDerivative:
 
     def test_derivative_exact_value_two_entries(self) -> None:
         """Test that the derivative matches the expected exact value with two entries."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         buf.record(np.array([0.3, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         buf.record(np.array([0.7, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         # With 2 entries, only one diff: C[0] - C[1] = 0.7 - 0.3 = 0.4
@@ -143,7 +143,7 @@ class TestMemoryState:
 
     def test_empty_buffer_returns_zeros(self) -> None:
         """Test that an empty buffer returns a zero-filled memory state."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         state = buf.get_memory_state()
         assert state.shape == (11,)
         assert state.dtype == np.float32
@@ -151,7 +151,7 @@ class TestMemoryState:
 
     def test_shape_always_11(self) -> None:
         """Test that memory state shape is always 11 regardless of buffer contents."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for i in range(7):
             buf.record(np.array([float(i), 0.0, 0.0, 0.0]), (1.0, 0.0), i % 4)
             state = buf.get_memory_state()
@@ -159,7 +159,7 @@ class TestMemoryState:
 
     def test_weighted_means_in_first_four(self) -> None:
         """Test that the first four state elements contain weighted means of channels."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.0)  # No decay = equal weights
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.0, num_channels=4)  # No decay = equal weights
         buf.record(np.array([0.2, 0.4, 0.6, 0.8]), (0.0, 0.0), 0)
         buf.record(np.array([0.8, 0.6, 0.4, 0.2]), (0.0, 0.0), 0)
         state = buf.get_memory_state()
@@ -171,7 +171,7 @@ class TestMemoryState:
 
     def test_derivatives_in_indices_4_to_7(self) -> None:
         """Test that state indices 4-7 contain per-channel temporal derivatives."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         buf.record(np.array([0.2, 0.8, 0.5, 0.0]), (0.0, 0.0), 0)
         buf.record(np.array([0.8, 0.2, 0.5, 0.0]), (0.0, 0.0), 0)
         state = buf.get_memory_state()
@@ -182,7 +182,7 @@ class TestMemoryState:
 
     def test_partially_filled_buffer(self) -> None:
         """Test that a partially filled buffer produces correct weighted means."""
-        buf = STAMBuffer(buffer_size=30, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=30, decay_rate=0.1, num_channels=4)
         buf.record(np.array([0.5, 0.3, 0.1, 0.2]), (1.0, 0.0), 0)
         state = buf.get_memory_state()
         assert state.shape == (11,)
@@ -198,7 +198,7 @@ class TestPositionDeltas:
 
     def test_single_entry_zero_deviation(self) -> None:
         """Test that a single entry produces zero position deviation."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (1.0, 0.0), 0)
         state = buf.get_memory_state()
         # Only one entry → deviation from mean is 0
@@ -207,7 +207,7 @@ class TestPositionDeltas:
 
     def test_consistent_movement_zero_deviation(self) -> None:
         """Test that consistent movement produces zero deviation from the mean."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.0)  # Equal weights
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.0, num_channels=4)  # Equal weights
         for _ in range(5):
             buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (1.0, 0.0), 0)
         state = buf.get_memory_state()
@@ -217,7 +217,7 @@ class TestPositionDeltas:
 
     def test_direction_change_nonzero_deviation(self) -> None:
         """Test that a sudden direction change produces nonzero deviation."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.0)  # Equal weights
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.0, num_channels=4)  # Equal weights
         # Consistent rightward movement
         for _ in range(4):
             buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (1.0, 0.0), 0)
@@ -230,7 +230,7 @@ class TestPositionDeltas:
 
     def test_uses_deltas_not_absolute_positions(self) -> None:
         """Verify we store step-to-step movement, not absolute coords."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         # These are (dx, dy) per step, not positions
         buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (1.0, 0.0), 0)  # Moved right
         buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (-1.0, 0.0), 0)  # Moved left
@@ -246,7 +246,7 @@ class TestActionEntropy:
 
     def test_single_action_zero_entropy(self) -> None:
         """Test that repeating a single action produces zero entropy."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for _ in range(5):
             buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         state = buf.get_memory_state()
@@ -254,7 +254,7 @@ class TestActionEntropy:
 
     def test_diverse_actions_positive_entropy(self) -> None:
         """Test that diverse actions produce positive entropy."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for i in range(8):
             buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (0.0, 0.0), i % 4)
         state = buf.get_memory_state()
@@ -262,7 +262,7 @@ class TestActionEntropy:
 
     def test_maximum_diversity(self) -> None:
         """Test that equally distributed actions produce maximum entropy."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         # Equal distribution across 4 actions
         for i in range(8):
             buf.record(np.array([0.0, 0.0, 0.0, 0.0]), (0.0, 0.0), i % 4)
@@ -276,7 +276,7 @@ class TestEpisodeReset:
 
     def test_reset_produces_zero_state(self) -> None:
         """Test that reset returns the memory state to all zeros."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         for i in range(5):
             buf.record(np.array([float(i), float(i), float(i), float(i)]), (1.0, 1.0), i)
         buf.reset()
@@ -285,7 +285,7 @@ class TestEpisodeReset:
 
     def test_reset_allows_fresh_recording(self) -> None:
         """Test that recording after reset is not influenced by pre-reset data."""
-        buf = STAMBuffer(buffer_size=10, decay_rate=0.1)
+        buf = STAMBuffer(buffer_size=10, decay_rate=0.1, num_channels=4)
         buf.record(np.array([1.0, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)
         buf.reset()
         buf.record(np.array([0.5, 0.0, 0.0, 0.0]), (0.0, 0.0), 0)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_lstmppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_lstmppo.py
@@ -578,8 +578,11 @@ class TestLSTMPPOBrainSensoryModules:
             ModuleName.STAM,
         ]
         brain = _make_brain(sensory_modules=modules)
-        # STAM has classical_dim=11, plus 2 per normal module = 4 + 11 = 15
-        expected_dim = 2 + 2 + 11  # food_chemotaxis_temporal + proprioception + STAM
+        # With only food temporal module, STAM infers 1 channel
+        from quantumnematode.agent.stam import compute_memory_dim
+
+        stam_dim = compute_memory_dim(1)  # Only food channel inferred
+        expected_dim = 2 + 2 + stam_dim
         assert brain.input_dim == expected_dim
 
         brain.prepare_episode()
@@ -589,7 +592,7 @@ class TestLSTMPPOBrainSensoryModules:
             agent_direction=Direction.UP,
             food_concentration=0.7,
             food_dconcentration_dt=0.1,
-            stam_state=(0.1,) * 11,
+            stam_state=(0.1,) * stam_dim,
         )
         actions = brain.run_brain(params, top_only=False, top_randomize=False)
         assert len(actions) == 1

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/test_temporal_modules.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/test_temporal_modules.py
@@ -222,5 +222,8 @@ class TestTemporalModuleIntegration:
             ModuleName.STAM,
         ]
         dim = get_classical_feature_dimension(modules)
-        # 2 + 2 + 3 + 11 = 18
-        assert dim == 18
+        # STAM infers 3 channels from temporal modules: food + predator + temperature
+        from quantumnematode.agent.stam import compute_memory_dim
+
+        stam_dim = compute_memory_dim(3)  # food + predator + temperature
+        assert dim == 2 + 2 + 3 + stam_dim

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -1701,6 +1701,14 @@ def _run_multi_agent(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     )
                 for agent in agents:
                     agent.env = env
+                    # Rebuild STAM channel fetchers for the new env instance
+                    if agent._active_channels:
+                        from quantumnematode.agent.agent import _build_channel_fetchers
+
+                        agent._channel_fetchers = _build_channel_fetchers(
+                            env,
+                            agent._active_channels,
+                        )
                     pos = env.agents[agent.agent_id].position
                     agent.path = [(pos[0], pos[1])]
                     agent.food_history = [list(env.foods)]


### PR DESCRIPTION
## Summary

Replaces hardcoded STAM channel constants with a registry-based approach where the channel list is derived from environment configuration. Closes #118.

### Problem

Adding a new STAM channel previously required synchronized changes across 5 files (stam.py constants, agent.py if/elif chain, agent.py scalar building, agent.py derivative extraction, modules.py _infer_stam_dim). This caused a runtime crash during Phase 4 evaluation (STAM dimension mismatch) and required `_infer_stam_dim()` as a workaround.

### Solution

- `STAMChannelDef` dataclass + `CHANNEL_REGISTRY` in stam.py defines all possible channels
- `resolve_active_channels(env)` determines active channels from environment config
- Channels are conditional on enabled features:
  - **food**: always present (1 channel minimum)
  - **temperature**: only when `env.thermotaxis.enabled`
  - **predator**: only when `env.predator.enabled`
  - **oxygen**: only when `env.aerotaxis.enabled`
  - **pheromone_food/alarm/aggregation**: only when pheromones enabled
- `_build_channel_fetchers()` creates env-reading callables per channel
- `_compute_temporal_data` refactored: scalar assembly and derivative extraction loop over active channels instead of hardcoded indices
- `_infer_stam_dim_from_modules()` replaces old `_infer_stam_dim()` with smarter channel counting

### Impact on STAM dimensions

| Config | Before | After |
|--------|--------|-------|
| Foraging-only | 4 channels, MEMORY_DIM=11 | **1 channel, MEMORY_DIM=5** |
| Thermal pursuit | 4 channels, MEMORY_DIM=11 | **3 channels, MEMORY_DIM=9** |
| Full pheromone | 7 channels, MEMORY_DIM=17 | 7 channels, MEMORY_DIM=17 (unchanged) |

Simpler configs get smaller brain inputs — less noise from zero-valued unused channels.

### Adding a new channel after this refactor

1. Add entry to `CHANNEL_REGISTRY` in stam.py
2. Add condition in `resolve_active_channels()`
3. Add fetcher lambda in `_build_channel_fetchers()` in agent.py

Three localized changes instead of five scattered ones.

## Regression checks (100 episodes)

| Config | Post-Refactor | Reference | Status |
|--------|--------------|-----------|--------|
| Oracle foraging (single-agent) | 96% success | 93-98% (Logbook 009) | In range |
| Temporal foraging (single-agent) | 13% at 100 eps | 67.9% at 1000 eps (Logbook 009) | On track |
| Multi-agent 5-agent oracle | 45.7 food/ep | 48.1 at 4000 eps (Logbook 011) | On track |

## Test plan

- [x] `uv run pytest -m "not nightly"` — 2074 passed
- [x] `uv run pre-commit run -a` — all hooks pass
- [x] `uv run pyright` on key files — 0 errors
- [x] `uv run ruff check` — all passed
- [x] 5 config sanity checks (foraging oracle, thermal pursuit, multi-agent oracle, multi-agent pheromone temporal, LSTM temporal)
- [x] 3 regression checks against logbook baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * STAM channel system now resolves active channels from the environment at runtime; memory dimensions are computed from enabled features and temporal derivatives are extracted per-active-channel.

* **Chores**
  * Per-episode logs report active channel counts and per-channel summaries; channel fetchers are rebuilt when environments are reset/assigned.

* **Tests**
  * Tests updated to compute expected STAM/memory dimensions dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->