### PR TITLE
docs(roadmap): add Future Directions entry 6 — Ecological Co-Evolution

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1131,6 +1131,13 @@ Beyond the current roadmap phases, potential research directions include:
 - Apply findings to broader quantum ML research
 - Contribute to theoretical understanding of quantum computational advantage
 
+### 6. Ecological Co-Evolution
+
+- Add state to predators (HP, satiety, death-by-starvation, kill-replenishes-energy) so the Phase 5 frozen-weight Red Queen substrate gains coupled population dynamics
+- Lotka-Volterra-style oscillations: study whether predator-prey populations stabilise, oscillate, or collapse under learned policies
+- Phase 5's `PredatorBrain` Protocol (M1) and `MLPPPOPredatorBrain` (M5) already supply the policy substrate; the new work is env-side state machinery + reward shaping
+- Selection pressure shifts from "maximise kill-rate" to "maintain a viable population against prey escape velocity" — natural follow-up if Phase 5's co-evolution verdict motivates richer eco-dynamics
+
 ______________________________________________________________________
 
 ## Technical Debt & Maintenance


### PR DESCRIPTION
## Summary

Adds a 6th entry to `docs/roadmap.md` `## Future Directions` capturing **ecological co-evolution** as a potential research direction beyond the current 8-phase roadmap.

The motivation came up while reviewing PR #146 (M5 PR 2 — predator factory + encoder + fitness): once Phase 5's frozen-weight co-evolution substrate is in place, a natural extension is to add state to predators (HP, satiety, death-by-starvation, kill-replenishes-energy) — turning the kill-rate objective into a coupled Lotka-Volterra-style population dynamic. The `PredatorBrain` Protocol (M1) and `MLPPPOPredatorBrain` (M5) already supply the policy substrate; only env-side state machinery + reward shaping would be new work. Worth recording while the architecture is fresh; not a commitment.

## What changed

One new entry under `## Future Directions`:

```markdown
### 6. Ecological Co-Evolution

- Add state to predators (HP, satiety, death-by-starvation, kill-replenishes-energy) so the Phase 5 frozen-weight Red Queen substrate gains coupled population dynamics
- Lotka-Volterra-style oscillations: study whether predator-prey populations stabilise, oscillate, or collapse under learned policies
- Phase 5's \`PredatorBrain\` Protocol (M1) and \`MLPPPOPredatorBrain\` (M5) already supply the policy substrate; the new work is env-side state machinery + reward shaping
- Selection pressure shifts from \"maximise kill-rate\" to \"maintain a viable population against prey escape velocity\" — natural follow-up if Phase 5's co-evolution verdict motivates richer eco-dynamics
```

Format matches existing entries 2-5 (plain bullets, 3-4 lines, high-level "if you go this direction, here's what you'd consider" framing). Milestone references are explicitly qualified by phase to stay consistent with the phase-agnostic framing of the other Future Directions entries (other phases also have M-numbered milestones; bare M-names would be ambiguous).

## Why a separate PR (not bundled with PR 2 / PR 146)

PR 2 is the M5 implementation substrate; this is a forward-looking docs note unrelated to the M5 implementation surface. Keeping them separate makes both reviewable independently and lets this land on its own merits without coupling the merge cadence.

## Test plan

- [x] `pre-commit run --files docs/roadmap.md` clean (mdformat + markdownlint).
- [ ] Reviewer to confirm the entry reads well alongside entries 1-5 and the framing is appropriately tentative (not promising a milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Ecological Co-Evolution" subsection to the project roadmap, outlining future directions for extending the predator–prey ecosystem framework with population dynamics coupling and learning-based predator behavior exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->