### PR TITLE
feat(evolution): scaffold TransgenerationalInheritance strategy (M6 commit 1)

### DIFF
--- a/openspec/changes/add-transgenerational-memory/tasks.md
+++ b/openspec/changes/add-transgenerational-memory/tasks.md
@@ -4,12 +4,12 @@ Tasks are grouped by commit (per the plan's 8-commit grouping). Each group repre
 
 ## 1. Scaffold strategy + Literal extensions (Commit 1)
 
-- [ ] 1.1 Create `quantumnematode/evolution/transgenerational_inheritance.py` with `TransgenerationalInheritance` skeleton implementing the `InheritanceStrategy` Protocol. Top-1 elite `select_parents`, single-elite `assign_parent`, `.tei.pt` `checkpoint_path`, `kind() -> "transgenerational"`. All methods runnable but the substrate-loading paths return placeholder no-ops pending commit 4.
-- [ ] 1.2 Extend `quantumnematode/evolution/inheritance.py` Protocol docstring + `kind()` Literal to include `"transgenerational"`. Update module docstring to document the fourth strategy.
-- [ ] 1.3 Extend `quantumnematode/utils/config_loader.py`: add `"transgenerational"` to the `EvolutionConfig.inheritance` Literal. No `TransgenerationalConfig` block yet (that lands in commit 6 alongside the YAML).
-- [ ] 1.4 Tests: `tests/.../evolution/test_transgenerational_inheritance.py` covers Protocol conformance: `select_parents` lex-tie (1 case), `assign_parent` single-broadcast (1 case), `checkpoint_path` format `gen-NNN/genome-<gid>.tei.pt` (1 case), `kind()` literal returns `"transgenerational"` (1 case). ~4 cases initially; expanded to ~14 in commit 4 as substrate-load/save paths fill in.
-- [ ] 1.5 Carry forward the uncommitted `add-transgenerational-memory` rename in `openspec/changes/phase5-tracking/tasks.md` (line 223) into commit 1's staged changes.
-- [ ] 1.6 Run `uv run pytest -m "not smoke and not nightly"` clean. Run `uv run pre-commit run -a` clean.
+- [x] 1.1 Create `quantumnematode/evolution/transgenerational_inheritance.py` with `TransgenerationalInheritance` skeleton implementing the `InheritanceStrategy` Protocol. Top-1 elite `select_parents`, single-elite `assign_parent`, `.tei.pt` `checkpoint_path`, `kind() -> "transgenerational"`. All methods runnable but the substrate-loading paths return placeholder no-ops pending commit 4.
+- [x] 1.2 Extend `quantumnematode/evolution/inheritance.py` Protocol docstring + `kind()` Literal to include `"transgenerational"`. Update module docstring to document the fourth strategy.
+- [x] 1.3 Extend `quantumnematode/utils/config_loader.py`: add `"transgenerational"` to the `EvolutionConfig.inheritance` Literal. No `TransgenerationalConfig` block yet (that lands in commit 6 alongside the YAML). Also: extended `evolution/__init__.py` exports, `evolution/loop.py` `_expected_kind` dispatch dict, and `scripts/run_evolution.py` CLI choices + strategy factory to keep the Literal extension runnable end-to-end (otherwise YAML loads with `inheritance: transgenerational` would crash at loop init or CLI parse).
+- [x] 1.4 Tests: `tests/.../evolution/test_transgenerational_inheritance.py` (11 cases): `kind()` literal returns `"transgenerational"`; extended known-kind set guard (all 4 strategies in `{"none","weights","trait","transgenerational"}`); `checkpoint_path` format + zero-padding; `assign_parent` returns None (3 cases); `select_parents` single-elite + lex-tie + matches Baldwin/Lamarckian(1) byte-for-byte + empty-input + length-mismatch (5 cases); `isinstance` Protocol conformance check.
+- [x] 1.5 Carry forward the `add-transgenerational-memory` rename + status update in `openspec/changes/phase5-tracking/tasks.md` (line 223: "(not yet created)" → "(scaffolded in PR #158; implementation in progress)"; status "ready to start" → "in progress").
+- [x] 1.6 `uv run pytest -m "not smoke and not nightly"` passes 2665/2665. `uv run pre-commit run -a` passes all 10 hooks.
 
 ## 2. TransgenerationalMemory dataclass (Commit 2)
 

--- a/openspec/changes/phase5-tracking/tasks.md
+++ b/openspec/changes/phase5-tracking/tasks.md
@@ -220,8 +220,8 @@ Optional follow-up that revisits the Baldwin Effect with **task-distribution sel
 
 ## M6: Transgenerational Memory
 
-**OpenSpec change**: `add-transgenerational-memory` (not yet created)
-**Status**: ready to start (gated on M3 GO ✅ + M4 closed STOP ✅ + M5 closed STOP ✅ — all gates cleared). Highest-novelty remaining Phase 5 milestone; M6 implementation unblocked.
+**OpenSpec change**: `add-transgenerational-memory` (scaffolded in PR #158; implementation in progress)
+**Status**: in progress (gated on M3 GO ✅ + M4 closed STOP ✅ + M5 closed STOP ✅ — all gates cleared). Highest-novelty remaining Phase 5 milestone; M6 implementation underway.
 **Bio fidelity**: HIGH
 **Brain target**: LSTMPPO+klinotaxis
 **Dependencies**: M3 GO ✅ + (M4 closed STOP ✅ / M5 closed STOP ✅) — all gates cleared

--- a/packages/quantum-nematode/quantumnematode/evolution/__init__.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/__init__.py
@@ -33,6 +33,7 @@ from quantumnematode.evolution.inheritance import (
 )
 from quantumnematode.evolution.lineage import CSV_HEADER, LineageTracker
 from quantumnematode.evolution.loop import CHECKPOINT_VERSION, EvolutionLoop
+from quantumnematode.evolution.transgenerational_inheritance import TransgenerationalInheritance
 
 __all__ = [
     "CHECKPOINT_VERSION",
@@ -54,6 +55,7 @@ __all__ = [
     "LineageTracker",
     "MLPPPOEncoder",
     "NoInheritance",
+    "TransgenerationalInheritance",
     "build_birth_metadata",
     "genome_id_for",
     "get_encoder",

--- a/packages/quantum-nematode/quantumnematode/evolution/inheritance.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/inheritance.py
@@ -1,6 +1,6 @@
 """Inheritance strategies for the evolution loop.
 
-Provides the :class:`InheritanceStrategy` Protocol and three concrete
+Provides the :class:`InheritanceStrategy` Protocol and four concrete
 implementations:
 
 - :class:`NoInheritance` (the default): every child is from-scratch; no
@@ -18,6 +18,15 @@ implementations:
   evolutionary trace), but no per-genome weight checkpoints are written.
   Mechanically equivalent to :class:`NoInheritance` on the weight-IO
   path; differs only by populating lineage rows from gen 1 onwards.
+- :class:`~quantumnematode.evolution.transgenerational_inheritance.TransgenerationalInheritance`:
+  substrate-flow inheritance — an inheritable behavioural-bias
+  substrate (``TransgenerationalMemory``) is extracted from the F0
+  elite's policy via a deterministic telemetry pass and multiplicatively
+  decayed across F1/F2/F3 generations. The substrate biases the actor's
+  logits before softmax, independently of trained weights. Defined in
+  the sibling module ``transgenerational_inheritance`` so this module
+  stays focused on the three baseline strategies; both modules share
+  the Protocol defined below.
 
 The Protocol exposes four methods so future strategies (tournament,
 fitness-proportionate "roulette", soft-elite top-k sampling) can plug
@@ -30,10 +39,12 @@ in without touching the loop:
   Lamarckian; sampling in tournament/roulette/soft-elite variants).
 - ``checkpoint_path`` — single canonical path-builder used by both the
   capture (writer) and warm-start (reader) sides so the two cannot drift.
-- ``kind`` — returns one of ``"none"``, ``"weights"``, or ``"trait"``
-  so the loop branches on intent rather than ``isinstance`` checks.
-  ``"none"`` skips both lineage-tracking and weight-IO; ``"weights"``
-  enables both; ``"trait"`` enables lineage-tracking only.
+- ``kind`` — returns one of ``"none"``, ``"weights"``, ``"trait"``, or
+  ``"transgenerational"`` so the loop branches on intent rather than
+  ``isinstance`` checks.  ``"none"`` skips both lineage-tracking and
+  weight-IO; ``"weights"`` enables both; ``"trait"`` enables
+  lineage-tracking only; ``"transgenerational"`` enables lineage-tracking
+  + the substrate-flow code path (commit 4 onwards).
 
 Future-work strategies (tournament selection, roulette sampling,
 soft-elite top-k) are NOT implemented here — they each become a new
@@ -119,10 +130,10 @@ class InheritanceStrategy(Protocol):
         """
         ...
 
-    def kind(self) -> Literal["none", "weights", "trait"]:
+    def kind(self) -> Literal["none", "weights", "trait", "transgenerational"]:
         """Return the inheritance kind so the loop can branch on intent.
 
-        Three values, each gating different code paths:
+        Four values, each gating different code paths:
 
         - ``"none"`` (e.g. :class:`NoInheritance`) — loop skips ALL
           inheritance code paths.  No `select_parents` call, no
@@ -136,11 +147,24 @@ class InheritanceStrategy(Protocol):
           `select_parents` and writes `inherited_from` to lineage rows
           (so the elite-parent ID flows in lineage), but does NOT
           capture or GC any weight checkpoints.
+        - ``"transgenerational"`` (e.g.
+          :class:`~quantumnematode.evolution.transgenerational_inheritance.TransgenerationalInheritance`)
+          — loop calls `select_parents` and writes `inherited_from` to
+          lineage rows (same as Baldwin); additionally captures the F0
+          elite's substrate via the F0 Substrate Extraction Pipeline
+          (commit 4 onwards) and threads ``tei_prior_source`` into
+          ``fitness.evaluate`` for F1+ workers (commit 5 onwards). No
+          per-child weight warm-start — the substrate is the only
+          cross-generation flow.
 
         The loop's ``_inheritance_active()`` helper SHALL evaluate
         ``kind() == "weights"`` (gates weight-IO code paths).  The loop's
         ``_inheritance_records_lineage()`` helper SHALL evaluate
         ``kind() != "none"`` (gates lineage-tracking + `select_parents`).
+        A new ``_substrate_inheritance_active()`` helper (landing in
+        commit 4) SHALL evaluate ``kind() == "transgenerational"``
+        (gates the F0 substrate extraction pipeline + F1+ kwarg
+        forwarding).
         """
         ...
 

--- a/packages/quantum-nematode/quantumnematode/evolution/inheritance.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/inheritance.py
@@ -44,7 +44,9 @@ in without touching the loop:
   ``isinstance`` checks.  ``"none"`` skips both lineage-tracking and
   weight-IO; ``"weights"`` enables both; ``"trait"`` enables
   lineage-tracking only; ``"transgenerational"`` enables lineage-tracking
-  + the substrate-flow code path (commit 4 onwards).
+  + the substrate-flow code path (substrate extraction and worker
+  forwarding are follow-up additions tracked in
+  ``openspec/changes/add-transgenerational-memory/``).
 
 Future-work strategies (tournament selection, roulette sampling,
 soft-elite top-k) are NOT implemented here — they each become a new
@@ -152,8 +154,10 @@ class InheritanceStrategy(Protocol):
           — loop calls `select_parents` and writes `inherited_from` to
           lineage rows (same as Baldwin); additionally captures the F0
           elite's substrate via the F0 Substrate Extraction Pipeline
-          (commit 4 onwards) and threads ``tei_prior_source`` into
-          ``fitness.evaluate`` for F1+ workers (commit 5 onwards). No
+          and threads ``tei_prior_source`` into ``fitness.evaluate``
+          for F1+ workers. (The extraction pipeline and worker
+          forwarding are follow-up additions tracked in
+          ``openspec/changes/add-transgenerational-memory/``.) No
           per-child weight warm-start — the substrate is the only
           cross-generation flow.
 
@@ -161,10 +165,9 @@ class InheritanceStrategy(Protocol):
         ``kind() == "weights"`` (gates weight-IO code paths).  The loop's
         ``_inheritance_records_lineage()`` helper SHALL evaluate
         ``kind() != "none"`` (gates lineage-tracking + `select_parents`).
-        A new ``_substrate_inheritance_active()`` helper (landing in
-        commit 4) SHALL evaluate ``kind() == "transgenerational"``
-        (gates the F0 substrate extraction pipeline + F1+ kwarg
-        forwarding).
+        A follow-up ``_substrate_inheritance_active()`` helper SHALL
+        evaluate ``kind() == "transgenerational"`` (gates the F0
+        substrate extraction pipeline + F1+ kwarg forwarding).
         """
         ...
 

--- a/packages/quantum-nematode/quantumnematode/evolution/loop.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/loop.py
@@ -235,6 +235,7 @@ class EvolutionLoop:
             "none": "none",
             "lamarckian": "weights",
             "baldwin": "trait",
+            "transgenerational": "transgenerational",
         }[self.evolution_config.inheritance]
         if self.inheritance.kind() != _expected_kind:
             msg = (

--- a/packages/quantum-nematode/quantumnematode/evolution/loop.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/loop.py
@@ -400,9 +400,11 @@ class EvolutionLoop:
         """Return True iff the active strategy populates the lineage CSV's `inherited_from`.
 
         Gates the per-generation ``select_parents`` call and the
-        ``_selected_parent_ids`` update.  Both :class:`LamarckianInheritance`
-        and :class:`BaldwinInheritance` return ``True`` here; only
-        :class:`NoInheritance` returns ``False``.
+        ``_selected_parent_ids`` update.  :class:`LamarckianInheritance`,
+        :class:`BaldwinInheritance`, and
+        :class:`~quantumnematode.evolution.transgenerational_inheritance.TransgenerationalInheritance`
+        all return ``True`` here; only :class:`NoInheritance` returns
+        ``False``.
         """
         return self.inheritance.kind() != "none"
 
@@ -443,7 +445,7 @@ class EvolutionLoop:
     ) -> tuple[Path | None, Path | None, str]:
         """Compute one child's (parent_warm_start, child_capture_path, inherited_from).
 
-        Three-branch switch on the strategy's ``kind()``:
+        Four-branch switch on the strategy's ``kind()``:
 
         - ``"none"`` → returns ``(None, None, "")``.  The loop's
           per-child step short-circuits to from-scratch evaluation
@@ -453,6 +455,16 @@ class EvolutionLoop:
           (``self._selected_parent_ids[0]`` if set, else ``""`` for
           gen 0).  No checkpoint paths are computed; the child trains
           from-scratch but its lineage row records the elite ID.
+        - ``"transgenerational"`` → returns ``(None, None, parent_id)``
+          — same shape as ``"trait"``.  Transgenerational inheritance
+          does not use per-child weight-IO inheritance paths; the
+          F0 substrate is captured by a separate loop-level pipeline
+          (a follow-up addition tracked in the OpenSpec change) and
+          F1+ workers receive the substrate via a separate kwarg
+          path into ``fitness.evaluate``, not via the per-child
+          ``weight_capture_path`` field.  The lineage CSV's
+          ``inherited_from`` column records the F0 elite ID from
+          gen 1 onwards (same as Baldwin).
         - ``"weights"`` (Lamarckian) → returns the full
           ``(parent_warm_start, child_capture_path, parent_id)``
           tuple.  ``parent_warm_start`` is the ``Path`` to the parent's
@@ -464,7 +476,7 @@ class EvolutionLoop:
         kind = self.inheritance.kind()
         if kind == "none":
             return None, None, ""
-        if kind == "trait":
+        if kind in ("trait", "transgenerational"):
             parent_id = self._selected_parent_ids[0] if self._selected_parent_ids else ""
             return None, None, parent_id
         # The remaining branch handles ``kind == "weights"`` (Lamarckian).

--- a/packages/quantum-nematode/quantumnematode/evolution/transgenerational_inheritance.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/transgenerational_inheritance.py
@@ -6,7 +6,7 @@ implementation of the :class:`InheritanceStrategy` Protocol (alongside
 in :mod:`quantumnematode.evolution.inheritance`).
 
 The strategy carries an inheritable behavioural-bias substrate
-(``TransgenerationalMemory``, landing in commit 2) extracted from the
+(``TransgenerationalMemory``, a follow-up addition) extracted from the
 F0 elite's policy and multiplicatively decayed across F1/F2/F3
 generations. The substrate biases the actor's logits before softmax,
 independently of trained weights.
@@ -18,24 +18,22 @@ methods:
   ``genome_id``), matching the Lamarckian/Baldwin selection rule so
   the loop's existing ``_selected_parent_ids`` array carries the F0
   elite ID forward.
-- ``assign_parent`` — returns ``None`` (TEI does not warm-start any
-  child from a per-genome weight checkpoint; the substrate flows
-  separately through ``fitness.evaluate``'s ``tei_prior_source``
-  kwarg, landing in commit 5).
+- ``assign_parent`` — returns ``None`` (transgenerational inheritance
+  does not warm-start any child from a per-genome weight checkpoint;
+  the substrate flows separately through ``fitness.evaluate``'s
+  ``tei_prior_source`` kwarg, a follow-up addition).
 - ``checkpoint_path`` — returns the ``.tei.pt`` path under
   ``inheritance/gen-NNN/genome-<gid>.tei.pt``. Distinct extension
   from Lamarckian's ``.pt`` so the two substrate types cannot
   collide on disk if a future config ever mixes them.
 - ``kind()`` — returns the new literal ``"transgenerational"``.
 
-This commit ships ONLY the strategy skeleton + Protocol conformance.
+This module ships ONLY the strategy skeleton + Protocol conformance.
 The F0 substrate extraction pipeline (writing the ``.tei.pt`` after
-F0 weight capture + telemetry pass) lands in commit 4; the worker
-tuple extension + ``fitness.evaluate`` kwarg forwarding land in
-commit 5.
-
-See the M6 OpenSpec change (``openspec/changes/add-transgenerational-
-memory/``) for the full design rationale.
+F0 weight capture + telemetry pass) and the worker tuple extension +
+``fitness.evaluate`` kwarg forwarding are follow-up additions tracked
+in the OpenSpec change under ``openspec/changes/add-transgenerational-
+memory/``.
 """
 
 from __future__ import annotations
@@ -53,14 +51,14 @@ class TransgenerationalInheritance:
     by :class:`BaldwinInheritance` and :class:`LamarckianInheritance`
     (``elite_count=1``). The selected elite's substrate is extracted
     AFTER F0 fitness evaluation via a deterministic telemetry pass
-    (``TransgenerationalMemory.extract_from_brain``, landing in
-    commit 2) and saved to disk at ``checkpoint_path(...)``. F1+
+    (``TransgenerationalMemory.extract_from_brain``, a follow-up
+    addition) and saved to disk at ``checkpoint_path(...)``. F1+
     children load this single F0 substrate and apply
     ``inherit_from(...)`` N times where N = current generation,
     producing depth-N substrates mechanically (no per-gen storage).
 
-    The Protocol's ``inheritance_elite_count`` field is unused under
-    transgenerational (single-elite by construction, matching
+    The ``EvolutionConfig.inheritance_elite_count`` field is unused
+    under transgenerational (single-elite by construction, matching
     Baldwin). The structural ``inheritance_elite_count <=
     population_size`` validator on ``EvolutionConfig`` still applies
     uniformly across all inheritance modes.
@@ -102,9 +100,9 @@ class TransgenerationalInheritance:
     ) -> str | None:
         """Return ``None`` — transgenerational does not warm-start any child.
 
-        TEI's substrate flows through the separate
-        ``tei_prior_source`` kwarg path into ``fitness.evaluate``
-        (landing in commit 5), not through the per-child weight-
+        The transgenerational substrate flows through the separate
+        ``tei_prior_source`` kwarg path into ``fitness.evaluate`` (a
+        follow-up addition), not through the per-child weight-
         checkpoint warm-start mechanism that Lamarckian uses. The
         F1+ branch of ``_resolve_per_child_inheritance`` returns
         ``(None, None, parent_id)`` — same shape as Baldwin's trait-
@@ -126,12 +124,12 @@ class TransgenerationalInheritance:
         config ever mixes them. Both capture (writer) and load
         (reader) sides MUST use this path-builder to avoid drift.
 
-        Used in commit 4 by the F0 Substrate Extraction Pipeline to
-        write the F0 elite's substrate. F1/F2/F3 substrates are
-        mechanically derived in-memory at load time (no per-gen
-        storage), so this method is only invoked at gen 0 in
-        practice — but it is structurally valid at any generation
-        for forensic round-trip tests.
+        Used by the F0 Substrate Extraction Pipeline (a follow-up
+        addition) to write the F0 elite's substrate. F1/F2/F3
+        substrates are mechanically derived in-memory at load time
+        (no per-gen storage), so this method is only invoked at
+        gen 0 in practice — but it is structurally valid at any
+        generation for forensic round-trip tests.
         """
         return output_dir / "inheritance" / f"gen-{generation:03d}" / f"genome-{genome_id}.tei.pt"
 

--- a/packages/quantum-nematode/quantumnematode/evolution/transgenerational_inheritance.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/transgenerational_inheritance.py
@@ -1,0 +1,140 @@
+"""Transgenerational inheritance strategy for the evolution loop.
+
+Provides :class:`TransgenerationalInheritance`, the fourth concrete
+implementation of the :class:`InheritanceStrategy` Protocol (alongside
+``NoInheritance``, ``LamarckianInheritance``, and ``BaldwinInheritance``
+in :mod:`quantumnematode.evolution.inheritance`).
+
+The strategy carries an inheritable behavioural-bias substrate
+(``TransgenerationalMemory``, landing in commit 2) extracted from the
+F0 elite's policy and multiplicatively decayed across F1/F2/F3
+generations. The substrate biases the actor's logits before softmax,
+independently of trained weights.
+
+Structurally mirrors ``BaldwinInheritance`` for the four Protocol
+methods:
+
+- ``select_parents`` — single-elite (top fitness, lex-tie-broken on
+  ``genome_id``), matching the Lamarckian/Baldwin selection rule so
+  the loop's existing ``_selected_parent_ids`` array carries the F0
+  elite ID forward.
+- ``assign_parent`` — returns ``None`` (TEI does not warm-start any
+  child from a per-genome weight checkpoint; the substrate flows
+  separately through ``fitness.evaluate``'s ``tei_prior_source``
+  kwarg, landing in commit 5).
+- ``checkpoint_path`` — returns the ``.tei.pt`` path under
+  ``inheritance/gen-NNN/genome-<gid>.tei.pt``. Distinct extension
+  from Lamarckian's ``.pt`` so the two substrate types cannot
+  collide on disk if a future config ever mixes them.
+- ``kind()`` — returns the new literal ``"transgenerational"``.
+
+This commit ships ONLY the strategy skeleton + Protocol conformance.
+The F0 substrate extraction pipeline (writing the ``.tei.pt`` after
+F0 weight capture + telemetry pass) lands in commit 4; the worker
+tuple extension + ``fitness.evaluate`` kwarg forwarding land in
+commit 5.
+
+See the M6 OpenSpec change (``openspec/changes/add-transgenerational-
+memory/``) for the full design rationale.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TransgenerationalInheritance:
+    """Single-elite substrate-flow inheritance — F0 substrate cascade.
+
+    Selects the F0 elite via the same top-1 lex-tie-broken rule used
+    by :class:`BaldwinInheritance` and :class:`LamarckianInheritance`
+    (``elite_count=1``). The selected elite's substrate is extracted
+    AFTER F0 fitness evaluation via a deterministic telemetry pass
+    (``TransgenerationalMemory.extract_from_brain``, landing in
+    commit 2) and saved to disk at ``checkpoint_path(...)``. F1+
+    children load this single F0 substrate and apply
+    ``inherit_from(...)`` N times where N = current generation,
+    producing depth-N substrates mechanically (no per-gen storage).
+
+    The Protocol's ``inheritance_elite_count`` field is unused under
+    transgenerational (single-elite by construction, matching
+    Baldwin). The structural ``inheritance_elite_count <=
+    population_size`` validator on ``EvolutionConfig`` still applies
+    uniformly across all inheritance modes.
+    """
+
+    def select_parents(
+        self,
+        gen_ids: list[str],
+        fitnesses: list[float],
+        generation: int,  # noqa: ARG002
+    ) -> list[str]:
+        """Return ``[best_genome_id]`` (single-element list, lex-tie-broken).
+
+        Same selection rule as :class:`BaldwinInheritance.select_parents`
+        and :class:`LamarckianInheritance.select_parents` with
+        ``elite_count=1``. The three strategies factor the selection
+        rule separately rather than sharing because they are
+        conceptually distinct (Lamarckian broadcasts weights to
+        descendants; Baldwin records only lineage; transgenerational
+        flows a behavioural-bias substrate).
+        """
+        if len(gen_ids) != len(fitnesses):
+            msg = (
+                f"select_parents requires len(gen_ids) == len(fitnesses); "
+                f"got {len(gen_ids)} vs {len(fitnesses)}."
+            )
+            raise ValueError(msg)
+        if not gen_ids:
+            return []
+        # Sort by (-fitness, genome_id): higher fitness wins, lexicographic
+        # tie-break ensures deterministic selection across runs.
+        ranked = sorted(zip(gen_ids, fitnesses, strict=True), key=lambda x: (-x[1], x[0]))
+        return [ranked[0][0]]
+
+    def assign_parent(
+        self,
+        child_index: int,  # noqa: ARG002
+        parent_ids: list[str],  # noqa: ARG002
+    ) -> str | None:
+        """Return ``None`` — transgenerational does not warm-start any child.
+
+        TEI's substrate flows through the separate
+        ``tei_prior_source`` kwarg path into ``fitness.evaluate``
+        (landing in commit 5), not through the per-child weight-
+        checkpoint warm-start mechanism that Lamarckian uses. The
+        F1+ branch of ``_resolve_per_child_inheritance`` returns
+        ``(None, None, parent_id)`` — same shape as Baldwin's trait-
+        only flow — so the lineage CSV records the F0 elite ID but
+        no warm-start path.
+        """
+        return None
+
+    def checkpoint_path(
+        self,
+        output_dir: Path,
+        generation: int,
+        genome_id: str,
+    ) -> Path | None:
+        """Return the canonical ``inheritance/gen-NNN/genome-<gid>.tei.pt`` path.
+
+        Distinct ``.tei.pt`` extension (vs Lamarckian's ``.pt``) so
+        the two substrate types cannot collide on disk if a future
+        config ever mixes them. Both capture (writer) and load
+        (reader) sides MUST use this path-builder to avoid drift.
+
+        Used in commit 4 by the F0 Substrate Extraction Pipeline to
+        write the F0 elite's substrate. F1/F2/F3 substrates are
+        mechanically derived in-memory at load time (no per-gen
+        storage), so this method is only invoked at gen 0 in
+        practice — but it is structurally valid at any generation
+        for forensic round-trip tests.
+        """
+        return output_dir / "inheritance" / f"gen-{generation:03d}" / f"genome-{genome_id}.tei.pt"
+
+    def kind(self) -> Literal["transgenerational"]:
+        """Return ``"transgenerational"`` — gates the loop into the substrate-flow code path."""
+        return "transgenerational"

--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -1110,8 +1110,11 @@ class EvolutionConfig(BaseModel):
                     "requires a non-zero train phase: Lamarckian needs "
                     "weights to inherit; Baldwin's whole premise is that "
                     "lifetime learning shapes the gen-N elite that becomes "
-                    "the prior for gen-N+1. Either set "
-                    "learn_episodes_per_eval > 0 or set inheritance: none."
+                    "the prior for gen-N+1; transgenerational needs a "
+                    "trained F0 elite for the substrate-extraction "
+                    "telemetry pass to produce meaningful biases. Either "
+                    "set learn_episodes_per_eval > 0 or set inheritance: "
+                    "none."
                 )
                 raise ValueError(msg)
             if self.warm_start_path is not None:
@@ -1122,8 +1125,11 @@ class EvolutionConfig(BaseModel):
                     "brain slot before the K train phase. Under Baldwin, "
                     "static warm-start would collapse the Baldwin signal "
                     "(every child starts from the same checkpoint regardless "
-                    "of the elite's evolved hyperparameters). Drop one of "
-                    "the two."
+                    "of the elite's evolved hyperparameters). Under "
+                    "transgenerational, static warm-start would similarly "
+                    "decouple the F0 elite's trained policy from the "
+                    "evolved-hyperparameter genome, breaking the substrate-"
+                    "extraction provenance. Drop one of the two."
                 )
                 raise ValueError(msg)
         if self.inheritance == "lamarckian" and self.inheritance_elite_count != 1:
@@ -1576,10 +1582,13 @@ class SimulationConfig(BaseModel):
                 "no hyperparam_schema is set.  Lamarckian inheritance over "
                 "weight encoders would double-count weights as both genome "
                 "and substrate; Baldwin needs a hyperparameter genome to "
-                "evolve — without one there is no trait substrate to inherit. "
-                "Either drop inheritance (returning to weight evolution) "
-                "or add a hyperparam_schema (switching to hyperparameter "
-                "evolution + inheritance)."
+                "evolve — without one there is no trait substrate to "
+                "inherit; transgenerational needs the genome-identity "
+                "anchor that the hyperparam_schema provides so the F0 "
+                "elite's substrate has a stable provenance. Either drop "
+                "inheritance (returning to weight evolution) or add a "
+                "hyperparam_schema (switching to hyperparameter evolution "
+                "+ inheritance)."
             )
             raise ValueError(msg)
 

--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -1042,7 +1042,7 @@ class EvolutionConfig(BaseModel):
     # = no weights to inherit); and incompatible with
     # architecture-changing schema fields.  All checks enforced by the
     # model validators below + ``SimulationConfig._validate_hyperparam_schema``.
-    inheritance: Literal["none", "lamarckian", "baldwin"] = "none"
+    inheritance: Literal["none", "lamarckian", "baldwin", "transgenerational"] = "none"
     # Number of prior-generation elites whose checkpoints survive into
     # the next generation.  Default 1 (single-elite-broadcast).  Only
     # 1 is currently accepted when inheritance is "lamarckian"; the

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_transgenerational_inheritance.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_transgenerational_inheritance.py
@@ -1,0 +1,180 @@
+"""Unit tests for :mod:`quantumnematode.evolution.transgenerational_inheritance`.
+
+Mirrors the structure of ``test_inheritance.py`` for the Baldwin
+strategy. Covers the four ``InheritanceStrategy`` Protocol methods
+plus the known-kind set guard. Commit 1 ships the strategy skeleton
+only; F0 substrate extraction + worker forwarding land in commits 4
+and 5 with their own integration tests.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from quantumnematode.evolution.inheritance import (
+    BaldwinInheritance,
+    LamarckianInheritance,
+    NoInheritance,
+)
+from quantumnematode.evolution.transgenerational_inheritance import (
+    TransgenerationalInheritance,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# TransgenerationalInheritance.kind
+# ---------------------------------------------------------------------------
+
+
+def test_transgenerational_kind() -> None:
+    """``TransgenerationalInheritance.kind`` SHALL return the literal ``"transgenerational"``."""
+    assert TransgenerationalInheritance().kind() == "transgenerational"
+
+
+def test_kind_values_are_in_extended_known_set() -> None:
+    """All four shipped strategies SHALL return a value from the known kind set.
+
+    Extends the existing three-strategy guard in ``test_inheritance.py``
+    to include the new ``"transgenerational"`` literal. Guards against
+    future strategies leaking new literals without updating the loop's
+    branching logic.
+    """
+    known = {"none", "weights", "trait", "transgenerational"}
+    assert NoInheritance().kind() in known
+    assert LamarckianInheritance().kind() in known
+    assert BaldwinInheritance().kind() in known
+    assert TransgenerationalInheritance().kind() in known
+
+
+# ---------------------------------------------------------------------------
+# TransgenerationalInheritance.checkpoint_path
+# ---------------------------------------------------------------------------
+
+
+def test_transgenerational_checkpoint_path_uses_tei_pt_extension(tmp_path: Path) -> None:
+    """``checkpoint_path`` SHALL return ``inheritance/gen-NNN/genome-<gid>.tei.pt``.
+
+    The ``.tei.pt`` extension (vs Lamarckian's ``.pt``) prevents
+    on-disk collision if a future config ever mixes the two
+    substrate types.
+    """
+    t = TransgenerationalInheritance()
+    path = t.checkpoint_path(tmp_path, 0, "gid-a")
+    assert path is not None
+    assert path == tmp_path / "inheritance" / "gen-000" / "genome-gid-a.tei.pt"
+
+
+def test_transgenerational_checkpoint_path_zero_pads_generation(tmp_path: Path) -> None:
+    """Generation index SHALL be 3-digit zero-padded (``gen-007``, not ``gen-7``).
+
+    Matches the Lamarckian / Baldwin / NoInheritance path-builder
+    convention so lineage directory ordering stays stable across
+    string sorts.
+    """
+    t = TransgenerationalInheritance()
+    path = t.checkpoint_path(tmp_path, 7, "abc-123")
+    assert path is not None
+    assert "gen-007" in str(path)
+    assert path.name == "genome-abc-123.tei.pt"
+
+
+# ---------------------------------------------------------------------------
+# TransgenerationalInheritance.assign_parent
+# ---------------------------------------------------------------------------
+
+
+def test_transgenerational_assign_parent_returns_none() -> None:
+    """``assign_parent`` SHALL return ``None`` (no per-child warm-start under TEI).
+
+    TEI's substrate flows through ``fitness.evaluate``'s
+    ``tei_prior_source`` kwarg path (commit 5), not through the per-
+    child weight-checkpoint warm-start mechanism. Matches Baldwin's
+    return semantics.
+    """
+    t = TransgenerationalInheritance()
+    assert t.assign_parent(0, []) is None
+    assert t.assign_parent(0, ["a", "b"]) is None
+    assert t.assign_parent(99, ["a"]) is None
+
+
+# ---------------------------------------------------------------------------
+# TransgenerationalInheritance.select_parents
+# ---------------------------------------------------------------------------
+
+
+def test_transgenerational_select_parents_returns_single_elite() -> None:
+    """``select_parents`` SHALL return ``[best_genome_id]`` (single-element list)."""
+    t = TransgenerationalInheritance()
+    assert t.select_parents(["a", "b", "c"], [0.1, 0.9, 0.5], 0) == ["b"]
+
+
+def test_transgenerational_select_parents_breaks_ties_lexicographically() -> None:
+    """``select_parents`` SHALL break fitness ties on ``genome_id`` lex order.
+
+    Matches the Lamarckian / Baldwin tie-break rule for deterministic
+    F0 elite selection across runs.
+    """
+    t = TransgenerationalInheritance()
+    # All three tied at 0.7 — lex-smallest "x" wins.
+    assert t.select_parents(["x", "y", "z"], [0.7, 0.7, 0.7], 5) == ["x"]
+    # Higher-fitness tie at 0.9, lower-fitness "z" at 0.3 — "a" wins over "b".
+    assert t.select_parents(["b", "a", "z"], [0.9, 0.9, 0.3], 5) == ["a"]
+
+
+def test_transgenerational_select_parents_matches_baldwin_and_lamarckian_single_elite() -> None:
+    """Transgenerational selection SHALL match Baldwin and Lamarckian(1) byte-for-byte.
+
+    All three single-elite strategies share the same selection rule
+    (top fitness, lex-tie-broken on ``genome_id``). Asserting
+    equivalence here pins the shared rule and guards against drift
+    if any one implementation changes.
+    """
+    t = TransgenerationalInheritance()
+    b = BaldwinInheritance()
+    lam1 = LamarckianInheritance(elite_count=1)
+    cases = [
+        (["a", "b", "c"], [0.1, 0.9, 0.5]),
+        (["x", "y", "z"], [0.7, 0.7, 0.3]),
+        (["c", "a", "b"], [0.5, 0.5, 0.5]),
+        (["only"], [0.42]),
+    ]
+    for ids, fits in cases:
+        t_result = t.select_parents(ids, fits, 0)
+        b_result = b.select_parents(ids, fits, 0)
+        lam_result = lam1.select_parents(ids, fits, 0)
+        assert t_result == b_result == lam_result
+
+
+def test_transgenerational_select_parents_empty_input_returns_empty() -> None:
+    """Gen-0 case: empty prior generation → empty selection."""
+    assert TransgenerationalInheritance().select_parents([], [], 0) == []
+
+
+def test_transgenerational_select_parents_length_mismatch_raises() -> None:
+    """``select_parents`` SHALL raise on mismatched ``gen_ids`` / ``fitnesses``."""
+    t = TransgenerationalInheritance()
+    with pytest.raises(ValueError, match="len\\(gen_ids\\) == len\\(fitnesses\\)"):
+        t.select_parents(["a", "b"], [0.5], 0)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_transgenerational_satisfies_inheritance_strategy_protocol() -> None:
+    """``TransgenerationalInheritance`` SHALL satisfy the runtime-checkable Protocol.
+
+    The Protocol is declared ``@runtime_checkable``, so ``isinstance``
+    works as a structural check that all four required methods
+    exist with the right shape. The loop relies on this Protocol
+    contract (not on ``isinstance(strategy, NoInheritance)`` etc.)
+    to dispatch on ``kind()``.
+    """
+    from quantumnematode.evolution.inheritance import InheritanceStrategy
+
+    assert isinstance(TransgenerationalInheritance(), InheritanceStrategy)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_transgenerational_inheritance.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_transgenerational_inheritance.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import pytest
 from quantumnematode.evolution.inheritance import (
     BaldwinInheritance,
+    InheritanceStrategy,
     LamarckianInheritance,
     NoInheritance,
 )
@@ -90,10 +91,10 @@ def test_transgenerational_checkpoint_path_zero_pads_generation(tmp_path: Path) 
 def test_transgenerational_assign_parent_returns_none() -> None:
     """``assign_parent`` SHALL return ``None`` (no per-child warm-start under TEI).
 
-    TEI's substrate flows through ``fitness.evaluate``'s
-    ``tei_prior_source`` kwarg path (commit 5), not through the per-
-    child weight-checkpoint warm-start mechanism. Matches Baldwin's
-    return semantics.
+    The transgenerational substrate flows through ``fitness.evaluate``'s
+    ``tei_prior_source`` kwarg path (a follow-up addition), not
+    through the per-child weight-checkpoint warm-start mechanism.
+    Matches Baldwin's return semantics.
     """
     t = TransgenerationalInheritance()
     assert t.assign_parent(0, []) is None
@@ -175,6 +176,4 @@ def test_transgenerational_satisfies_inheritance_strategy_protocol() -> None:
     contract (not on ``isinstance(strategy, NoInheritance)`` etc.)
     to dispatch on ``kind()``.
     """
-    from quantumnematode.evolution.inheritance import InheritanceStrategy
-
     assert isinstance(TransgenerationalInheritance(), InheritanceStrategy)

--- a/scripts/run_evolution.py
+++ b/scripts/run_evolution.py
@@ -109,12 +109,15 @@ def parse_arguments() -> argparse.Namespace:
             "warm-start from the prior generation's elite parent (weight flow). "
             "'baldwin' records the prior elite ID in the lineage CSV but does "
             "NOT propagate weights — every child trains from-scratch (trait "
-            "flow only). 'transgenerational' (M6 substrate flow) extracts an "
-            "inheritable behavioural-bias substrate from the F0 elite and "
-            "decays it across F1/F2/F3 — substrate set + decay pipeline land "
-            "in subsequent M6 commits. All three require hyperparam_schema "
-            "and learn_episodes_per_eval > 0; all are mutually exclusive with "
-            "warm_start_path. See evolution-framework spec."
+            "flow only). 'transgenerational' extracts an inheritable "
+            "behavioural-bias substrate from the F0 elite and decays it "
+            "across F1/F2/F3 generations — the substrate extraction and "
+            "kwarg forwarding into fitness.evaluate are follow-up additions; "
+            "this branch currently behaves like 'baldwin' on the loop side "
+            "(lineage tracking only) until those land. All three non-'none' "
+            "modes require hyperparam_schema and learn_episodes_per_eval > 0; "
+            "all are mutually exclusive with warm_start_path. See "
+            "evolution-framework spec."
         ),
     )
     parser.add_argument(
@@ -505,9 +508,11 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915 — sequential CLI e
     # child of the next generation); "transgenerational" →
     # TransgenerationalInheritance (substrate flow — F0-elite-derived
     # behavioural-bias substrate cascaded F1/F2/F3 with multiplicative
-    # decay; F0 extraction + F1+ kwarg forwarding land in subsequent
-    # M6 commits).  Validators on EvolutionConfig already rejected
-    # unsafe combinations at YAML/CLI parse time.
+    # decay; F0 extraction + F1+ kwarg forwarding are follow-up
+    # additions tracked in
+    # ``openspec/changes/add-transgenerational-memory/``).  Validators
+    # on EvolutionConfig already rejected unsafe combinations at
+    # YAML/CLI parse time.
     inheritance: InheritanceStrategy
     if evolution_config.inheritance == "lamarckian":
         inheritance = LamarckianInheritance(

--- a/scripts/run_evolution.py
+++ b/scripts/run_evolution.py
@@ -51,6 +51,7 @@ from quantumnematode.evolution import (
     LamarckianInheritance,
     LearnedPerformanceFitness,
     NoInheritance,
+    TransgenerationalInheritance,
     select_encoder,
 )
 from quantumnematode.logging_config import configure_file_logging, logger
@@ -101,15 +102,19 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--inheritance",
         type=str,
-        choices=["none", "lamarckian", "baldwin"],
+        choices=["none", "lamarckian", "baldwin", "transgenerational"],
         default=None,
         help=(
             "Override evolution.inheritance. 'lamarckian' enables per-genome "
             "warm-start from the prior generation's elite parent (weight flow). "
             "'baldwin' records the prior elite ID in the lineage CSV but does "
             "NOT propagate weights — every child trains from-scratch (trait "
-            "flow only). Both require hyperparam_schema and learn_episodes_per_eval > 0; "
-            "both are mutually exclusive with warm_start_path. See evolution-framework spec."
+            "flow only). 'transgenerational' (M6 substrate flow) extracts an "
+            "inheritable behavioural-bias substrate from the F0 elite and "
+            "decays it across F1/F2/F3 — substrate set + decay pipeline land "
+            "in subsequent M6 commits. All three require hyperparam_schema "
+            "and learn_episodes_per_eval > 0; all are mutually exclusive with "
+            "warm_start_path. See evolution-framework spec."
         ),
     )
     parser.add_argument(
@@ -497,8 +502,12 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915 — sequential CLI e
     # with the configured elite count; "baldwin" → BaldwinInheritance
     # (no per-genome weight checkpoints, but the prior generation's
     # elite ID is recorded in lineage CSV's `inherited_from` for every
-    # child of the next generation).  Validators on EvolutionConfig
-    # already rejected unsafe combinations at YAML/CLI parse time.
+    # child of the next generation); "transgenerational" →
+    # TransgenerationalInheritance (substrate flow — F0-elite-derived
+    # behavioural-bias substrate cascaded F1/F2/F3 with multiplicative
+    # decay; F0 extraction + F1+ kwarg forwarding land in subsequent
+    # M6 commits).  Validators on EvolutionConfig already rejected
+    # unsafe combinations at YAML/CLI parse time.
     inheritance: InheritanceStrategy
     if evolution_config.inheritance == "lamarckian":
         inheritance = LamarckianInheritance(
@@ -506,6 +515,8 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915 — sequential CLI e
         )
     elif evolution_config.inheritance == "baldwin":
         inheritance = BaldwinInheritance()
+    elif evolution_config.inheritance == "transgenerational":
+        inheritance = TransgenerationalInheritance()
     else:
         inheritance = NoInheritance()
 


### PR DESCRIPTION
## Summary

First implementation commit for the M6 transgenerational memory milestone (OpenSpec change `add-transgenerational-memory`, scaffolded in #158). Lands the `TransgenerationalInheritance` strategy skeleton + Literal extensions, end-to-end runnable for `inheritance: transgenerational` YAML loads.

This commit ships ONLY the strategy class + Protocol conformance — the F0 substrate extraction pipeline + worker tuple/kwarg forwarding into `fitness.evaluate` are follow-up additions tracked in subsequent commits of the OpenSpec change. Until those land, an `inheritance: transgenerational` run constructs the strategy correctly but produces no substrate effect — only the lineage CSV populates `inherited_from` from gen 1 onwards (kind() != "none").

## What changed

**New files:**
- `packages/quantum-nematode/quantumnematode/evolution/transgenerational_inheritance.py` (~140 LoC)
  - `TransgenerationalInheritance` class implementing the four `InheritanceStrategy` Protocol methods
  - Top-1 lex-tie-broken `select_parents` (matches Baldwin/Lamarckian(1) byte-for-byte)
  - `assign_parent` returns `None` (substrate flows via separate kwarg path, not per-child warm-start)
  - `checkpoint_path` returns `inheritance/gen-NNN/genome-<gid>.tei.pt` (distinct `.tei.pt` extension prevents on-disk collision with Lamarckian's `.pt`)
  - `kind()` returns the new `"transgenerational"` literal
- `packages/quantum-nematode/tests/.../test_transgenerational_inheritance.py` (~180 LoC, **11 cases**) covering all four Protocol methods + extended known-kind set guard + Protocol isinstance conformance

**Modified files (end-to-end runnability):**
- `evolution/inheritance.py` — Protocol `kind()` Literal extended to include `"transgenerational"`; module + Protocol docstrings document the fourth strategy
- `evolution/__init__.py` — `TransgenerationalInheritance` added to exports + `__all__`
- `evolution/loop.py` — `_expected_kind` dispatch dict extended so the constructor's kind()-vs-config consistency guard accepts the new strategy
- `utils/config_loader.py` — `EvolutionConfig.inheritance` Literal extended; validator error messages now mention transgenerational alongside Lamarckian/Baldwin
- `scripts/run_evolution.py` — `--inheritance` argparse choices + strategy-factory if/elif chain extended

**Tracker:**
- `openspec/changes/add-transgenerational-memory/tasks.md` — 1.1-1.6 ticked
- `openspec/changes/phase5-tracking/tasks.md` — M6 OpenSpec change line + status flipped to "in progress"

## Test plan

- [x] `uv run pytest -m "not smoke and not nightly"` — 2665/2665 pass
- [x] `uv run pre-commit run -a` — all 10 hooks pass (mdformat, markdownlint, ruff check + format, pyright, tests, etc.)
- [x] Targeted new-test run — 11/11 pass + full inheritance suite 33/33 pass (no regressions on `NoInheritance`/`Lamarckian`/`Baldwin`)
- [x] Pre-commit home-path audit clean
- [x] Self-review pass before opening PR (SF1 milestone-ref scrub + SF2 validator-error rewrites + minor wording fixes) — applied as commit 2

## Commits

1. `3538ad54` feat(evolution): scaffold TransgenerationalInheritance strategy (M6.1)
2. `6507c826` chore(m6): apply pre-PR review fixes (SF1-SF2, M1-M2)

## Out of scope (deferred follow-ups in subsequent commits of the OpenSpec change)

- `TransgenerationalMemory` dataclass (substrate carrier with logit_bias / lineage_depth / source_genome_id; inherit_from + clamp + apply_to_logits + extract_from_brain + .tei.pt round-trip)
- LSTMPPO `tei_prior` attribute + dual-call-site application in `run_brain` and `learn` (PPO sampling/update distribution consistency)
- F0 Substrate Extraction Pipeline in `EvolutionLoop` (per-genome F0 weight capture → elite identify → load elite into fresh brain → telemetry pass → save `.tei.pt` → GC F0 `.pt` files)
- Per-generation `lawn_schedule` consumer + worker tuple extension + `tei_prior_source` kwarg forwarding into `fitness.evaluate`
- `TransgenerationalConfig` Pydantic block + `LawnScheduleEntry` + inheritance/pairing validator + CLI `--fitness` guard
- Config YAML + campaign shell + per-gen choice-index evaluator + paired-arm aggregator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a transgenerational inheritance strategy to the evolution framework for multi-generation substrate flow.

* **Configuration & CLI**
  * Config and command-line options now accept a "transgenerational" inheritance mode.

* **Tests**
  * Added comprehensive tests validating behavior, checkpoint naming, parent selection, and integration.

* **Documentation / Tracking**
  * Roadmap/tracking items updated to show the transgenerational work scaffolded and in progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SyntheticBrains/nematode/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->