### PR TITLE
feat(agent): add TransgenerationalMemory dataclass (M6 commit 2)

### DIFF
--- a/openspec/changes/add-transgenerational-memory/tasks.md
+++ b/openspec/changes/add-transgenerational-memory/tasks.md
@@ -13,13 +13,13 @@ Tasks are grouped by commit (per the plan's 8-commit grouping). Each group repre
 
 ## 2. TransgenerationalMemory dataclass (Commit 2)
 
-- [ ] 2.1 Create `quantumnematode/agent/transgenerational_memory.py` with the `TransgenerationalMemory` dataclass: `logit_bias: torch.Tensor`, `lineage_depth: int`, `source_genome_id: str`. `frozen=True`. `__post_init__` validates shape (`ndim == 1`), dtype (`float32`), and clamps `|x| ≤ 2.0`.
-- [ ] 2.2 Implement `apply_to_logits(logits)` returning `logits + self.logit_bias` (broadcast over leading dims), preserving shape/dtype/device, no in-place mutation.
-- [ ] 2.3 Implement `inherit_from(parents, decay_factor)` class method (or module factory). Top-1 elite semantics. Validates `0.0 ≤ decay_factor ≤ 1.0` and non-empty parents. Increments `lineage_depth`. Inherits `source_genome_id`.
-- [ ] 2.4 Implement `extract_from_brain(brain, env, probe_positions, rng_seed)` telemetry-pass extraction. Deterministic on `rng_seed`. Runs on disjoint episode rollouts from those that produced fitness scores.
-- [ ] 2.5 Implement serialise/deserialise via `torch.save`/`torch.load` over `.tei.pt`. Round-trip preserves all fields byte-equivalently.
-- [ ] 2.6 Tests: `tests/.../agent/test_transgenerational_memory.py`. ~12 cases covering construction-time clamp, shape/dtype validation, `apply_to_logits` shape preservation + non-mutation, `inherit_from` geometric decay across F0→F3, decay-factor range validator, empty-parents rejection, serialise round-trip, missing-file load error, determinism of telemetry pass.
-- [ ] 2.7 Run pytest + pre-commit clean.
+- [x] 2.1 Created `quantumnematode/agent/transgenerational_memory.py` with the `TransgenerationalMemory` dataclass: `logit_bias: torch.Tensor`, `lineage_depth: int`, `source_genome_id: str`. `frozen=True`. `__post_init__` validates shape (`ndim == 1`), dtype (`float32`), `lineage_depth ≥ 0`, and clamps `|x| ≤ LOGIT_BIAS_CLAMP` (= 2.0) via `object.__setattr__` on a `.detach().clone()` copy so the input tensor is never mutated.
+- [x] 2.2 Implemented `apply_to_logits(logits)` returning `logits + self.logit_bias` (broadcast over leading dims), preserving shape/dtype/device, no in-place mutation.
+- [x] 2.3 Implemented `inherit_from(parents, decay_factor)` as a `@classmethod`. Top-1 elite semantics (reads `parents[0]` only). Validates `0.0 ≤ decay_factor ≤ 1.0` and non-empty parents. Increments `lineage_depth`. Inherits `source_genome_id`.
+- [x] 2.4 `extract_from_brain(brain, env, probe_positions, rng_seed)` shipped as a `NotImplementedError`-raising placeholder. **Functional implementation deferred to the F0 Substrate Extraction Pipeline commit** (it requires env coupling — pathogen lawn at a known position + probe-position generator + brain-policy adapter — which belongs to the loop-integration commit). The placeholder preserves the public-API surface so downstream importers can register the symbol today.
+- [x] 2.5 Implemented module-level `save(substrate, path)` / `load(path)` via `torch.save` / `torch.load`. Round-trip preserves all fields byte-equivalently. `save` creates the parent dir if missing (mirrors Lamarckian capture). `load` raises `FileNotFoundError` with the missing path in the message.
+- [x] 2.6 Tests: `tests/.../agent/test_transgenerational_memory.py` (20 cases): construction clamp + no-input-mutation + shape/dtype/depth rejections + frozen-instance assertion (7 cases); `inherit_from` geometric decay F0→F3 + depth increment + source preservation + empty-parents + decay range validators + multi-parent picks parents[0] (7 cases); `apply_to_logits` additive + broadcast + no-mutation + distinct-object (2 cases); save/load round-trip + save-creates-parent-dir + load-missing-file (3 cases); `extract_from_brain` raises NotImplementedError (1 case).
+- [x] 2.7 `uv run pytest packages/.../test_transgenerational_memory.py -v` passes 20/20.
 
 ## 3. LSTMPPO TEI prior application (Commit 3)
 

--- a/packages/quantum-nematode/quantumnematode/agent/__init__.py
+++ b/packages/quantum-nematode/quantumnematode/agent/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "DEFAULT_AGENT_BODY_LENGTH",
     "DEFAULT_MAX_STEPS",
+    "LOGIT_BIAS_CLAMP",
     "FoodCompetitionPolicy",
     "ManyworldsModeConfig",
     "MultiAgentEpisodeResult",
@@ -11,6 +12,10 @@ __all__ = [
     "RewardConfig",
     "STAMBuffer",
     "SatietyConfig",
+    "TransgenerationalMemory",
+    "extract_from_brain",
+    "load_transgenerational_memory",
+    "save_transgenerational_memory",
 ]
 
 from quantumnematode.agent.agent import (
@@ -27,3 +32,10 @@ from quantumnematode.agent.multi_agent import (
     MultiAgentSimulation,
 )
 from quantumnematode.agent.stam import STAMBuffer
+from quantumnematode.agent.transgenerational_memory import (
+    LOGIT_BIAS_CLAMP,
+    TransgenerationalMemory,
+    extract_from_brain,
+)
+from quantumnematode.agent.transgenerational_memory import load as load_transgenerational_memory
+from quantumnematode.agent.transgenerational_memory import save as save_transgenerational_memory

--- a/packages/quantum-nematode/quantumnematode/agent/transgenerational_memory.py
+++ b/packages/quantum-nematode/quantumnematode/agent/transgenerational_memory.py
@@ -1,0 +1,363 @@
+"""Transgenerational memory substrate — inheritable behavioural-bias dataclass.
+
+Provides :class:`TransgenerationalMemory`, the heritable substrate
+that the ``TransgenerationalInheritance`` strategy
+(:class:`quantumnematode.evolution.transgenerational_inheritance.TransgenerationalInheritance`)
+threads from the F0 elite through F1/F2/F3 generations. The
+substrate carries a per-action additive logit bias that, when set on
+``LSTMPPOBrain.tei_prior``, augments the actor's logits before
+softmax at every step of every episode — biasing offspring action
+distributions toward avoidance independently of trained weights.
+
+Three fields:
+
+- ``logit_bias``: ``torch.Tensor`` of shape ``(num_actions,)``,
+  dtype ``float32``. Clamped to ``|x| ≤ 2.0`` post-construction
+  (Boltzmann ratio cap ≈ 7.4x). The size matches the brain's
+  ``num_actions`` (4 for the default ``DEFAULT_ACTIONS`` set;
+  forward-compatible with ``SIX_ACTIONS``).
+- ``lineage_depth``: ``int``, 0 for F0, incremented by 1 at each
+  ``inherit_from`` call.
+- ``source_genome_id``: ``str``, the F0 elite's genome ID — the
+  authoritative provenance anchor for the cascade.
+
+The dataclass is ``frozen=True`` so cross-generation aliasing
+cannot mutate an ancestor's substrate; ``__post_init__`` validates
+shape + dtype and clamps the bias via ``object.__setattr__`` (the
+canonical Python pattern for frozen-dataclass post-init mutation).
+
+Three operations:
+
+- :meth:`apply_to_logits`: additive ``logits + self.logit_bias``,
+  broadcast over leading batch/sequence dimensions, preserving
+  input shape/dtype/device, no in-place mutation.
+- :meth:`inherit_from`: class method producing a child substrate
+  as ``child.logit_bias = parents[0].logit_bias * decay_factor``,
+  with ``lineage_depth`` incremented and ``source_genome_id``
+  inherited. Decay is multiplicative at the generation boundary.
+- :func:`save` / :func:`load`: ``.tei.pt`` round-trip via
+  ``torch.save`` / ``torch.load``.
+
+One stub:
+
+- :func:`extract_from_brain`: contractual placeholder that raises
+  ``NotImplementedError``. The functional implementation requires
+  env coupling (a pathogen lawn at a known position + probe-position
+  generator + brain-policy adapter) and lands alongside the F0
+  Substrate Extraction Pipeline in a follow-up commit. The stub
+  preserves the public-API surface so callers can import the symbol
+  today.
+
+See the OpenSpec change ``openspec/changes/add-transgenerational-
+memory/`` for the full design rationale + cascade semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+# Maximum absolute element-wise magnitude of ``logit_bias``. Caps the
+# Boltzmann ratio at ``e^2 ≈ 7.4x`` so a strong bias cannot collapse
+# exploration. Kaletsky F2 ≈ 0.55 choice index corresponds to a
+# ~3x action-probability tilt, so the cap leaves headroom while
+# preventing pathological deterministic policies.
+LOGIT_BIAS_CLAMP: float = 2.0
+
+
+@dataclass(frozen=True)
+class TransgenerationalMemory:
+    """Inheritable behavioural-bias substrate carried across generations.
+
+    Stores a per-action additive logit bias that biases an actor's
+    action distribution at every step of every episode. The bias is
+    extracted from an F0 elite policy via :func:`extract_from_brain`
+    and multiplicatively decayed across F1/F2/F3 generations via
+    :meth:`inherit_from`.
+
+    Parameters
+    ----------
+    logit_bias : torch.Tensor
+        1-D tensor of shape ``(num_actions,)`` and dtype ``float32``.
+        Each element SHALL satisfy ``|x| ≤ LOGIT_BIAS_CLAMP`` after
+        construction; values are clamped automatically in
+        ``__post_init__`` and the input tensor is NOT mutated in place.
+    lineage_depth : int
+        Inheritance generation (0 for F0, 1 for F1, etc.). Incremented
+        by 1 at each :meth:`inherit_from` call. SHALL be non-negative.
+    source_genome_id : str
+        F0 elite genome ID — the provenance anchor for the cascade.
+        Inherited unchanged across all generations.
+
+    Raises
+    ------
+    ValueError
+        If ``logit_bias.ndim != 1``, ``logit_bias.dtype != torch.float32``,
+        or ``lineage_depth < 0``.
+
+    Notes
+    -----
+    ``frozen=True`` prevents cross-generation aliasing mutation. The
+    clamping pass inside ``__post_init__`` uses ``object.__setattr__``
+    (the canonical Python pattern for frozen-dataclass post-init
+    mutation, since frozen dataclasses cannot reassign fields
+    directly). The original caller-provided ``logit_bias`` tensor is
+    cloned before clamping so the caller's tensor is never modified
+    in place.
+    """
+
+    logit_bias: torch.Tensor
+    lineage_depth: int
+    source_genome_id: str
+
+    def __post_init__(self) -> None:
+        """Validate shape/dtype/depth and clamp ``logit_bias`` element-wise.
+
+        Runs after dataclass field assignment. Raises ``ValueError`` on
+        invalid inputs (non-1-D logit_bias, non-float32 dtype, or
+        negative ``lineage_depth``). Clones the input ``logit_bias``
+        and clamps the copy to ``[-LOGIT_BIAS_CLAMP, +LOGIT_BIAS_CLAMP]``,
+        then reassigns via ``object.__setattr__`` (frozen-dataclass
+        canonical post-init mutation pattern) so the caller's tensor
+        is never mutated in place.
+        """
+        # Shape validation: must be 1-D so broadcast over (batch, seq, num_actions)
+        # logits is unambiguous. Higher-dim biases would broadcast non-obviously.
+        if self.logit_bias.ndim != 1:
+            msg = (
+                f"TransgenerationalMemory.logit_bias must be 1-D "
+                f"(shape (num_actions,)); got ndim={self.logit_bias.ndim} "
+                f"with shape {tuple(self.logit_bias.shape)} and "
+                f"dtype {self.logit_bias.dtype}."
+            )
+            raise ValueError(msg)
+        # Dtype validation: float32 is the actor's logit dtype across all
+        # LSTMPPO call sites; mixing dtypes would silently cast at the
+        # addition site and break torch.equal-based round-trip tests.
+        if self.logit_bias.dtype != torch.float32:
+            msg = (
+                f"TransgenerationalMemory.logit_bias must have dtype "
+                f"torch.float32; got dtype={self.logit_bias.dtype} "
+                f"with shape {tuple(self.logit_bias.shape)} and "
+                f"ndim={self.logit_bias.ndim}."
+            )
+            raise ValueError(msg)
+        if self.lineage_depth < 0:
+            msg = (
+                f"TransgenerationalMemory.lineage_depth must be >= 0 "
+                f"(0 for F0, incremented at each inherit_from call); "
+                f"got {self.lineage_depth}."
+            )
+            raise ValueError(msg)
+        # Clone-then-clamp: the input tensor is NEVER mutated. clone()
+        # detaches autograd history too, which is desired — the substrate
+        # is non-trainable additive state, not a gradient-flowing parameter.
+        clamped = self.logit_bias.detach().clone().clamp_(-LOGIT_BIAS_CLAMP, LOGIT_BIAS_CLAMP)
+        # Frozen dataclasses cannot reassign fields directly; the canonical
+        # post-init mutation pattern uses object.__setattr__.
+        object.__setattr__(self, "logit_bias", clamped)
+
+    def apply_to_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Return ``logits + self.logit_bias`` without in-place mutation.
+
+        Broadcasts over leading batch / sequence dimensions: a
+        ``(num_actions,)`` bias added to ``(batch, seq, num_actions)``
+        logits broadcasts elementwise over the actions axis. The
+        returned tensor is a distinct object — neither the input
+        ``logits`` nor ``self.logit_bias`` is mutated.
+
+        Parameters
+        ----------
+        logits : torch.Tensor
+            Actor logits of shape ``(..., num_actions)``. The trailing
+            dimension SHALL match ``self.logit_bias.shape[0]``; mismatch
+            raises ``RuntimeError`` at the addition site (PyTorch
+            broadcast rule), with a clear message.
+
+        Returns
+        -------
+        torch.Tensor
+            New tensor of the same shape, dtype, and device as
+            ``logits``, with the bias added element-wise.
+        """
+        # `+` is non-in-place on tensors; returns a new tensor.
+        return logits + self.logit_bias
+
+    @classmethod
+    def inherit_from(
+        cls,
+        parents: Sequence[TransgenerationalMemory],
+        decay_factor: float,
+    ) -> TransgenerationalMemory:
+        """Produce a child substrate decayed from a single parent (top-1 elite).
+
+        ``child.logit_bias = parents[0].logit_bias * decay_factor``;
+        ``child.lineage_depth = parents[0].lineage_depth + 1``;
+        ``child.source_genome_id = parents[0].source_genome_id``.
+
+        The multi-parent ``parents`` signature is forward-compatible
+        with future strategies (tournament, soft-elite top-k) but the
+        current single-elite-broadcast semantics use only ``parents[0]``.
+        This matches ``LamarckianInheritance.assign_parent``'s
+        round-robin contract under ``elite_count=1``.
+
+        Parameters
+        ----------
+        parents : Sequence[TransgenerationalMemory]
+            At least one parent substrate. The single-elite rule uses
+            ``parents[0]``.
+        decay_factor : float
+            Multiplicative decay applied to the parent's ``logit_bias``.
+            Constrained to ``[0.0, 1.0]``; values outside raise
+            ``ValueError``.
+
+        Returns
+        -------
+        TransgenerationalMemory
+            Child substrate with depth ``parent.lineage_depth + 1``.
+            Post-construction clamp still applies (so a decayed bias
+            that re-enters the ``[-2.0, 2.0]`` range from a higher
+            magnitude is preserved).
+
+        Raises
+        ------
+        ValueError
+            If ``parents`` is empty, or ``decay_factor`` is outside
+            ``[0.0, 1.0]``.
+        """
+        if not parents:
+            msg = (
+                "TransgenerationalMemory.inherit_from requires at least one "
+                "parent substrate; got an empty sequence."
+            )
+            raise ValueError(msg)
+        if not 0.0 <= decay_factor <= 1.0:
+            msg = (
+                f"TransgenerationalMemory.inherit_from decay_factor must be "
+                f"in [0.0, 1.0]; got {decay_factor}."
+            )
+            raise ValueError(msg)
+        parent = parents[0]
+        return cls(
+            logit_bias=parent.logit_bias * decay_factor,
+            lineage_depth=parent.lineage_depth + 1,
+            source_genome_id=parent.source_genome_id,
+        )
+
+
+def save(substrate: TransgenerationalMemory, path: Path) -> None:
+    """Serialise a substrate to disk via ``torch.save`` at the ``.tei.pt`` path.
+
+    Stores all three fields (``logit_bias`` tensor, ``lineage_depth``
+    int, ``source_genome_id`` str) in a dict so :func:`load` can
+    reconstruct the dataclass byte-equivalently. The parent
+    directory is created if missing (mirrors ``LamarckianInheritance``'s
+    capture-side behaviour).
+
+    Parameters
+    ----------
+    substrate : TransgenerationalMemory
+        The substrate to serialise.
+    path : Path
+        Destination ``.tei.pt`` file. Parent directory created if
+        missing. The path-builder
+        (``TransgenerationalInheritance.checkpoint_path``) returns
+        the canonical ``inheritance/gen-NNN/genome-<gid>.tei.pt``
+        layout; callers SHOULD use it to avoid drift between writer
+        and reader.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "logit_bias": substrate.logit_bias,
+        "lineage_depth": substrate.lineage_depth,
+        "source_genome_id": substrate.source_genome_id,
+    }
+    torch.save(payload, path)
+
+
+def load(path: Path) -> TransgenerationalMemory:
+    """Deserialise a substrate from disk; reconstruct the dataclass.
+
+    The returned instance SHALL be byte-equivalent to the original
+    that was saved: ``logit_bias`` tensor equal element-wise,
+    ``lineage_depth`` equal, ``source_genome_id`` equal.
+
+    Parameters
+    ----------
+    path : Path
+        Source ``.tei.pt`` file. SHALL exist.
+
+    Returns
+    -------
+    TransgenerationalMemory
+        Reconstructed substrate (post-construction clamp re-applies,
+        but a previously-clamped tensor is idempotent under the
+        re-clamp).
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist. The message includes the missing
+        path so the operator can diagnose.
+    """
+    if not path.exists():
+        msg = (
+            f"TransgenerationalMemory.load: substrate file not found at "
+            f"{path}. Check the F0 substrate extraction pipeline ran "
+            f"successfully and the path matches "
+            f"TransgenerationalInheritance.checkpoint_path's output."
+        )
+        raise FileNotFoundError(msg)
+    # weights_only=False because the payload is a dict of mixed types
+    # (tensor + int + str), not just a tensor state_dict. The .tei.pt
+    # files are produced by our own pipeline (never user-supplied), so
+    # the unpickle risk is bounded by the same trust assumption that
+    # applies to the rest of the project's .pt artefacts.
+    payload = torch.load(path, weights_only=False)
+    return TransgenerationalMemory(
+        logit_bias=payload["logit_bias"],
+        lineage_depth=payload["lineage_depth"],
+        source_genome_id=payload["source_genome_id"],
+    )
+
+
+def extract_from_brain(
+    brain: object,
+    env: object,
+    probe_positions: Sequence[tuple[int, int]],
+    rng_seed: int,
+) -> TransgenerationalMemory:
+    """Telemetry-pass placeholder. Functional implementation lands with the F0 pipeline.
+
+    The functional implementation requires env coupling (a pathogen
+    lawn at a known position, a probe-position generator, and a
+    brain-policy adapter that extracts action distributions from
+    actor logits) which belongs to the F0 Substrate Extraction
+    Pipeline in the evolution loop. This stub preserves the public
+    API surface so downstream callers can import the symbol today;
+    the loop integration commit will replace the body.
+
+    See the OpenSpec change's "F0 Telemetry-Pass Extraction" and
+    "F0 Substrate Extraction Pipeline" requirements for the
+    contract this function will satisfy.
+
+    Raises
+    ------
+    NotImplementedError
+        Always. Use the F0 Substrate Extraction Pipeline (loop-side
+        integration, a follow-up commit) instead.
+    """
+    msg = (
+        "TransgenerationalMemory.extract_from_brain is a placeholder; the "
+        "functional implementation requires env coupling and lands with the "
+        "F0 Substrate Extraction Pipeline in a follow-up commit. See "
+        "openspec/changes/add-transgenerational-memory/."
+    )
+    raise NotImplementedError(msg)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_transgenerational_memory.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_transgenerational_memory.py
@@ -1,0 +1,288 @@
+"""Unit tests for :mod:`quantumnematode.agent.transgenerational_memory`.
+
+Covers the four spec scenarios for the substrate (clamp, shape/dtype
+validation, decay, apply_to_logits, serialisation round-trip) plus
+the placeholder behaviour for ``extract_from_brain``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import torch
+from quantumnematode.agent.transgenerational_memory import (
+    LOGIT_BIAS_CLAMP,
+    TransgenerationalMemory,
+    extract_from_brain,
+    load,
+    save,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _f0(logit_bias: torch.Tensor, source_genome_id: str = "gid-a") -> TransgenerationalMemory:
+    """Construct an F0 substrate (lineage_depth=0) for test convenience."""
+    return TransgenerationalMemory(
+        logit_bias=logit_bias,
+        lineage_depth=0,
+        source_genome_id=source_genome_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction: clamp + shape/dtype validation + frozen + no-input-mutation
+# ---------------------------------------------------------------------------
+
+
+def test_construction_clamps_bias_values() -> None:
+    """``__post_init__`` SHALL clamp ``|logit_bias[i]| > 2.0`` to ``±2.0``.
+
+    Matches the spec scenario "Substrate construction clamps bias values":
+    input ``[5.0, -3.0, 0.5, 1.0]`` → stored ``[2.0, -2.0, 0.5, 1.0]``.
+    """
+    raw = torch.tensor([5.0, -3.0, 0.5, 1.0], dtype=torch.float32)
+    sub = _f0(raw)
+    expected = torch.tensor([2.0, -2.0, 0.5, 1.0], dtype=torch.float32)
+    assert torch.equal(sub.logit_bias, expected)
+
+
+def test_construction_does_not_mutate_input_tensor() -> None:
+    """The caller-provided input tensor SHALL NOT be mutated in place.
+
+    Critical for callers that retain a reference to the pre-clamp
+    tensor (e.g., downstream telemetry that records raw extraction
+    values alongside the substrate).
+    """
+    raw = torch.tensor([5.0, -3.0, 0.5, 1.0], dtype=torch.float32)
+    raw_before = raw.clone()
+    _ = _f0(raw)
+    assert torch.equal(raw, raw_before)
+
+
+def test_construction_rejects_non_1d_logit_bias() -> None:
+    """``logit_bias.ndim != 1`` SHALL raise ``ValueError`` naming the shape."""
+    raw = torch.zeros((2, 4), dtype=torch.float32)
+    with pytest.raises(ValueError, match=r"must be 1-D"):
+        _f0(raw)
+
+
+def test_construction_rejects_non_float32_logit_bias() -> None:
+    """``logit_bias.dtype != float32`` SHALL raise ``ValueError`` naming the dtype."""
+    raw = torch.zeros(4, dtype=torch.float64)
+    with pytest.raises(ValueError, match=r"must have dtype torch.float32"):
+        _f0(raw)
+
+
+def test_construction_rejects_negative_lineage_depth() -> None:
+    """``lineage_depth < 0`` SHALL raise ``ValueError`` naming the offending value."""
+    raw = torch.zeros(4, dtype=torch.float32)
+    with pytest.raises(ValueError, match=r"lineage_depth must be >= 0"):
+        TransgenerationalMemory(logit_bias=raw, lineage_depth=-1, source_genome_id="gid-a")
+
+
+def test_dataclass_is_frozen() -> None:
+    """The dataclass SHALL be frozen (cross-generation aliasing protection).
+
+    Attempting to reassign any field SHALL raise ``FrozenInstanceError``
+    (dataclasses raise this from the auto-generated ``__setattr__``).
+    """
+    sub = _f0(torch.zeros(4, dtype=torch.float32))
+    with pytest.raises(Exception, match=r"frozen|immutable|cannot assign"):
+        sub.lineage_depth = 5  # type: ignore[misc]
+
+
+def test_clamp_constant_matches_spec() -> None:
+    """``LOGIT_BIAS_CLAMP`` SHALL be ``2.0`` per the spec's e^2 ~ 7.4x Boltzmann cap."""
+    expected_clamp = 2.0
+    assert expected_clamp == LOGIT_BIAS_CLAMP
+
+
+# ---------------------------------------------------------------------------
+# inherit_from: geometric decay + validation
+# ---------------------------------------------------------------------------
+
+
+def test_inherit_from_single_parent_geometric_retention() -> None:
+    """``inherit_from`` SHALL produce ``parent.logit_bias * decay_factor`` for each call.
+
+    Matches the spec scenario "Single-parent decay produces geometric retention":
+    F0 ``[0.0, 1.0, -0.5, 0.2]`` → F1 ``[0.0, 0.6, -0.3, 0.12]`` →
+    F2 ``[0.0, 0.36, -0.18, 0.072]`` → F3 ``[0.0, 0.216, -0.108, 0.0432]``.
+    """
+    f0 = _f0(torch.tensor([0.0, 1.0, -0.5, 0.2], dtype=torch.float32))
+    f1 = TransgenerationalMemory.inherit_from([f0], decay_factor=0.6)
+    f2 = TransgenerationalMemory.inherit_from([f1], decay_factor=0.6)
+    f3 = TransgenerationalMemory.inherit_from([f2], decay_factor=0.6)
+
+    assert torch.allclose(f1.logit_bias, torch.tensor([0.0, 0.6, -0.3, 0.12]))
+    assert torch.allclose(f2.logit_bias, torch.tensor([0.0, 0.36, -0.18, 0.072]))
+    assert torch.allclose(f3.logit_bias, torch.tensor([0.0, 0.216, -0.108, 0.0432]))
+
+
+def test_inherit_from_increments_lineage_depth() -> None:
+    """``inherit_from`` SHALL increment ``lineage_depth`` by 1 per call."""
+    f0 = _f0(torch.tensor([0.0, 1.0, -0.5, 0.2], dtype=torch.float32))
+    f1 = TransgenerationalMemory.inherit_from([f0], decay_factor=0.6)
+    f2 = TransgenerationalMemory.inherit_from([f1], decay_factor=0.6)
+    f3 = TransgenerationalMemory.inherit_from([f2], decay_factor=0.6)
+    assert f0.lineage_depth == 0
+    assert f1.lineage_depth == 1
+    f2_depth = 2
+    assert f2.lineage_depth == f2_depth
+    f3_depth = 3
+    assert f3.lineage_depth == f3_depth
+
+
+def test_inherit_from_preserves_source_genome_id() -> None:
+    """``inherit_from`` SHALL preserve ``source_genome_id`` across all descendants."""
+    f0 = _f0(torch.tensor([0.0, 1.0, -0.5, 0.2], dtype=torch.float32), source_genome_id="gid-a")
+    f1 = TransgenerationalMemory.inherit_from([f0], decay_factor=0.6)
+    f2 = TransgenerationalMemory.inherit_from([f1], decay_factor=0.6)
+    f3 = TransgenerationalMemory.inherit_from([f2], decay_factor=0.6)
+    assert f1.source_genome_id == "gid-a"
+    assert f2.source_genome_id == "gid-a"
+    assert f3.source_genome_id == "gid-a"
+
+
+def test_inherit_from_empty_parents_raises() -> None:
+    """``inherit_from`` SHALL raise on empty parents sequence."""
+    with pytest.raises(ValueError, match=r"at least one parent"):
+        TransgenerationalMemory.inherit_from([], decay_factor=0.6)
+
+
+def test_inherit_from_decay_factor_below_zero_raises() -> None:
+    """``inherit_from`` SHALL reject ``decay_factor < 0.0``."""
+    f0 = _f0(torch.zeros(4, dtype=torch.float32))
+    with pytest.raises(ValueError, match=r"decay_factor must be in \[0.0, 1.0\]"):
+        TransgenerationalMemory.inherit_from([f0], decay_factor=-0.1)
+
+
+def test_inherit_from_decay_factor_above_one_raises() -> None:
+    """``inherit_from`` SHALL reject ``decay_factor > 1.0``."""
+    f0 = _f0(torch.zeros(4, dtype=torch.float32))
+    with pytest.raises(ValueError, match=r"decay_factor must be in \[0.0, 1.0\]"):
+        TransgenerationalMemory.inherit_from([f0], decay_factor=1.5)
+
+
+def test_inherit_from_uses_single_elite_when_multi_parents() -> None:
+    """``inherit_from`` SHALL use ``parents[0]`` only (single-elite-broadcast).
+
+    Matches ``LamarckianInheritance.assign_parent`` semantics under
+    ``elite_count=1``. The multi-parent signature is forward-
+    compatible with future strategies but the current single-elite
+    rule reads only the first element.
+    """
+    f0_a = _f0(torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32), source_genome_id="gid-a")
+    f0_b = _f0(torch.tensor([0.0, 1.0, 0.0, 0.0], dtype=torch.float32), source_genome_id="gid-b")
+    child = TransgenerationalMemory.inherit_from([f0_a, f0_b], decay_factor=0.5)
+    # parents[0] is f0_a, so child inherits f0_a's bias scaled by 0.5
+    # and f0_a's source_genome_id, NOT f0_b's.
+    assert torch.allclose(child.logit_bias, torch.tensor([0.5, 0.0, 0.0, 0.0]))
+    assert child.source_genome_id == "gid-a"
+
+
+# ---------------------------------------------------------------------------
+# apply_to_logits: additive, broadcast, no-mutation
+# ---------------------------------------------------------------------------
+
+
+def test_apply_to_logits_additive_without_mutation() -> None:
+    """``apply_to_logits`` SHALL return ``logits + bias`` without mutating input.
+
+    Matches the spec scenario "Logits are augmented additively without
+    mutation": bias ``[0.5, -0.5, 1.0, 0.0]`` + logits
+    ``[[1.0, 2.0, 3.0, 0.0]]`` → ``[[1.5, 1.5, 4.0, 0.0]]``; input
+    logits tensor unchanged.
+    """
+    sub = _f0(torch.tensor([0.5, -0.5, 1.0, 0.0], dtype=torch.float32))
+    logits = torch.tensor([[1.0, 2.0, 3.0, 0.0]], dtype=torch.float32)
+    logits_before = logits.clone()
+    result = sub.apply_to_logits(logits)
+    expected = torch.tensor([[1.5, 1.5, 4.0, 0.0]], dtype=torch.float32)
+    assert torch.equal(result, expected)
+    # Input not mutated:
+    assert torch.equal(logits, logits_before)
+    # Returned tensor is a distinct object:
+    assert result.data_ptr() != logits.data_ptr()
+
+
+def test_apply_to_logits_broadcasts_over_batch_and_seq() -> None:
+    """``apply_to_logits`` SHALL broadcast ``(num_actions,)`` over leading dims.
+
+    Matches the spec scenario "Apply preserves shape and dtype across
+    batch dimensions": bias shape ``(4,)`` + logits shape ``(batch, seq, 4)``
+    → result shape ``(batch, seq, 4)`` with bias broadcast over batch+seq.
+    """
+    sub = _f0(torch.tensor([0.5, -0.5, 1.0, 0.0], dtype=torch.float32))
+    logits = torch.zeros((3, 5, 4), dtype=torch.float32)
+    result = sub.apply_to_logits(logits)
+    assert result.shape == (3, 5, 4)
+    assert result.dtype == torch.float32
+    # Every (batch, seq) cell should equal the bias since logits is zero:
+    for b in range(3):
+        for s in range(5):
+            assert torch.equal(result[b, s], sub.logit_bias)
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_round_trip_preserves_all_fields(tmp_path: Path) -> None:
+    """``save`` / ``load`` SHALL produce a byte-equivalent deserialisation.
+
+    Matches the spec scenario "Round-trip preserves all fields":
+    F2 substrate with ``logit_bias=[0.5, -0.3, 1.0, 0.0]``,
+    ``lineage_depth=2``, ``source_genome_id="gid-elite-3"`` → save →
+    load → identical fields.
+    """
+    original = TransgenerationalMemory(
+        logit_bias=torch.tensor([0.5, -0.3, 1.0, 0.0], dtype=torch.float32),
+        lineage_depth=2,
+        source_genome_id="gid-elite-3",
+    )
+    path = tmp_path / "foo.tei.pt"
+    save(original, path)
+    loaded = load(path)
+    assert torch.equal(loaded.logit_bias, original.logit_bias)
+    assert loaded.lineage_depth == original.lineage_depth
+    assert loaded.source_genome_id == original.source_genome_id
+
+
+def test_save_creates_parent_directory(tmp_path: Path) -> None:
+    """``save`` SHALL create the parent directory if missing (mirrors Lamarckian capture)."""
+    sub = _f0(torch.zeros(4, dtype=torch.float32))
+    path = tmp_path / "inheritance" / "gen-000" / "genome-gid-a.tei.pt"
+    assert not path.parent.exists()
+    save(sub, path)
+    assert path.parent.exists()
+    assert path.exists()
+
+
+def test_load_missing_file_raises_filenotfounderror(tmp_path: Path) -> None:
+    """``load`` SHALL raise ``FileNotFoundError`` naming the missing path."""
+    path = tmp_path / "nonexistent.tei.pt"
+    with pytest.raises(FileNotFoundError, match=r"substrate file not found"):
+        load(path)
+
+
+# ---------------------------------------------------------------------------
+# Placeholder behaviour: extract_from_brain raises NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_extract_from_brain_raises_not_implemented() -> None:
+    """``extract_from_brain`` SHALL raise ``NotImplementedError`` (placeholder).
+
+    The functional implementation requires env coupling and lands
+    with the F0 Substrate Extraction Pipeline in a follow-up commit.
+    Asserting the placeholder raises here pins the public-API
+    surface so importers can register the symbol today; the loop
+    integration commit will replace the body.
+    """
+    with pytest.raises(NotImplementedError, match=r"placeholder"):
+        extract_from_brain(brain=object(), env=object(), probe_positions=[], rng_seed=42)


### PR DESCRIPTION
## Summary

Second implementation commit for the M6 transgenerational memory milestone (OpenSpec change `add-transgenerational-memory`). Lands the `TransgenerationalMemory` frozen dataclass + helpers, fully self-contained with no env coupling.

The strategy class added by PR #159 (`TransgenerationalInheritance`) will carry instances of this dataclass across F1/F2/F3 generations once the F0 Substrate Extraction Pipeline + loop integration land in subsequent commits.

## What's shipped

**New file**: `packages/quantum-nematode/quantumnematode/agent/transgenerational_memory.py` (~360 LoC)

- `TransgenerationalMemory` frozen dataclass with three fields:
  - `logit_bias: torch.Tensor` — shape `(num_actions,)`, dtype `float32`, clamped to `|x| ≤ LOGIT_BIAS_CLAMP` (= 2.0)
  - `lineage_depth: int` — ≥ 0, 0 for F0, incremented at each `inherit_from` call
  - `source_genome_id: str` — F0 elite provenance anchor, inherited unchanged
- `__post_init__` validates shape/dtype/depth and clamps the bias via `.detach().clone()` + `object.__setattr__` so the caller's input tensor is never mutated
- `apply_to_logits(logits)` returns `logits + self.logit_bias` (broadcast over leading dims, no in-place mutation)
- `inherit_from(parents, decay_factor)` classmethod with top-1 elite semantics, validates `decay_factor ∈ [0, 1]` and non-empty parents
- Module-level `save(substrate, path)` / `load(path)` helpers for `.tei.pt` round-trip
- `extract_from_brain(...)` shipped as `NotImplementedError` placeholder — functional implementation requires env coupling and lands with the F0 Substrate Extraction Pipeline in a follow-up commit

**Tests**: `packages/quantum-nematode/tests/.../agent/test_transgenerational_memory.py` (~290 LoC) — 20 cases covering:
- 7 construction tests (clamp + shape/dtype/depth rejections + frozen + no-input-mutation + LOGIT_BIAS_CLAMP constant)
- 7 `inherit_from` tests (geometric F0→F3 decay + depth increment + source preservation + empty-parents + decay range + multi-parent picks `parents[0]`)
- 2 `apply_to_logits` tests (additive non-mutating + broadcast over batch/seq)
- 3 serialisation tests (round-trip + parent-dir creation + load-missing-file)
- 1 placeholder test (`extract_from_brain` raises NotImplementedError)

**Modified**: `agent/__init__.py` — `TransgenerationalMemory`, `LOGIT_BIAS_CLAMP`, `extract_from_brain`, `save_transgenerational_memory`, `load_transgenerational_memory` added to exports + `__all__`. `save` / `load` are exposed at the package level under longer names to avoid clashing with stdlib `save` / `load` conventions; inside the module they remain `save` / `load` for consistency with `torch.save` / `torch.load`.

**Tracker**: `openspec/changes/add-transgenerational-memory/tasks.md` — sub-tasks 2.1-2.7 ticked (with 2.4 noted as deferred functional implementation).

## Self-review pre-PR

Caught and fixed before push:
- `TransgenerationalMemory` was not exported from `agent/__init__.py` (registration parity with `TransgenerationalInheritance` in `evolution/__init__.py`)
- `typing.Sequence` (legacy) instead of `collections.abc.Sequence` (project convention)
- 6 ruff failures that the original commit silently shipped because pre-commit's git hook is not installed in the repo — caught when re-running `uv run pre-commit run -a` after the registration changes (added new memory rule `feedback_run_precommit_before_each_commit.md` to prevent recurrence)

## Test plan

- [x] `uv run pytest packages/.../test_transgenerational_memory.py -v` — 20/20 pass
- [x] `uv run pre-commit run -a` — all 10 hooks pass (mdformat, markdownlint, ruff check + format, pyright, tests, etc.)
- [x] Pre-commit home-path audit clean
- [x] Milestone/Phase reference scrub clean (per `feedback_no_milestone_refs_in_code` memory rule)
- [x] Self-review pass before opening PR

## Spec coverage

| Spec scenario | Test |
|---|---|
| Substrate construction clamps bias values | `test_construction_clamps_bias_values` ✅ |
| Substrate shape is validated | `test_construction_rejects_non_1d_logit_bias` + `test_construction_rejects_non_float32_logit_bias` ✅ |
| Single-parent decay produces geometric retention | `test_inherit_from_single_parent_geometric_retention` ✅ |
| Decay factor out of range is rejected | `test_inherit_from_decay_factor_below_zero_raises` + `_above_one_raises` ✅ |
| Empty parents list raises clearly | `test_inherit_from_empty_parents_raises` ✅ |
| Logits are augmented additively without mutation | `test_apply_to_logits_additive_without_mutation` ✅ |
| Apply preserves shape and dtype across batch dimensions | `test_apply_to_logits_broadcasts_over_batch_and_seq` ✅ |
| Round-trip preserves all fields | `test_save_load_round_trip_preserves_all_fields` ✅ |
| Loading a missing file raises FileNotFoundError | `test_load_missing_file_raises_filenotfounderror` ✅ |
| Extraction is deterministic for a given seed | ⏸️ deferred (needs env coupling — F0 pipeline commit) |
| Extraction is computed AFTER fitness evaluation | ⏸️ deferred (same) |

## Out of scope (subsequent commits in the OpenSpec change)

- LSTMPPO `tei_prior` attribute + dual-call-site application in `run_brain` and `learn`
- F0 Substrate Extraction Pipeline in `EvolutionLoop` (per-genome F0 weight capture → elite identify → load elite into fresh brain → telemetry pass → save `.tei.pt` → GC F0 `.pt` files)
- Per-generation `lawn_schedule` consumer + worker tuple extension + `tei_prior_source` kwarg forwarding into `fitness.evaluate`
- `TransgenerationalConfig` Pydantic block + `LawnScheduleEntry` + inheritance/pairing validator + CLI `--fitness` guard
- Config YAML + campaign shell + per-gen choice-index evaluator + paired-arm aggregator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced transgenerational memory substrates enabling inherited per-action logit biases across evolutionary generations
  * Substrates support geometric decay inheritance and full save/load persistence
  * Integrated into the public API for direct access

* **Tests**
  * Added comprehensive test coverage for substrate construction, inheritance, persistence, and API behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SyntheticBrains/nematode/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->