### PR TITLE
docs: add Phase 5 tracking scaffold (M-1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,4 +64,10 @@ Three tiers:
 
 Always run `uv run pytest -m "not nightly"` after changes. Run `uv run pre-commit run -a` before committing.
 
+## Pull Requests
+
+PR titles MUST use [Conventional Commits](https://www.conventionalcommits.org/) prefixes. Common types in this repo: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`. Use `!` after the type for breaking changes (e.g. `feat!: remove legacy preprocessing mode`). Examples from project history: `feat: Add aerotaxis (oxygen sensing) system`, `fix: multi-agent sensing - use agent's own position in BrainParams`, `docs: Klinotaxis Era multi-agent pheromone evaluation (Logbook 011)`.
+
+Commit messages do not require this prefix — only PR titles do.
+
 <!-- markdownlint-disable MD025 -->

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,7 +58,7 @@ ______________________________________________________________________
 | **2** | Q2 - Q3 2026 | Architecture Analysis | ✅ SUBSTANTIALLY COMPLETE | 300+ session quantum evaluation, brain renaming, statistical framework |
 | **3** | Q2 - Q3 2026 | Temporal Sensing & Memory | ✅ SUBSTANTIALLY COMPLETE | Temporal/derivative sensing, STAM, LSTM/GRU PPO brain (19th architecture). Temporal Mode A achieves 94% L500 on hardest environment. Oxygen sensing (aerotaxis) implemented with 5-zone system and combined thermal+oxygen environments. |
 | **4** | Q3 - Q4 2026 | Multi-Agent Complexity | ✅ SUBSTANTIALLY COMPLETE | Deliverables 1-3 merged (infrastructure, pheromones, social dynamics). Evaluation campaign (Logbook 011): temporal collective exploration advantage (+14.3%), social feeding +35% food under scarcity, zero coordination overhead with proportional resources, pheromones neutral. Two critical bugs found and fixed (#112, #115). Quantum checkpoint not triggered — no genuine coordination complexity. Food spatial persistence deferred (issue #116). |
-| **5** | Q4 2026 - Q1 2027 | Evolution & Adaptation | 🔲 PLANNED | Baldwin Effect, co-evolution, transgenerational memory |
+| **5** | Q4 2026 - Q1 2027 | Evolution & Adaptation | 🟡 IN PROGRESS | Baldwin Effect, co-evolution, transgenerational memory |
 | **6** | Q1 - Q3 2027 | Continuous Physics & Connectome | 🔲 PLANNED | Continuous 2D, realistic locomotion, full 302-neuron connectome |
 | **7** | Q2 - Q4 2027 | Community & Publication | 🔲 PLANNED | NematodeBench launch, publication campaign, external collaboration |
 | **8** | Late 2027+ | Integration & Evaluation | 🔲 PLANNED | Full integration, definitive quantum vs. classical comparison |
@@ -494,6 +494,25 @@ ______________________________________________________________________
 **Prerequisites**: Phase 3 (memory infrastructure for transgenerational memory). Phase 4 multi-agent infrastructure required only for co-evolution (deliverable 4) — other deliverables can begin in parallel with Phase 4.
 
 **Pilot-Then-Focus Approach**: Start with lightweight pilots of 2-3 evolutionary approaches using small populations and few generations. Based on pilot results, select 1-2 approaches for deep investigation.
+
+#### Phase 5 Milestone Tracker
+
+Phase 5 is broken into 8 milestones (M0–M7) plus a tracking scaffold (M-1). The living checklist with sub-task granularity lives in [openspec/changes/2026-04-26-phase5-tracking/tasks.md](../openspec/changes/2026-04-26-phase5-tracking/tasks.md). Three Phase 5 design decisions are recorded in that change's [proposal.md](../openspec/changes/2026-04-26-phase5-tracking/proposal.md): pilot-first, no QVarCircuit backwards compatibility, and LSTMPPO+klinotaxis as the first-class brain for headline scientific milestones (M4/M5/M6).
+
+| # | Milestone | Bio fidelity | Status |
+|---|-----------|--------------|--------|
+| M-1 | Phase 5 tracking scaffold | — | 🟡 in progress |
+| M0 | Brain-agnostic evolution framework (fresh build) | LOW | 🔲 not started |
+| M1 | Predator-as-brain refactor | MEDIUM | 🔲 not started |
+| M2 | Hyperparameter evolution pilot | LOW | 🔲 not started |
+| M3 | Lamarckian evolution pilot | MEDIUM | 🔲 not started |
+| M4 | Baldwin effect demonstration (gated on M3) | MEDIUM | 🔲 not started |
+| M5 | Co-evolution arms race | HIGH | 🔲 not started |
+| M6 | Transgenerational memory (gated on M3 + M4/M5) | HIGH | 🔲 not started |
+| M6.5 | NEAT topology evolution (optional) | LOW | 🔲 not started |
+| M7 | Phase 5 synthesis logbook | — | 🔲 not started |
+
+**How to orient**: a fresh AI session resuming Phase 5 work should read this tracker first to identify the current milestone, then open the [tasks.md](../openspec/changes/2026-04-26-phase5-tracking/tasks.md) checklist for sub-task detail, then any active per-milestone OpenSpec change (e.g. `openspec/changes/2026-04-28-add-evolution-framework/`) for the in-flight scope.
 
 #### Deliverables
 

--- a/openspec/changes/2026-04-26-phase5-tracking/design.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/design.md
@@ -1,0 +1,68 @@
+## Overview
+
+Phase 5 (Evolution & Adaptation) spans 8 milestones (M0–M7) plus this scaffold (M-1) over many months and AI sessions. This design documents the cross-session tracking strategy so the choice of artefacts is explicit and can be revisited if it proves insufficient.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A future AI session can answer "what's the next Phase 5 milestone?" by reading two files (this `tasks.md` and the roadmap Phase 5 block)
+- Each Phase 5 milestone PR has a single canonical place to mark progress
+- Three Phase 5 design decisions (pilot-first, no QVarCircuit backwards compat, LSTMPPO+klinotaxis first-class) are recorded once, not re-derived per session
+- The tracking artefact decays gracefully: when M7 is published, this change archives alongside it
+
+**Non-Goals:**
+
+- Real-time progress dashboards (the roadmap status table is enough)
+- Automated milestone status (humans/agents update the checklist manually as part of milestone PRs)
+- Replacing per-milestone OpenSpec changes — those still happen, this scaffold is *additional* coordination
+- GitHub Issues / Project boards — optional mirror, decided at PR time per milestone
+
+## Design Decisions
+
+### Decision 1: One change directory for all of Phase 5, not one per milestone
+
+Each Phase 5 milestone (M0–M7) gets its own OpenSpec change directory (e.g. `2026-04-28-add-evolution-framework`). This M-1 change is *additional* — it's the meta-tracking layer above the per-milestone changes.
+
+**Why:** Per-milestone changes are scoped to one PR with concrete code/spec deltas; they archive on merge. The Phase 5 tracker needs to outlive any single milestone — it spans the entire phase. Putting it in its own change directory means it lives until M7 archives it, while individual milestones come and go.
+
+**Alternative considered:** Embed milestone tracking in `docs/roadmap.md` only. Rejected because the roadmap is the public-facing strategy doc; sub-task granularity belongs in a working artefact. The roadmap gets a one-line status per milestone (the "Milestone Tracker" sub-section); the OpenSpec `tasks.md` carries the full sub-task checklist.
+
+### Decision 2: tasks.md uses sub-task granularity matching Phase 4
+
+Phase 4's `2026-04-11-add-phase4-evaluation/tasks.md` used numbered sub-tasks (1.1, 1.2, … 7.x) with `[x]` checkboxes. M-1 follows the same convention — each Phase 5 milestone gets a numbered section with its sub-tasks listed. This means subsequent milestone PRs that update the checklist look stylistically identical to Phase 4 evaluation work.
+
+**Why:** Familiarity reduces cognitive load. Future AI sessions that have seen Phase 4 patterns will read the Phase 5 tracker the same way.
+
+### Decision 3: Three recorded design decisions surface in proposal.md, not buried in this file
+
+The three decisions (pilot-first, no QVarCircuit backwards compat, LSTMPPO+klinotaxis first-class) are stated in `proposal.md` so they show up in `openspec change show 2026-04-26-phase5-tracking`. The rationale lives here in `design.md` for anyone who wants the reasoning.
+
+**Why:** A future session reading the proposal first should see *what was decided* without having to open the design doc. The design doc explains *why those decisions* but isn't required reading.
+
+## Tracking Strategy
+
+Three artefacts answer "where are we in Phase 5?":
+
+1. **`openspec/changes/2026-04-26-phase5-tracking/tasks.md`** — sub-task checklist updated by every milestone PR
+2. **`openspec/changes/<milestone>/`** — per-milestone proposal/tasks/design/specs, archived on milestone merge
+3. **`docs/roadmap.md` Phase 5 section** — one-line milestone status, updated as part of every milestone PR
+
+A future AI session orients by:
+
+- Reading the roadmap Phase 5 block first (one-line current status per milestone)
+- Reading this `tasks.md` for sub-task granularity
+- Reading active `openspec/changes/<milestone>/` if a specific milestone is in flight
+- Reading the latest published `artifacts/logbooks/0XX/` if a milestone has completed evaluation
+
+## Maintenance
+
+- Every Phase 5 milestone PR updates `tasks.md` (mark sub-tasks complete) and `docs/roadmap.md` Phase 5 milestone tracker (one-line status update)
+- This change does not archive until M7 completes
+- If Phase 5 deviates substantially from this plan (e.g. a milestone is dropped or reordered), update `tasks.md` to reflect reality — the checklist is descriptive, not aspirational
+
+## Risks
+
+1. **The checklist drifts from reality if PRs forget to update it.** Mitigation: include "update phase5-tracking tasks.md" in the per-milestone PR template / checklist.
+2. **The three recorded decisions become stale if circumstances change.** Mitigation: any decision reversal must amend `proposal.md` in a follow-up commit to this same change directory, leaving git history as the audit trail.
+3. **Sub-task granularity becomes too fine and burdensome.** Mitigation: the M-1 initial `tasks.md` keeps each milestone to ~5–10 sub-tasks; expand only if necessary.

--- a/openspec/changes/2026-04-26-phase5-tracking/proposal.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Phase 4 (multi-agent complexity) is complete. Phase 5 (Evolution & Adaptation) begins now and will span multiple AI sessions over months across many milestone PRs. Without an explicit cross-session tracking artefact, future sessions will have to re-derive the milestone plan, re-read recent logbooks, and re-discover decisions already made.
+
+Phase 4 used the per-milestone OpenSpec change directory and Logbook 011 to coordinate work, but lacked a single living checklist tying milestones together. This change introduces that scaffold for Phase 5 so any AI session can resume Phase 5 work by reading two files: this change's `tasks.md` and the roadmap Phase 5 block.
+
+This is a **process-only change**: no code, no spec capability changes, no behavioural impact. It exists so subsequent Phase 5 milestone PRs have a place to update progress.
+
+## What Changes
+
+### 1. Phase 5 Milestone Tracking Change
+
+Create `openspec/changes/2026-04-26-phase5-tracking/` with proposal/tasks/design. The `tasks.md` is a living checklist of every Phase 5 milestone (M0–M7) at sub-task granularity. Each subsequent Phase 5 milestone PR (M0, M1, M2, …) updates this checklist as part of its diff.
+
+This change is intentionally not archived after merge — it stays open until the entire Phase 5 is complete (M7 logbook published). At that point it gets archived alongside the M7 evaluation change.
+
+### 2. Roadmap Status Block Update
+
+Edit `docs/roadmap.md` Phase 5 section:
+
+- Update Phase 5 row in Timeline Overview table from `🔲 PLANNED` to `🟡 IN PROGRESS`
+- Add a **Phase 5 Milestone Tracker** sub-section directly under the existing Phase 5 deliverables list, with one bullet per milestone (M-1 through M7) and current status
+
+### 3. Three Recorded Phase 5 Decisions
+
+The plan that generated these milestones made three decisions that should be visible in `proposal.md` and `design.md` so they aren't re-litigated:
+
+- **Pilot-first**: M2 hyperparameter + M3 Lamarckian as lightweight pilots (20-30 gens, small population). Subsequent scientific milestones (M4 Baldwin, M5 co-evolution, M6 transgenerational) are gated on pilot evidence.
+- **No QVarCircuit backwards compatibility**: existing `scripts/run_evolution.py` is hardcoded to `QVarCircuitBrain` — the M0 framework rebuild does not preserve byte-equivalent behaviour. Old script moves to `scripts/legacy/` unmaintained. Quantum brain support deferred to Phase 6.
+- **LSTMPPO + klinotaxis as first-class brain**: M2/M3 use cheap MLPPPO for fast iteration, but the headline scientific milestones (M4/M5/M6) all target LSTMPPO+klinotaxis because Phase 4 produced 20+ validated configs with this combination, recurrent state allows transmission of meaningful priors (relevant for Lamarckian/Baldwin/transgenerational), and bilateral head-sweep sensing is the most biologically realistic configuration we have.
+
+## Capabilities
+
+**No spec capability changes** — process scaffold only.
+
+## Impact
+
+**Docs:**
+
+- `openspec/changes/2026-04-26-phase5-tracking/proposal.md` — this file
+- `openspec/changes/2026-04-26-phase5-tracking/tasks.md` — living Phase 5 milestone checklist
+- `openspec/changes/2026-04-26-phase5-tracking/design.md` — tracking strategy notes
+- `docs/roadmap.md` — Phase 5 status → IN PROGRESS, milestone tracker sub-section
+
+**Code:** None.
+
+**Configs:** None.
+
+## Breaking Changes
+
+None.
+
+## Backward Compatibility
+
+Process-only change. No runtime behaviour affected.

--- a/openspec/changes/2026-04-26-phase5-tracking/proposal.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/proposal.md
@@ -4,7 +4,7 @@ Phase 4 (multi-agent complexity) is complete. Phase 5 (Evolution & Adaptation) b
 
 Phase 4 used the per-milestone OpenSpec change directory and Logbook 011 to coordinate work, but lacked a single living checklist tying milestones together. This change introduces that scaffold for Phase 5 so any AI session can resume Phase 5 work by reading two files: this change's `tasks.md` and the roadmap Phase 5 block.
 
-This is a **process-only change**: no code, no spec capability changes, no behavioural impact. It exists so subsequent Phase 5 milestone PRs have a place to update progress.
+This change adds a new `phase5-tracking` spec capability whose requirements commit the project to (a) maintaining a single living checklist for all of Phase 5, (b) keeping the roadmap status block in sync with that checklist, and (c) recording Phase 5 design decisions in this change directory rather than re-deriving them per session. There is no runtime / source-code impact — the commitment is documentation discipline enforced by future PR review.
 
 ## What Changes
 
@@ -31,7 +31,7 @@ The plan that generated these milestones made three decisions that should be vis
 
 ## Capabilities
 
-**No spec capability changes** — process scaffold only.
+**Added**: `phase5-tracking` (new) — three requirements covering the living milestone checklist, the roadmap Phase 5 status block, and the Phase 5 decision record. This capability lives until M7 archives alongside it.
 
 ## Impact
 
@@ -40,6 +40,7 @@ The plan that generated these milestones made three decisions that should be vis
 - `openspec/changes/2026-04-26-phase5-tracking/proposal.md` — this file
 - `openspec/changes/2026-04-26-phase5-tracking/tasks.md` — living Phase 5 milestone checklist
 - `openspec/changes/2026-04-26-phase5-tracking/design.md` — tracking strategy notes
+- `openspec/changes/2026-04-26-phase5-tracking/specs/phase5-tracking/spec.md` — new capability
 - `docs/roadmap.md` — Phase 5 status → IN PROGRESS, milestone tracker sub-section
 
 **Code:** None.
@@ -52,4 +53,4 @@ None.
 
 ## Backward Compatibility
 
-Process-only change. No runtime behaviour affected.
+No runtime behaviour affected. The new `phase5-tracking` capability is documentation-only and has no consumers in code.

--- a/openspec/changes/2026-04-26-phase5-tracking/specs/phase5-tracking/spec.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/specs/phase5-tracking/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Phase 5 Living Milestone Checklist
+
+The repository SHALL maintain a single living checklist file at `openspec/changes/2026-04-26-phase5-tracking/tasks.md` covering every Phase 5 milestone (M-1 through M7) at sub-task granularity, updated by every Phase 5 milestone PR as part of its diff.
+
+#### Scenario: Future session orients to Phase 5
+
+- **GIVEN** a fresh AI session resumes Phase 5 work
+- **WHEN** the agent reads `openspec/changes/2026-04-26-phase5-tracking/tasks.md` and the `docs/roadmap.md` Phase 5 block
+- **THEN** the agent SHALL be able to identify the current in-progress milestone and the next milestone to start without further codebase exploration
+
+#### Scenario: Milestone PR updates the checklist
+
+- **GIVEN** a Phase 5 milestone PR (e.g. M0, M1, …, M7) is being prepared
+- **WHEN** the PR is opened
+- **THEN** the PR diff SHALL include updates to `openspec/changes/2026-04-26-phase5-tracking/tasks.md` marking completed sub-tasks as `[x]` and updating the milestone status header
+
+#### Scenario: Checklist outlives individual milestones
+
+- **GIVEN** a Phase 5 milestone OpenSpec change (e.g. `2026-04-28-add-evolution-framework`) is archived
+- **WHEN** archival completes
+- **THEN** the `2026-04-26-phase5-tracking` change SHALL remain unarchived and continue to receive updates from subsequent milestone PRs
+- **AND** archival of `2026-04-26-phase5-tracking` itself SHALL only occur alongside the M7 synthesis evaluation change
+
+### Requirement: Roadmap Phase 5 Status Block
+
+The `docs/roadmap.md` Phase 5 section SHALL include a Phase 5 Milestone Tracker sub-section listing each milestone with current status, updated as part of every Phase 5 milestone PR.
+
+#### Scenario: Roadmap reflects current milestone progress
+
+- **GIVEN** a Phase 5 milestone has just been completed
+- **WHEN** the milestone PR is merged
+- **THEN** the roadmap Phase 5 Milestone Tracker SHALL show that milestone's status as `complete` with a one-line summary
+- **AND** the next milestone in sequence SHALL show status `in progress` if work has begun, otherwise `not started`
+
+#### Scenario: Roadmap timeline table reflects phase status
+
+- **GIVEN** Phase 5 has at least one milestone in progress (M-1 onward)
+- **WHEN** a reader views the Timeline Overview table at the top of `docs/roadmap.md`
+- **THEN** the Phase 5 row SHALL show status `🟡 IN PROGRESS` (not `🔲 PLANNED`)
+- **AND** when M7 completes the row SHALL change to `✅ COMPLETE`
+
+### Requirement: Recorded Phase 5 Decisions
+
+The `proposal.md` of `2026-04-26-phase5-tracking` SHALL record the three Phase 5 design decisions (pilot-first, no QVarCircuit backwards compatibility, LSTMPPO+klinotaxis as first-class brain) so that subsequent sessions do not re-litigate them.
+
+#### Scenario: Decision is recorded once
+
+- **GIVEN** a Phase 5 design decision has been made (e.g. "no QVarCircuit backwards compatibility")
+- **WHEN** the decision is finalized
+- **THEN** it SHALL appear in `openspec/changes/2026-04-26-phase5-tracking/proposal.md`
+- **AND** the rationale SHALL appear in `openspec/changes/2026-04-26-phase5-tracking/design.md`
+
+#### Scenario: Decision reversal preserves audit trail
+
+- **GIVEN** a recorded Phase 5 decision is reversed during the phase
+- **WHEN** the reversal is committed
+- **THEN** `proposal.md` and `design.md` SHALL be amended in a follow-up commit to the same change directory
+- **AND** git history SHALL serve as the audit trail of the change

--- a/openspec/changes/2026-04-26-phase5-tracking/tasks.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/tasks.md
@@ -18,8 +18,8 @@ to mark sub-tasks complete as part of its diff.
 - [x] M-1.4 Update `docs/roadmap.md` Phase 5 row in Timeline Overview to `🟡 IN PROGRESS`
 - [x] M-1.5 Add "Phase 5 Milestone Tracker" sub-section to `docs/roadmap.md` Phase 5 block
 - [x] M-1.6 Validate change: `openspec validate --changes 2026-04-26-phase5-tracking --strict`
-- [ ] M-1.7 Run `uv run pre-commit run -a` clean
-- [ ] M-1.8 Open PR
+- [x] M-1.7 Run `uv run pre-commit run -a` clean
+- [x] M-1.8 Open PR
 
 ## M0: Brain-Agnostic Evolution Framework (Fresh Build)
 

--- a/openspec/changes/2026-04-26-phase5-tracking/tasks.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/tasks.md
@@ -1,0 +1,176 @@
+# Tasks: Phase 5 (Evolution & Adaptation) Milestone Tracker
+
+This is the living checklist for all of Phase 5. Each milestone (M0–M7) has its own
+OpenSpec change directory listed below. Each milestone PR MUST update this file
+to mark sub-tasks complete as part of its diff.
+
+**Status legend**: `[ ]` not started, `[~]` in progress, `[x]` complete
+
+## M-1: Phase 5 Tracking Scaffold (THIS CHANGE)
+
+**Branch**: `feat/phase5-tracking-scaffold`
+**OpenSpec change**: `2026-04-26-phase5-tracking` (this directory)
+**Status**: in progress
+
+- [x] M-1.1 Create `openspec/changes/2026-04-26-phase5-tracking/proposal.md`
+- [x] M-1.2 Create `openspec/changes/2026-04-26-phase5-tracking/design.md`
+- [x] M-1.3 Create `openspec/changes/2026-04-26-phase5-tracking/tasks.md` (this file)
+- [ ] M-1.4 Update `docs/roadmap.md` Phase 5 row in Timeline Overview to `🟡 IN PROGRESS`
+- [ ] M-1.5 Add "Phase 5 Milestone Tracker" sub-section to `docs/roadmap.md` Phase 5 block
+- [ ] M-1.6 Validate change: `openspec change validate 2026-04-26-phase5-tracking --strict`
+- [ ] M-1.7 Run `uv run pre-commit run -a` clean
+- [ ] M-1.8 Open PR
+
+## M0: Brain-Agnostic Evolution Framework (Fresh Build)
+
+**OpenSpec change**: `2026-04-28-add-evolution-framework` (not yet created)
+**Status**: not started
+**Bio fidelity**: LOW
+**Brain target**: MLPPPO (smoke) + LSTMPPO+klinotaxis (smoke)
+**Dependencies**: M-1
+
+- [ ] M0.1 Create `packages/quantum-nematode/quantumnematode/evolution/` module: `genome.py`, `encoders.py`, `lineage.py`, `loop.py`, `fitness.py`
+- [ ] M0.2 Implement `GenomeEncoder` protocol + `MLPPPOEncoder` + `LSTMPPOEncoder` + `ENCODER_REGISTRY` (no `QVarCircuitEncoder`)
+- [ ] M0.3 Implement `LineageTracker` writing `evolution_results/<session>/lineage.csv`
+- [ ] M0.4 Implement `EvolutionLoop` class (fresh, not extracted from old script)
+- [ ] M0.5 Implement `FitnessFunction` protocol with `EpisodicSuccessRate` default and `LearnedPerformanceFitness` stub
+- [ ] M0.6 Move existing `scripts/run_evolution.py` → `scripts/legacy/run_qvarcircuit_evolution.py`
+- [ ] M0.7 Write fresh `scripts/run_evolution.py` as a thin CLI wiring loop + encoder + fitness
+- [ ] M0.8 Extend `config_loader.py` with an `evolution:` block schema
+- [ ] M0.9 Create `configs/evolution/mlpppo_foraging_small.yml`
+- [ ] M0.10 Create `configs/evolution/lstmppo_foraging_small_klinotaxis.yml`
+- [ ] M0.11 Tests: encoder round-trip (MLPPPO + LSTMPPO), lineage CSV, smoke loop
+- [ ] M0.12 Smoke run: 10-gen MLPPPO config, verify `best_params_*.json` round-trips
+- [ ] M0.13 Smoke run: 10-gen LSTMPPO+klinotaxis config, verify `best_params_*.json` round-trips
+- [ ] M0.14 Update this checklist + roadmap milestone tracker
+
+## M1: Predator-as-Brain Refactor
+
+**OpenSpec change**: `2026-05-05-add-learning-predators` (not yet created)
+**Status**: not started
+**Bio fidelity**: MEDIUM
+**Brain target**: MLPPPO predator
+**Dependencies**: M0
+
+- [ ] M1.1 Create `env/predator_brain.py`: `PredatorBrain` protocol, `HeuristicPredatorBrain` adapter, `PredatorBrainParams` dataclass
+- [ ] M1.2 Modify `Predator.update_position` to delegate to `self.brain.run_brain(params)` if brain set, else fall back to current behaviour
+- [ ] M1.3 Extend `PredatorParams` with optional `brain_config`; `create_predators()` defaults to `HeuristicPredatorBrain`
+- [ ] M1.4 Modify `MultiAgentSimulation` to expose per-predator metrics (`kills`, `prey_proximity_steps`, `distance_traveled`) in `EpisodeResult`
+- [ ] M1.5 Tests: `tests/env/test_predator_brain.py`
+- [ ] M1.6 Regression: 4-seed × 200-episode run on existing predator scenarios, agent survival rate within ±2pp of pre-refactor baseline
+- [ ] M1.7 `uv run pytest -m smoke -v` passes
+- [ ] M1.8 Update this checklist + roadmap milestone tracker
+
+## M2: Hyperparameter Evolution Pilot
+
+**OpenSpec change**: `2026-05-12-add-hyperparameter-evolution` (not yet created)
+**Status**: not started
+**Bio fidelity**: LOW
+**Brain target**: MLPPPO + LSTMPPO+klinotaxis
+**Dependencies**: M0
+**Decision gate**: GO if either brain ≥3pp over hand-tuned baseline AND fitness still rising at gen 20
+
+- [ ] M2.1 Implement `HyperparameterEncoder` in `evolution/encoders.py` (encodes config dict, not weights)
+- [ ] M2.2 Implement `LearnedPerformanceFitness` in `evolution/fitness.py`
+- [ ] M2.3 Create `configs/evolution/hyperparam_mlpppo_pilot.yml`
+- [ ] M2.4 Create `configs/evolution/hyperparam_lstmppo_klinotaxis_pilot.yml`
+- [ ] M2.5 Create campaign script `scripts/campaigns/phase5_m2_hyperparam.sh`
+- [ ] M2.6 Run pilot: 20 gens × population 12 × 4 seeds × 2 brains
+- [ ] M2.7 Publish `artifacts/logbooks/012/m2_hyperparam_pilot.md` with GO/PIVOT/STOP decision
+- [ ] M2.8 Update this checklist + roadmap milestone tracker
+
+## M3: Lamarckian Evolution Pilot
+
+**OpenSpec change**: `2026-05-19-add-lamarckian-evolution` (not yet created)
+**Status**: not started
+**Bio fidelity**: MEDIUM
+**Brain target**: MLPPPO (cheap) + LSTMPPO+klinotaxis (headline)
+**Dependencies**: M0
+**Decision gate**: GO to M4 if LSTMPPO+klinotaxis shows ≥10pp faster convergence AND F1 eval-only success > random init
+
+- [ ] M3.1 Create `evolution/inheritance.py` with `LamarckianInheritance` strategy
+- [ ] M3.2 Wire through `EvolutionLoop` via `--inheritance lamarckian` CLI flag
+- [ ] M3.3 Encoder round-trip serialization for MLPPPO + LSTMPPO via `WeightPersistence`
+- [ ] M3.4 Create `configs/evolution/lamarckian_mlpppo_pilot.yml`
+- [ ] M3.5 Create `configs/evolution/lamarckian_lstmppo_klinotaxis_pilot.yml`
+- [ ] M3.6 Run pilot: 30 gens × population 16 × 4 seeds × 2 brains
+- [ ] M3.7 Publish `artifacts/logbooks/012/m3_lamarckian_pilot.md` with GO/PIVOT/STOP decision
+- [ ] M3.8 Update this checklist + roadmap milestone tracker
+
+## M4: Baldwin Effect Demonstration
+
+**OpenSpec change**: `2026-06-02-add-baldwin-effect` (not yet created)
+**Status**: not started (gated on M3 GO)
+**Bio fidelity**: MEDIUM
+**Brain target**: LSTMPPO+klinotaxis
+**Dependencies**: M3 GO
+**Decision gate**: GO if Baldwin cohort outperforms from-scratch AND learning-blocked control still improves
+
+- [ ] M4.1 Implement `BaldwinInheritance` in `evolution/inheritance.py`
+- [ ] M4.2 Implement learning-blocked F1 control cohort (config fields: `control_cohort_interval`, `control_cohort_fraction`)
+- [ ] M4.3 Create `configs/evolution/baldwin_lstmppo_klinotaxis_full.yml`
+- [ ] M4.4 Create `configs/evolution/baldwin_comparison_campaign.yml`
+- [ ] M4.5 Run head-to-head: from-scratch vs Lamarckian (M3) vs Baldwin × 50 gens × 4 seeds
+- [ ] M4.6 Publish `artifacts/logbooks/013/` with full Baldwin Effect findings
+- [ ] M4.7 Update this checklist + roadmap milestone tracker
+
+## M5: Co-Evolution Arms Race
+
+**OpenSpec change**: `2026-06-16-add-coevolution` (not yet created)
+**Status**: not started
+**Bio fidelity**: HIGH
+**Brain target**: LSTMPPO+klinotaxis prey, MLPPPO predator
+**Dependencies**: M0, M1
+**Decision gate**: GO if phenotypic cycling visible AND trait escalation monotonic over ≥30 gens
+
+- [ ] M5.1 Create `evolution/coevolution.py` with `CoevolutionLoop`
+- [ ] M5.2 Create `evolution/redqueen_metrics.py` with phenotypic cycling, trait escalation, fitness lag, coupled rate
+- [ ] M5.3 Create `configs/evolution/coevolution_pilot.yml`
+- [ ] M5.4 Create `configs/evolution/coevolution_full.yml`
+- [ ] M5.5 Run 50+ gen × 4 seed campaign
+- [ ] M5.6 Multi-cluster vs single-cluster transfer evaluation
+- [ ] M5.7 Publish `artifacts/logbooks/014/` with Red Queen findings
+- [ ] M5.8 Update this checklist + roadmap milestone tracker
+
+## M6: Transgenerational Memory
+
+**OpenSpec change**: `2026-06-30-add-transgenerational-memory` (not yet created)
+**Status**: not started (gated on M3 GO + M4-or-M5)
+**Bio fidelity**: HIGH
+**Brain target**: LSTMPPO+klinotaxis
+**Dependencies**: M3 GO + (M4 or M5) complete
+**Decision gate**: GO if F1 retains ≥40% of F0 avoidance, F3 ≤10%
+
+- [ ] M6.1 Create `agent/transgenerational_memory.py` with `TransgenerationalMemory` class
+- [ ] M6.2 Hook into `prepare_episode()` as a prior on response distribution
+- [ ] M6.3 Implement `inherit_from(parents, decay_factor)` transmission
+- [ ] M6.4 Create `configs/evolution/transgenerational_pathogen_avoidance_lstmppo_klinotaxis.yml`
+- [ ] M6.5 Run F0/F1/F2/F3 pathogen avoidance experiment (Posner replication design)
+- [ ] M6.6 Publish `artifacts/logbooks/015/` with transgenerational findings
+- [ ] M6.7 Update this checklist + roadmap milestone tracker
+
+## M6.5: NEAT Architecture Evolution (OPTIONAL)
+
+**OpenSpec change**: `2026-07-14-add-neat-evolution` (only if scheduled)
+**Status**: not started (compute-budget dependent)
+**Bio fidelity**: LOW
+**Brain target**: MLPPPO
+
+- [ ] M6.5.1 Integrate `neat-python` via `NeatEncoder` + `NeatGenome`
+- [ ] M6.5.2 30-gen pilot, single environment
+- [ ] M6.5.3 Logbook supplement to whichever logbook is current
+- [ ] M6.5.4 Update this checklist + roadmap milestone tracker
+
+## M7: Phase 5 Synthesis Logbook
+
+**OpenSpec change**: `2026-07-21-add-phase5-evaluation` (not yet created)
+**Status**: not started
+**Dependencies**: M2–M6 complete (or explicitly dropped via gates)
+
+- [ ] M7.1 Aggregate cross-milestone fitness curves and tables
+- [ ] M7.2 Walk through each Phase 5 exit criterion with evidence
+- [ ] M7.3 Document negative findings honestly (Phase 4 precedent)
+- [ ] M7.4 Phase 6 quantum re-evaluation trigger recommendation
+- [ ] M7.5 Publish `artifacts/logbooks/016/synthesis.md`
+- [ ] M7.6 Update `docs/roadmap.md` Phase 5 status → COMPLETE; record exit criterion outcomes
+- [ ] M7.7 Archive `2026-04-26-phase5-tracking` alongside `2026-07-21-add-phase5-evaluation`

--- a/openspec/changes/2026-04-26-phase5-tracking/tasks.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/tasks.md
@@ -15,9 +15,9 @@ to mark sub-tasks complete as part of its diff.
 - [x] M-1.1 Create `openspec/changes/2026-04-26-phase5-tracking/proposal.md`
 - [x] M-1.2 Create `openspec/changes/2026-04-26-phase5-tracking/design.md`
 - [x] M-1.3 Create `openspec/changes/2026-04-26-phase5-tracking/tasks.md` (this file)
-- [ ] M-1.4 Update `docs/roadmap.md` Phase 5 row in Timeline Overview to `🟡 IN PROGRESS`
-- [ ] M-1.5 Add "Phase 5 Milestone Tracker" sub-section to `docs/roadmap.md` Phase 5 block
-- [ ] M-1.6 Validate change: `openspec change validate 2026-04-26-phase5-tracking --strict`
+- [x] M-1.4 Update `docs/roadmap.md` Phase 5 row in Timeline Overview to `🟡 IN PROGRESS`
+- [x] M-1.5 Add "Phase 5 Milestone Tracker" sub-section to `docs/roadmap.md` Phase 5 block
+- [x] M-1.6 Validate change: `openspec validate --changes 2026-04-26-phase5-tracking --strict`
 - [ ] M-1.7 Run `uv run pre-commit run -a` clean
 - [ ] M-1.8 Open PR
 

--- a/openspec/changes/2026-04-26-phase5-tracking/tasks.md
+++ b/openspec/changes/2026-04-26-phase5-tracking/tasks.md
@@ -4,7 +4,7 @@ This is the living checklist for all of Phase 5. Each milestone (M0–M7) has it
 OpenSpec change directory listed below. Each milestone PR MUST update this file
 to mark sub-tasks complete as part of its diff.
 
-**Status legend**: `[ ]` not started, `[~]` in progress, `[x]` complete
+**Status legend**: `[ ]` not started, `[x]` complete. Milestone-level "in progress" status lives in the **Status** header of each milestone section (matches the roadmap milestone tracker emoji column).
 
 ## M-1: Phase 5 Tracking Scaffold (THIS CHANGE)
 


### PR DESCRIPTION
## Summary

- Establishes the cross-session tracking scaffold for Phase 5 (Evolution & Adaptation): an OpenSpec change directory with a living `tasks.md` checklist covering all milestones M-1 → M7, plus a new `phase5-tracking` capability with three requirements (living checklist, roadmap status block, decision record)
- Updates [docs/roadmap.md](https://github.com/SyntheticBrains/nematode/blob/feat/phase5-tracking-scaffold/docs/roadmap.md) Phase 5 row to 🟡 IN PROGRESS and adds a Phase 5 Milestone Tracker sub-section listing all 10 milestones with bio-fidelity grades
- Adds a Pull Requests section to [AGENTS.md](https://github.com/SyntheticBrains/nematode/blob/feat/phase5-tracking-scaffold/AGENTS.md) requiring Conventional Commits prefixes on PR titles (long-standing implicit convention now documented)

This is M-1 of the Phase 5 plan — process scaffolding only, no code changes. It exists so subsequent Phase 5 milestone PRs (M0 onward) have a single canonical place to mark progress, and so future AI sessions resuming Phase 5 work can orient without conversational context.

The change records three Phase 5 design decisions in [proposal.md](https://github.com/SyntheticBrains/nematode/blob/feat/phase5-tracking-scaffold/openspec/changes/2026-04-26-phase5-tracking/proposal.md): pilot-first sequencing, no QVarCircuit backwards compatibility for the M0 framework rebuild, and LSTMPPO+klinotaxis as the first-class brain for headline scientific milestones (M4/M5/M6).

This OpenSpec change does NOT archive on merge — it stays open until M7 (Phase 5 synthesis logbook) lands, accumulating sub-task checkbox updates from each milestone PR.

## Test plan

- [x] `openspec validate --changes 2026-04-26-phase5-tracking --strict` passes
- [x] `uv run pre-commit run -a` clean
- [x] Roadmap relative paths resolve (`../openspec/changes/...`)
- [x] Self-review: caught and fixed proposal.md/spec.md inconsistency about whether this change adds a capability (it does — `phase5-tracking`)
- [x] Reviewer sanity check: a fresh reading of `openspec/changes/2026-04-26-phase5-tracking/tasks.md` + the roadmap Phase 5 block correctly identifies M0 as the next milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established PR title conventions using Conventional Commits prefixes for contributor guidance.
  * Updated Phase 5 "Evolution & Adaptation" status to in progress with a detailed milestone tracker and phase-level task checklists.
  * Documented Phase 5 design decisions and cross-session coordination strategy for transparent roadmap tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->