### PR TITLE
chore(cleanup): strip planning-doc refs from production code + tests

### DIFF
--- a/packages/quantum-nematode/quantumnematode/agent/agent.py
+++ b/packages/quantum-nematode/quantumnematode/agent/agent.py
@@ -211,19 +211,19 @@ class RewardConfig(BaseModel):
     )
     # Predator-evasion reward shape. Three modes:
     #
-    # - ``"default"`` (legacy): distance-scaled evasion term
+    # - ``"default"``: distance-scaled evasion term
     #   ``penalty_predator_proximity * (curr_dist - prev_dist)`` rewards
     #   moving AWAY / penalises moving CLOSER, PLUS the contact penalty
-    #   + flat-fallback path. Byte-equivalent to M3 / M4 / M5 / M6.
-    # - ``"gradient_only"`` (M6.10 audit-B remediation v1): drops the
-    #   distance-scaled term AND the flat fallback; only the contact
-    #   penalty fires when the agent enters dist <= 1 of a predator.
-    #   Removes the "circle right" tangential-motion attractor's
-    #   *incentive*. Smoke pass 2 found this trades one attractor for
-    #   another: agents now learn "never approach anything" because the
-    #   only predator signal is the terminal contact penalty.
-    # - ``"gradient_proximity"`` (M6.10 audit-B remediation v2): adds
-    #   a smooth per-step penalty proportional to
+    #   + flat-fallback path.
+    # - ``"gradient_only"``: drops the distance-scaled term AND the
+    #   flat fallback; only the contact penalty fires when the agent
+    #   enters dist <= 1 of a predator. Removes the "circle right"
+    #   tangential-motion attractor's *incentive* but trades one
+    #   attractor for another — agents now learn "never approach
+    #   anything" because the only predator signal is the terminal
+    #   contact penalty.
+    # - ``"gradient_proximity"``: adds a smooth per-step penalty
+    #   proportional to
     #   ``env.get_predator_concentration(agent_pos)`` (exponential-decay
     #   sum from all predators, tanh-normalised to [0, 1]). Agent gets
     #   continuous "closer = worse" signal BEFORE adjacency. Removes
@@ -920,7 +920,7 @@ class QuantumNematodeAgent:
                 if self.env.aerotaxis.enabled
                 else 12.5
             ),
-            # Temporal sensing (Phase 3)
+            # Temporal sensing
             food_concentration=temporal.get("food_concentration"),
             predator_concentration=temporal.get("predator_concentration"),
             food_dconcentration_dt=temporal.get("food_dconcentration_dt"),

--- a/packages/quantum-nematode/quantumnematode/agent/reward_calculator.py
+++ b/packages/quantum-nematode/quantumnematode/agent/reward_calculator.py
@@ -103,20 +103,20 @@ class RewardCalculator:
 
         # Predator evasion reward. Three modes, gated by ``reward_mode``:
         #
-        # - ``"default"`` (legacy): distance-scaled evasion term
+        # - ``"default"``: distance-scaled evasion term
         #   ``penalty_predator_proximity * (curr_dist - prev_dist)`` rewards
         #   moving away / penalises moving closer, plus the contact penalty
         #   at ``dist <= 1`` and a flat-fallback penalty when no prev step
-        #   exists. Byte-equivalent to M3 / M4 / M5 / M6.
-        # - ``"gradient_only"`` (M6.10 v1): drops the distance-scaled term
-        #   AND the flat fallback; only the contact penalty at ``dist <= 1``
+        #   exists.
+        # - ``"gradient_only"``: drops the distance-scaled term AND the
+        #   flat fallback; only the contact penalty at ``dist <= 1``
         #   fires. Removes the "circle right" tangential-motion attractor
-        #   but trades for a "never-approach" attractor (smoke pass 2).
-        # - ``"gradient_proximity"`` (M6.10 v2): smooth per-step penalty
-        #   proportional to the env's predator concentration field at the
-        #   agent's position. Agent gets continuous "closer = worse"
-        #   signal BEFORE contact; preserves the contact penalty. The
-        #   gradient penalty fires anywhere the agent is in any predator's
+        #   but empirically trades for a "never-approach" attractor.
+        # - ``"gradient_proximity"``: smooth per-step penalty proportional
+        #   to the env's predator concentration field at the agent's
+        #   position. Agent gets continuous "closer = worse" signal
+        #   BEFORE contact; preserves the contact penalty. The gradient
+        #   penalty fires anywhere the agent is in any predator's
         #   exp-decay field, so the "do nothing" agent still accumulates
         #   penalty if it sits near a predator.
 

--- a/packages/quantum-nematode/quantumnematode/agent/transgenerational_memory.py
+++ b/packages/quantum-nematode/quantumnematode/agent/transgenerational_memory.py
@@ -7,17 +7,16 @@ F0 elite through F1/F2/F3 generations.
 Two substrate forms, selected via the optional ``bias_network``
 field:
 
-- **Constant logit-bias** (legacy default; M6 fallback). When
-  ``bias_network is None`` the substrate's effective bias is the
-  per-action constant ``logit_bias`` tensor of shape
-  ``(num_actions,)``.
+- **Constant logit-bias**. When ``bias_network is None`` the
+  substrate's effective bias is the per-action constant
+  ``logit_bias`` tensor of shape ``(num_actions,)``.
 - **Sensory-conditional bias-network**. When ``bias_network`` is set
   to a ``torch.nn.Sequential``, the effective bias is computed per
   step as ``bias_network(sensory_input)`` where ``sensory_input`` is
   a 1-D tensor of features named in ``input_features``. This lets
   the substrate express *context-conditional* biases (avoid when
-  near a pathogen gradient, forage otherwise) which the M6 constant
-  form structurally could not.
+  near a pathogen gradient, forage otherwise) which the constant
+  form structurally cannot.
 
 Both forms clamp the effective bias at ``|x| ≤ LOGIT_BIAS_CLAMP``
 (Boltzmann ratio cap ≈ 7.4x). The dataclass is ``frozen=True`` so
@@ -30,12 +29,8 @@ frozen-dataclass post-init mutation).
 The ``inherit_from`` cascade supports three decay shapes
 (geometric / linear / sigmoid) configured at the strategy layer.
 The cascade scales every weight tensor in the bias-network (or the
-constant logit_bias tensor, when in legacy form) by the decay
+constant logit_bias tensor, when in that form) by the decay
 schedule's per-generation factor.
-
-See the OpenSpec change
-``openspec/changes/add-transgenerational-memory-redesign/`` for the
-full audit-driven design rationale.
 """
 
 from __future__ import annotations
@@ -58,13 +53,13 @@ if TYPE_CHECKING:
 # ``bias_network(sensory_input)``). Caps the Boltzmann ratio at
 # ``e^6 ≈ 403x`` so a strong bias can dominate fresh-init policy
 # noise at F1+ (K=0). Kaletsky F2 ≈ 0.55 choice index corresponds
-# to a ~3x action-probability tilt; the previous cap of 2.0
-# (e^2 ≈ 7.4x) saturated FORWARD/STAY at pilot 1 + pilot 2, blunting
-# substrate signal at F1+ even when the bias_network produced
-# stronger raw outputs (-5 to -6 range). The cap was raised to 6.0
-# after the M6.9+ pilot-2 critique flagged saturation as the
-# mechanical bottleneck. This still prevents pathological
-# deterministic policies (a 403x tilt is high but not infinity).
+# to a ~3x action-probability tilt; a tighter cap saturates
+# FORWARD/STAY and blunts substrate signal at F1+ even when the
+# bias_network produces stronger raw outputs. The cap was raised
+# from 2.0 (e^2 ≈ 7.4x) to 6.0 after empirical evidence of
+# saturation as the mechanical bottleneck. 6.0 still prevents
+# pathological deterministic policies (a 403x tilt is high but
+# not infinity).
 LOGIT_BIAS_CLAMP: float = 6.0
 
 DecayShape = Literal["geometric", "linear", "sigmoid"]
@@ -114,19 +109,19 @@ def build_sensory_input(params: object, input_features: Sequence[str]) -> torch.
 class TransgenerationalMemory:
     """Inheritable behavioural-bias substrate carried across generations.
 
-    Stores either a per-action constant logit bias (legacy M6 form) or
-    a sensory-conditional parametric bias-network (M6.9+ default).
-    The substrate is extracted from an F0 elite policy via
-    :func:`extract_from_brain` and multiplicatively decayed across
-    F1/F2/F3 generations via :meth:`inherit_from`.
+    Stores either a per-action constant logit bias or a sensory-
+    conditional parametric bias-network. The substrate is extracted
+    from an F0 elite policy via :func:`extract_from_brain` and
+    multiplicatively decayed across F1/F2/F3 generations via
+    :meth:`inherit_from`.
 
     Parameters
     ----------
     logit_bias : torch.Tensor
         1-D tensor of shape ``(num_actions,)`` and dtype ``float32``.
-        Used as the effective bias when ``bias_network is None`` (M6
-        legacy path); used only as a placeholder / fallback dtype anchor
-        when ``bias_network`` is set. Each element SHALL satisfy
+        Used as the effective bias when ``bias_network is None``;
+        used only as a placeholder / fallback dtype anchor when
+        ``bias_network`` is set. Each element SHALL satisfy
         ``|x| ≤ LOGIT_BIAS_CLAMP`` after construction; values are
         clamped automatically in ``__post_init__`` and the input
         tensor is NOT mutated in place.
@@ -140,12 +135,12 @@ class TransgenerationalMemory:
         Optional sensory-conditional parametric bias-network. When
         set, :meth:`apply_to_logits` returns
         ``logits + clamp(bias_network(sensory_input))``; when ``None``,
-        falls back to the constant ``logits + logit_bias`` path
-        (M6 byte-equivalent). The caller-passed module is
-        ``copy.deepcopy``'d in ``__post_init__`` so caller-side
-        mutations cannot bleed across generations (mirrors the
-        ``logit_bias.detach().clone()`` clamp-clone pattern). Default
-        ``None`` preserves M6 behaviour.
+        falls back to the constant ``logits + logit_bias`` path.
+        The caller-passed module is ``copy.deepcopy``'d in
+        ``__post_init__`` so caller-side mutations cannot bleed across
+        generations (mirrors the ``logit_bias.detach().clone()``
+        clamp-clone pattern). Default ``None`` selects the constant
+        logit-bias form.
     input_features : tuple[str, ...]
         Names of the sensory features the ``bias_network`` consumes,
         in the order it expects them. Each entry is either a raw
@@ -255,14 +250,14 @@ class TransgenerationalMemory:
 
         Two paths:
 
-        - When ``bias_network is None`` (legacy M6 form): returns
+        - When ``bias_network is None`` (constant form): returns
           ``logits + self.logit_bias``. The ``sensory_input`` argument
           is ignored — supplied for signature compatibility with the
-          M6.9+ form. Broadcasts over leading batch / sequence
-          dimensions.
-        - When ``bias_network`` is set (M6.9+ form): returns
-          ``logits + clamp(bias_network(sensory_input))`` where the
-          clamp is element-wise to ``[-LOGIT_BIAS_CLAMP, +LOGIT_BIAS_CLAMP]``.
+          sensory-conditional form. Broadcasts over leading batch /
+          sequence dimensions.
+        - When ``bias_network`` is set (sensory-conditional form):
+          returns ``logits + clamp(bias_network(sensory_input))`` where
+          the clamp is element-wise to ``[-LOGIT_BIAS_CLAMP, +LOGIT_BIAS_CLAMP]``.
           ``sensory_input`` SHALL be a 1-D tensor matching the
           bias-network's expected input width (typically
           ``len(self.input_features)``). The returned tensor is a
@@ -294,7 +289,7 @@ class TransgenerationalMemory:
             condition).
         """
         if self.bias_network is None:
-            # Legacy M6 path: `+` is non-in-place on tensors.
+            # Constant-form path: `+` is non-in-place on tensors.
             return logits + self.logit_bias
         if sensory_input is None:
             msg = (
@@ -326,9 +321,9 @@ class TransgenerationalMemory:
         The cascade scales every weight tensor in the substrate by a
         per-generation factor determined by ``decay_shape``:
 
-        - ``geometric`` (M6 default, byte-equivalent): factor =
-          ``decay_factor`` every generation. Cumulative effect at
-          child depth ``d``: ``decay_factor ** d``.
+        - ``geometric`` (default): factor = ``decay_factor`` every
+          generation. Cumulative effect at child depth ``d``:
+          ``decay_factor ** d``.
         - ``linear``: factor at child depth ``d`` is
           ``max(0, 1 - d * (1 - decay_factor))``. The cumulative
           factor reaches zero at ``d = 1 / (1 - decay_factor)``;
@@ -338,8 +333,8 @@ class TransgenerationalMemory:
           **explicitly independent of `decay_factor`**. Slow-then-fast
           schedule with ``cum(0)≈0.881``, ``cum(1)=0.500``,
           ``cum(2)≈0.119``, ``cum(3)≈0.018``. Reserved as a
-          sensitivity-analysis alternative for pilot pivots; calibration
-          by ``decay_factor`` only applies to ``geometric`` and ``linear``.
+          sensitivity-analysis alternative; calibration by
+          ``decay_factor`` only applies to ``geometric`` and ``linear``.
 
         For non-geometric shapes, the per-generation factor depends on
         the *cumulative* depth of the child (``parent.lineage_depth + 1``),
@@ -360,7 +355,7 @@ class TransgenerationalMemory:
             ``ValueError``. Anchors all three decay shapes.
         decay_shape : Literal["geometric", "linear", "sigmoid"]
             Selects the per-generation factor formula. Default
-            ``"geometric"`` preserves M6 byte-equivalence.
+            ``"geometric"``.
 
         Returns
         -------
@@ -407,8 +402,8 @@ class TransgenerationalMemory:
         # the ``bias_network`` so the parent's module is never mutated
         # — we don't need to deep-copy here. Then scale the child's
         # (already-cloned) bias_network in-place so we only pay one
-        # deep-copy per generation step (the M6.9+ commit-1 review
-        # flagged the prior double-deep-copy as a latency leak).
+        # deep-copy per generation step (the prior double-deep-copy
+        # was a latency leak).
         child = cls(
             logit_bias=scaled_logit_bias,
             lineage_depth=child_depth,
@@ -512,8 +507,8 @@ def _describe_bias_network(net: nn.Sequential) -> dict:
     Records architecture metadata (dims + activation) alongside the
     state_dict so :func:`_build_bias_network_from_spec` can rebuild
     the module on load. The architecture introspection assumes the
-    canonical M6.9+ shapes (linear-only or linear-act-linear); a
-    future capacity bump would extend this descriptor.
+    canonical shapes (linear-only or linear-act-linear); a future
+    capacity bump would extend this descriptor.
     """
     linears = [m for m in net if isinstance(m, nn.Linear)]
     activations = [m for m in net if not isinstance(m, nn.Linear)]
@@ -656,19 +651,19 @@ def extract_from_brain(  # noqa: PLR0913 - the bias-network fit knobs are delibe
 
     Two paths, selected by ``bias_network_spec``:
 
-    - **Constant logit-bias** (M6 legacy, ``bias_network_spec is None``):
+    - **Constant logit-bias** (``bias_network_spec is None``):
       probes the trained F0 brain over ``probe_params``, accumulates
       empirical sampled-action counts, and returns a substrate whose
       ``logit_bias`` is the log-deviation from uniform.
-    - **Sensory-conditional bias-network** (M6.9+, ``bias_network_spec``
+    - **Sensory-conditional bias-network** (``bias_network_spec``
       provided): probes the brain ``samples_per_probe`` times per
       ``probe_params`` entry under the configured seed, fits the
       bias-network MLP against ``(sensory_input -> logit_offset_from_uniform)``
       with Adam over ``fit_epochs`` epochs (or closed-form
       least-squares when the spec's ``hidden_dim == 0``), and returns
       a substrate carrying the fitted MLP. The ``logit_bias``
-      tensor in the M6.9+ path is the per-probe-averaged offset
-      (an unused legacy artefact preserved for round-trip + diagnostics).
+      tensor in the sensory-conditional path is the per-probe-averaged
+      offset (an unused artefact preserved for round-trip + diagnostics).
 
     The deterministic-on-seed contract is satisfied because (a) the
     brain's RNG is reseeded via ``prepare_episode()`` (zeroes the
@@ -680,13 +675,13 @@ def extract_from_brain(  # noqa: PLR0913 - the bias-network fit knobs are delibe
     Parameters
     ----------
     brain : object
-        Trained brain (see existing M6 docstring for the duck-type
-        contract — ``prepare_episode``, ``run_brain``,
-        ``action_set``, ``num_actions``, optional ``rng``).
+        Trained brain. Duck-type contract: ``prepare_episode``,
+        ``run_brain``, ``action_set``, ``num_actions``, optional
+        ``rng``.
     probe_params : Sequence[object]
         Deterministic sequence of ``BrainParams`` instances. Caller
         (the F0 substrate-extraction pipeline) constructs these from
-        the env-derived probe ring (M6.11).
+        the env-derived probe ring.
     rng_seed : int
         Seed for deterministic action sampling + MLP fit. Same seed
         always produces the same substrate.
@@ -697,8 +692,8 @@ def extract_from_brain(  # noqa: PLR0913 - the bias-network fit knobs are delibe
         When set, must contain ``input_dim`` (= ``len(input_features)``),
         ``hidden_dim``, ``output_dim`` (= ``brain.num_actions``), and
         ``activation`` (Literal["tanh", "relu", "gelu"]). Triggers the
-        M6.9+ sensory-conditional path. When ``None``, the M6 legacy
-        path runs.
+        sensory-conditional path. When ``None``, the constant
+        logit-bias path runs.
     input_features : Sequence[str]
         Names of the ``BrainParams`` features (incl. ``_sin`` / ``_cos``
         suffixes) consumed by the bias-network. Required when
@@ -709,9 +704,10 @@ def extract_from_brain(  # noqa: PLR0913 - the bias-network fit knobs are delibe
     fit_lr : float
         Adam learning rate for the MLP fit.
     samples_per_probe : int
-        Per-probe action samples for the empirical distribution. M6
-        used 1 implicitly; M6.9+ defaults to 10 to reduce variance in
-        the MLP fit target.
+        Per-probe action samples for the empirical distribution.
+        Under the constant logit-bias path this is implicitly 1; the
+        sensory-conditional path defaults to 10 to reduce variance
+        in the MLP fit target.
 
     Returns
     -------
@@ -740,9 +736,10 @@ def extract_from_brain(  # noqa: PLR0913 - the bias-network fit knobs are delibe
     num_actions = brain.num_actions  # type: ignore[attr-defined]
     eps = 1e-8
 
-    # Probe the brain. M6 legacy path: one sample per probe → action_counts.
-    # M6.9+ path: samples_per_probe samples per probe → per-probe empirical
-    # distribution recorded alongside the probe params for the MLP fit.
+    # Probe the brain. Constant-form path: one sample per probe →
+    # action_counts. Sensory-conditional path: samples_per_probe
+    # samples per probe → per-probe empirical distribution recorded
+    # alongside the probe params for the MLP fit.
     #
     # Hidden-state reset between probes. The LSTM/GRU recurrent state
     # updates on every ``run_brain`` call, so the policy at probe N
@@ -777,8 +774,8 @@ def extract_from_brain(  # noqa: PLR0913 - the bias-network fit knobs are delibe
     logit_offsets = torch.log(probs + eps) - uniform_log
 
     if bias_network_spec is None:
-        # M6 legacy path: average across probes; the substrate carries
-        # the per-action constant tensor; bias_network=None.
+        # Constant-form path: average across probes; the substrate
+        # carries the per-action constant tensor; bias_network=None.
         mean_logit_bias = logit_offsets.mean(dim=0)
         return TransgenerationalMemory(
             logit_bias=mean_logit_bias,
@@ -788,7 +785,7 @@ def extract_from_brain(  # noqa: PLR0913 - the bias-network fit knobs are delibe
             input_features=(),
         )
 
-    # M6.9+ path: build the MLP, fit it against
+    # Sensory-conditional path: build the MLP, fit it against
     # (sensory_input -> logit_offset_from_uniform).
     # Seed BEFORE constructing the network so its initial parameter
     # init is deterministic on ``rng_seed`` (Linear's default init uses

--- a/packages/quantum-nematode/quantumnematode/brain/arch/_brain.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/_brain.py
@@ -214,7 +214,7 @@ class BrainParams(BaseModel):
         description="Maximum HP the agent can have.",
     )
 
-    # --- Temporal sensing (Phase 3) ---
+    # --- Temporal sensing ---
     food_concentration: float | None = Field(
         default=None,
         description="Scalar food signal at agent's position (tanh-normalized, no direction).",

--- a/packages/quantum-nematode/quantumnematode/brain/arch/lstmppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/lstmppo.py
@@ -179,8 +179,8 @@ class LSTMPPORolloutBuffer:
         self.h_states: list[torch.Tensor] = []
         self.c_states: list[torch.Tensor | None] = []
         # Per-step TEI bias tensor. Captures the bias value applied to
-        # actor logits at sampling time (M6.9+ sensory-conditional path
-        # OR legacy constant tensor) so the PPO update can replay the
+        # actor logits at sampling time (sensory-conditional path OR
+        # constant tensor) so the PPO update can replay the
         # exact same bias and the PPO ratio stays mathematically valid.
         # ``None`` entries indicate no bias was applied (legacy non-TEI
         # path). Mirrors the spec scenario "store the per-step bias
@@ -530,20 +530,18 @@ class LSTMPPOBrain(ClassicalBrain):
         # training forward pass (``learn``) so the PPO ratio
         # ``exp(new_log_probs - old_log_probs)`` stays well-defined:
         #
-        # - **Legacy 1-D Tensor** (M6 form): ``(num_actions,)`` float32
+        # - **Constant 1-D Tensor form**: ``(num_actions,)`` float32
         #   tensor added directly to logits. Same shape every step.
-        # - **TransgenerationalMemory substrate** (M6.9+ form): the
-        #   substrate's ``apply_to_logits(logits, sensory_input)`` is
-        #   called per step. When the substrate has a sensory-
-        #   conditional ``bias_network``, the bias VARIES per step
-        #   with the brain's sensory input; the per-step bias result
-        #   is captured into the rollout buffer at sampling time and
-        #   replayed at training time so the PPO ratio is exact even
-        #   under the sensory-conditional bias.
+        # - **TransgenerationalMemory substrate form**: the substrate's
+        #   ``apply_to_logits(logits, sensory_input)`` is called per
+        #   step. When the substrate has a sensory-conditional
+        #   ``bias_network``, the bias VARIES per step with the brain's
+        #   sensory input; the per-step bias result is captured into
+        #   the rollout buffer at sampling time and replayed at
+        #   training time so the PPO ratio is exact even under the
+        #   sensory-conditional bias.
         #
-        # See the OpenSpec change at
-        # ``openspec/changes/add-transgenerational-memory-redesign/``
-        # for the rationale. The attribute is set externally by
+        # The attribute is set externally by
         # ``LearnedPerformanceFitness.evaluate`` post-decode, before
         # ``_build_agent``; never mutated by the runner or the step loop.
         self.tei_prior: torch.Tensor | TransgenerationalMemory | None = None
@@ -776,8 +774,8 @@ class LSTMPPOBrain(ClassicalBrain):
             self._tei_prior_rollout_snapshot_value = _snapshot_tei_prior(self.tei_prior)
 
         # Actor: h_t → logits → (optional TEI bias) → action.
-        # Compute the per-step bias tensor (M6.9+ substrate path OR M6
-        # legacy tensor path) and capture it into ``_pending_bias`` so
+        # Compute the per-step bias tensor (substrate path OR
+        # constant tensor path) and capture it into ``_pending_bias`` so
         # ``learn()`` can store it in the rollout buffer. The training
         # forward pass replays the saved bias rather than recomputing —
         # this lets sensory-conditional bias-networks vary per step
@@ -946,9 +944,9 @@ class LSTMPPOBrain(ClassicalBrain):
 
                     # Actor — replay the per-step bias captured at
                     # sampling time. The bias was already computed by
-                    # ``run_brain`` (M6 legacy tensor path OR M6.9+
-                    # substrate path, dispatched by ``_compute_tei_bias``)
-                    # and stored per step in the rollout buffer. Replaying
+                    # ``run_brain`` (constant tensor path OR substrate
+                    # path, dispatched by ``_compute_tei_bias``) and
+                    # stored per step in the rollout buffer. Replaying
                     # the saved bias (rather than recomputing here) is
                     # mathematically exact even for sensory-conditional
                     # bias-networks that vary per step. ``.to(logits.device)``

--- a/packages/quantum-nematode/quantumnematode/brain/modules.py
+++ b/packages/quantum-nematode/quantumnematode/brain/modules.py
@@ -83,7 +83,7 @@ class ModuleName(StrEnum):
     # Aerotaxis module
     AEROTAXIS = "aerotaxis"
 
-    # Temporal sensing modules (Phase 3)
+    # Temporal sensing modules
     FOOD_CHEMOTAXIS_TEMPORAL = "food_chemotaxis_temporal"
     NOCICEPTION_TEMPORAL = "nociception_temporal"
     THERMOTAXIS_TEMPORAL = "thermotaxis_temporal"
@@ -357,7 +357,7 @@ def _thermotaxis_core(params: BrainParams) -> CoreFeatures:
 
 
 # =============================================================================
-# Temporal Sensing Core Feature Extractors (Phase 3)
+# Temporal Sensing Core Feature Extractors
 # =============================================================================
 
 
@@ -724,7 +724,7 @@ SENSORY_MODULES: dict[ModuleName, SensoryModule] = {
 }
 
 
-# Temporal sensing modules (Phase 3)
+# Temporal sensing modules
 SENSORY_MODULES[ModuleName.FOOD_CHEMOTAXIS_TEMPORAL] = SensoryModule(
     name=ModuleName.FOOD_CHEMOTAXIS_TEMPORAL,
     extract=_food_chemotaxis_temporal_core,

--- a/packages/quantum-nematode/quantumnematode/env/env.py
+++ b/packages/quantum-nematode/quantumnematode/env/env.py
@@ -144,16 +144,16 @@ class ForagingParams:
         food. None = disabled (no satiety gate).
     min_food_predator_distance : int
         Minimum Euclidean distance from any predator at which food may
-        spawn. Default 0 (byte-equivalent legacy behaviour — food may
-        spawn anywhere predators are not). Set to ``predator.damage_radius
-        + N`` to guarantee a foraging-without-dying corridor: at
-        ``damage_radius + 1`` food is just outside the damage zone; at
-        ``damage_radius + 2`` there's one cell of margin. The M6.9+ PR-A
-        audit-B remediation v3 (smoke pass 3 finding) sets this so the
-        env genuinely admits a foraging-while-avoiding policy — without
-        it, the "approach food" and "avoid predator" objectives are in
-        unresolvable conflict on a small grid and PPO collapses to one
-        extreme or the other regardless of reward shape.
+        spawn. Default 0 preserves the original behaviour where food
+        may spawn anywhere predators are not. Set to
+        ``predator.damage_radius + N`` to guarantee a foraging-without-
+        dying corridor: at ``damage_radius + 1`` food is just outside
+        the damage zone; at ``damage_radius + 2`` there's one cell of
+        margin. Setting this makes the env genuinely admit a
+        foraging-while-avoiding policy — without it, the "approach
+        food" and "avoid predator" objectives are in unresolvable
+        conflict on a small grid and PPO collapses to one extreme or
+        the other regardless of reward shape.
     """
 
     foods_on_grid: int = 10
@@ -1358,16 +1358,16 @@ class DynamicForagingEnvironment(BaseEnvironment):
         # Initialize food sources using Poisson disk sampling.
         #
         # Init-order policy:
-        # - ``min_food_predator_distance > 0`` (M6.9+ env-geometry fix):
-        #   predators MUST be placed before foods so the food validator
-        #   can read ``self.predators`` and enforce the distance
-        #   constraint during initial food sampling.
-        # - ``min_food_predator_distance == 0`` (default — M3 / M4 / M5 /
-        #   M6 legacy): foods are placed BEFORE predators so the RNG
-        #   draw sequence matches pre-M6.9+ behaviour exactly (both
-        #   ``_initialize_foods`` and ``_initialize_predators`` consume
-        #   from ``self.rng``; reversing them would shift seed-replay
-        #   outputs for every legacy config).
+        # - ``min_food_predator_distance > 0``: predators MUST be placed
+        #   before foods so the food validator can read ``self.predators``
+        #   and enforce the distance constraint during initial food
+        #   sampling.
+        # - ``min_food_predator_distance == 0`` (default): foods are
+        #   placed BEFORE predators so the RNG draw sequence is
+        #   stable across runs (both ``_initialize_foods`` and
+        #   ``_initialize_predators`` consume from ``self.rng``;
+        #   reversing them would shift seed-replay outputs for every
+        #   existing config).
         self.foods: list[tuple[int, int]] = []
         self.predators: list[Predator] = []
         if self.foraging.min_food_predator_distance > 0 and self.predator.enabled:
@@ -1561,11 +1561,10 @@ class DynamicForagingEnvironment(BaseEnvironment):
                 return False
 
         # Check Euclidean distance from all predators. ``min_food_predator_distance``
-        # = 0 (default) preserves byte-equivalence with the legacy
-        # food-placement behaviour (food may spawn anywhere predators are
-        # not). When > 0, food cannot spawn within that distance of any
-        # predator — the M6.9+ env-geometry-fix that admits a
-        # forage-without-dying policy by guaranteeing safe corridors
+        # = 0 (default) preserves the original food-placement behaviour
+        # (food may spawn anywhere predators are not). When > 0, food
+        # cannot spawn within that distance of any predator, admitting
+        # a forage-without-dying policy by guaranteeing safe corridors
         # between food sources.
         #
         # ``getattr(self, "predators", None)`` guards against the

--- a/packages/quantum-nematode/quantumnematode/evolution/coevolution.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/coevolution.py
@@ -159,7 +159,7 @@ _DEFAULT_PREY_HELD_OUT_BUNDLE_DIR = (
 # automatically nukes the diagnostic (every prey scores 0.0 regardless
 # of training quality; substrate ceiling, not overfitting).
 #
-# These values were calibrated by running the M3-trained held-out prey
+# These values were calibrated by running the trained held-out prey
 # bundle through frozen-weight `EpisodicSuccessRate` across a grid of
 # heuristic predator radii:
 #   - count=2, speed=0.5, grid=20 -> mean fitness 0.531 across 24 cells
@@ -2717,7 +2717,7 @@ class CoevolutionLoop:
         for the probe in that case produces uniformly-zero fitness
         independent of training quality, which is uninformative. The
         calibrated probe env preserves the probe's discriminative range
-        (M3 baseline prey score ~0.5 mean across this env's spec grid;
+        (baseline prey score ~0.5 mean across this env's spec grid;
         a co-evolved prey scoring near zero indicates real overfitting,
         not substrate ceiling).
 

--- a/packages/quantum-nematode/quantumnematode/evolution/fitness.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/fitness.py
@@ -494,9 +494,9 @@ class LearnedPerformanceFitness:
                     "delete it and re-run F0 extraction."
                 )
                 raise RuntimeError(msg) from exc
-            # Resolve the decay_shape from the live config when available;
-            # M6 callers (no transgenerational config block) fall through
-            # to the cascade's geometric default for byte-equivalence.
+            # Resolve the decay_shape from the live config when
+            # available; callers without a transgenerational config
+            # block fall through to the cascade's geometric default.
             from quantumnematode.agent.transgenerational_memory import DecayShape
 
             decay_shape: DecayShape = "geometric"
@@ -513,14 +513,14 @@ class LearnedPerformanceFitness:
                 )
             if hasattr(brain, "tei_prior"):
                 # Pass the substrate object directly. The LSTMPPO
-                # ``tei_prior`` attribute accepts either a legacy 1-D
-                # Tensor (M6 byte-equivalence path) or a
-                # ``TransgenerationalMemory`` (M6.9+ sensory-conditional
-                # path). When the substrate carries a bias_network, the
-                # brain dispatches via ``substrate.apply_to_logits`` per
-                # step with a sensory_input built from BrainParams; when
-                # bias_network is None, the brain's legacy path uses the
-                # substrate's constant logit_bias.
+                # ``tei_prior`` attribute accepts either a 1-D Tensor
+                # (constant-bias path) or a ``TransgenerationalMemory``
+                # (sensory-conditional path). When the substrate
+                # carries a bias_network, the brain dispatches via
+                # ``substrate.apply_to_logits`` per step with a
+                # sensory_input built from BrainParams; when
+                # bias_network is None, the brain's constant-bias
+                # path uses the substrate's logit_bias.
                 brain.tei_prior = substrate  # type: ignore[attr-defined]
             else:
                 logger.warning(
@@ -651,17 +651,16 @@ class LearnedPerformanceFitness:
         success_rate = successes / eval_count
         death_rate = deaths / eval_count
         survival_rate = 1.0 - death_rate
-        # Composite (M3/M6 byte-equivalent default): success-weighted
-        # by survival, with ``fitness_survival_weight`` controlling
-        # how harshly deaths penalise foraging score.
+        # Composite (default): success-weighted by survival, with
+        # ``fitness_survival_weight`` controlling how harshly deaths
+        # penalise foraging score.
         composite = success_rate * (1.0 - evolution_config.fitness_survival_weight * death_rate)
-        # Dispatch on ``fitness_metric``. The composite is the
-        # M3/M6/M5 legacy default — preserves byte-equivalence for
-        # configs that don't set the field. ``"survival_rate"`` is
-        # the M6.9+ PR-A spec primary metric (the decision-gate
-        # tripwires T1 + T3 + cross-arm primary verdict are
-        # specified against it). ``"success_rate"`` is a pure
-        # foraging measure for ablation studies.
+        # Dispatch on ``fitness_metric``. The composite is the default
+        # for configs that don't set the field. ``"survival_rate"`` is
+        # the primary metric for pathogen-avoidance campaigns where
+        # the decision-gate tripwires T1 + T3 + cross-arm primary
+        # verdict are specified against it. ``"success_rate"`` is a
+        # pure foraging measure for ablation studies.
         if evolution_config.fitness_metric == "survival_rate":
             fitness = survival_rate
         elif evolution_config.fitness_metric == "success_rate":
@@ -669,7 +668,7 @@ class LearnedPerformanceFitness:
         else:  # composite (default)
             fitness = composite
         # Optional per-genome telemetry side-channel. The decision-gate
-        # machinery (T1 envelope check, T3 M6-floor-to-beat, post-hoc
+        # machinery (T1 envelope check, T3 floor-to-beat, post-hoc
         # aggregator) needs survival_rate + success_rate alongside the
         # scalar fitness; the per_gen_elites.jsonl writer in the loop
         # only records the scalar. ``diagnostics_path`` lets the loop

--- a/packages/quantum-nematode/quantumnematode/evolution/inheritance.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/inheritance.py
@@ -44,9 +44,7 @@ in without touching the loop:
   ``isinstance`` checks.  ``"none"`` skips both lineage-tracking and
   weight-IO; ``"weights"`` enables both; ``"trait"`` enables
   lineage-tracking only; ``"transgenerational"`` enables lineage-tracking
-  + the substrate-flow code path (substrate extraction and worker
-  forwarding are follow-up additions tracked in
-  ``openspec/changes/add-transgenerational-memory/``).
+  + the substrate-flow code path.
 
 Future-work strategies (tournament selection, roulette sampling,
 soft-elite top-k) are NOT implemented here — they each become a new
@@ -165,10 +163,8 @@ class InheritanceStrategy(Protocol):
           Every F1+ child warm-starts from the F0 elite's ``.pt``
           (Lamarckian pattern) AND has ``brain.tei_prior`` set from
           the F0-extracted substrate (transgenerational pattern). The
-          retraining phase then runs with both signals active. Added
-          per ``openspec/changes/archive/2026-05-21-add-tei-prior-on-m3/`` as the
-          wet-lab-aligned reframe: TEI as a *prior on trained
-          weights*, not a standalone policy.
+          retraining phase then runs with both signals active. Frames
+          TEI as a *prior on trained weights*, not a standalone policy.
 
         The loop's ``_inheritance_active()`` helper SHALL evaluate
         ``kind() in {"weights", "weights+transgenerational"}`` (gates

--- a/packages/quantum-nematode/quantumnematode/evolution/lamarckian_transgenerational_inheritance.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/lamarckian_transgenerational_inheritance.py
@@ -31,10 +31,9 @@ on this value so both ``_inheritance_active()`` (weight-IO) and
 composed mode, threading both ``warm_start_path_override`` and
 ``tei_prior_source`` into every F1+ child's ``fitness.evaluate`` call.
 
-See the OpenSpec change ``openspec/changes/archive/2026-05-21-add-tei-prior-on-m3/``
-for the full design rationale + biological framing (TEI as a *prior on
-trained weights*, aligning with the wet-lab Kaletsky/mammalian
-mechanism — not a transmitted policy).
+Biological framing: TEI as a *prior on trained weights*, aligning
+with the wet-lab Kaletsky/mammalian mechanism — not a transmitted
+policy.
 """
 
 from __future__ import annotations

--- a/packages/quantum-nematode/quantumnematode/evolution/loop.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/loop.py
@@ -139,7 +139,7 @@ def _evaluate_in_worker(args: tuple) -> float:
           appends one per-genome row recording ``success_rate``,
           ``survival_rate``, deaths, successes, composite, and the
           scalar fitness it returned. Used by the decision-gate
-          machinery (T1 envelope check, T3 M6-floor-to-beat, post-hoc
+          machinery (T1 envelope check, T3 floor-to-beat, post-hoc
           aggregator). ``EpisodicSuccessRate`` does not accept this
           kwarg; the worker checks the signature dynamically before
           forwarding (so co-evolution dispatch on either fitness
@@ -209,7 +209,7 @@ def _evaluate_in_worker(args: tuple) -> float:
 
 
 # ---------------------------------------------------------------------------
-# F0 probe ring helpers (M6.11 — env-derived probe geometry)
+# F0 probe ring helpers — env-derived probe geometry
 # ---------------------------------------------------------------------------
 
 
@@ -257,7 +257,7 @@ def _manhattan_ring_offsets(radius: int) -> list[tuple[int, int]]:
     east → north → west → south. For ``radius == 0`` returns a single
     ``(0, 0)`` offset.
 
-    Used by the M6.11 probe-ring builder to enumerate integer cells at
+    Used by the probe-ring builder to enumerate integer cells at
     a fixed Manhattan distance from a stationary predator. Manhattan
     geometry matches the env's gradient-strength falloff
     (``1 / (1 + manhattan)``); a Euclidean ring would produce probes
@@ -815,19 +815,19 @@ class EvolutionLoop:
             return
         load_weights(brain, elite_pt_path)
 
-        # Build the probe params sequence. M6.11 path: when the
+        # Build the probe params sequence. Env-derived path: when the
         # transgenerational config has a ``probe_ring`` sub-block AND
         # the env has stationary predators, ``_build_f0_probe_params``
         # generates env-derived ring positions. Otherwise falls back
-        # to the M6 legacy synthetic-probe path.
+        # to the synthetic-probe path.
         probe_env = self._build_probe_env_if_configured()
         probe_params = self._build_f0_probe_params(brain=brain, env=probe_env)
 
         # Resolve the substrate form from the YAML-configured
         # ``transgenerational`` block. When ``bias_network`` is set
         # the F0 extraction follows the sensory-conditional path
-        # (MLP-fit substrate); when None it falls back to the M6
-        # legacy constant ``logit_bias`` path (byte-equivalent).
+        # (MLP-fit substrate); when None it falls back to the
+        # constant ``logit_bias`` path.
         # ``extraction_seed`` is also threaded from config so the
         # per-seed MLP init RNG is distinct across calibration
         # seeds — without this the substrate-diversity tripwire
@@ -912,20 +912,19 @@ class EvolutionLoop:
         """Construct a transient env for F0 probe-ring sampling, or return None.
 
         Returns ``None`` when no ``probe_ring`` sub-block is configured
-        (legacy M6 synthetic-probe path stays active). Otherwise
-        returns a freshly-constructed env from
-        ``self.sim_config.environment`` whose stationary predators the
-        probe-ring builder reads. The env is throwaway — used only
-        for predator-coordinate enumeration; no episode is run on it.
+        (the synthetic-probe path stays active). Otherwise returns a
+        freshly-constructed env from ``self.sim_config.environment``
+        whose stationary predators the probe-ring builder reads. The
+        env is throwaway — used only for predator-coordinate
+        enumeration; no episode is run on it.
 
         Probe env seed: hardcoded ``seed=0``, deliberately
-        independent of the campaign seed (which sweeps 42-45 across
-        the M6.9+ full campaign). Rationale: the substrate-diversity
-        tripwire T2 measures pairwise CoV across the 4 calibration
-        seeds' extracted bias-network ``state_dict()`` tensors. If
-        the probe env's predator positions varied with campaign
-        seed, T2 would conflate "different brain policy" (the M6
-        attractor signature we want to detect) with "different
+        independent of the campaign seed. Rationale: the substrate-
+        diversity tripwire T2 measures pairwise CoV across the
+        calibration seeds' extracted bias-network ``state_dict()``
+        tensors. If the probe env's predator positions varied with
+        campaign seed, T2 would conflate "different brain policy"
+        (the attractor signature we want to detect) with "different
         probe geometry" (noise from the seeded env layout). Pinning
         the probe-env seed makes substrate diversity attributable
         to the brain-policy difference alone.
@@ -939,8 +938,8 @@ class EvolutionLoop:
             # Defensive: should never happen under a transgenerational
             # run (the YAML schema requires an env block when predators
             # are configured) but guard explicitly so a misconfigured
-            # config fails over to the legacy synthetic-probe path
-            # rather than crashing.
+            # config fails over to the synthetic-probe path rather
+            # than crashing.
             return None
         from quantumnematode.env.theme import Theme
         from quantumnematode.utils.config_loader import create_env_from_config
@@ -964,22 +963,21 @@ class EvolutionLoop:
 
         Two paths:
 
-        - **Env-derived probe ring** (M6.11): when ``env`` is supplied
-          AND the transgenerational config has a ``probe_ring``
-          sub-block AND the env has at least one stationary predator,
-          generate ``probe_ring.count`` ring positions around each
-          stationary predator at distance ``predator.damage_radius +
+        - **Env-derived probe ring**: when ``env`` is supplied AND the
+          transgenerational config has a ``probe_ring`` sub-block AND
+          the env has at least one stationary predator, generate
+          ``probe_ring.count`` ring positions around each stationary
+          predator at distance ``predator.damage_radius +
           probe_ring.radius_offset``, evenly angular-distributed. For
           each ring position compute ``(predator_gradient_strength,
           predator_gradient_direction)`` via :func:`_compute_probe_gradient`
           relative to its source predator. Optionally emit two ring
           iterations (food-gradient set vs zeroed) when
           ``probe_ring.include_food_gradient_variants`` is True.
-        - **Legacy M6 synthetic** (fallback): three hardcoded probes
-          with varying food-gradient strengths and zero predator
-          gradient. Used when no ``probe_ring`` is configured (M6
-          byte-equivalent) or when no stationary predators exist on
-          the env.
+        - **Synthetic** (fallback): three hardcoded probes with
+          varying food-gradient strengths and zero predator gradient.
+          Used when no ``probe_ring`` is configured or when no
+          stationary predators exist on the env.
 
         When ``brain`` is provided, the probe params are filled with
         zero-valued ``stam_state`` sized/typed to match the brain's
@@ -1039,9 +1037,9 @@ class EvolutionLoop:
                 else:
                     stam_state = tuple(0.0 for _ in range(effective_stam_dim))
 
-        # M6.11 env-derived probe ring path. Falls back to the legacy
-        # synthetic-probe path when ``env`` is None, no ``probe_ring``
-        # config is set, or the env has no stationary predators.
+        # Env-derived probe ring path. Falls back to the synthetic-
+        # probe path when ``env`` is None, no ``probe_ring`` config is
+        # set, or the env has no stationary predators.
         probe_ring_cfg: ProbeRingConfig | None = None
         cfg = self.sim_config.evolution
         if cfg is not None and cfg.transgenerational is not None:
@@ -1051,10 +1049,10 @@ class EvolutionLoop:
             if ring_probes:
                 return ring_probes
 
-        # Legacy M6 fallback: three synthetic probes with varying
-        # food-gradient strengths and zero predator gradient. Active
-        # when ``env`` is None, ``probe_ring`` is unset, or the env
-        # has no stationary predators (e.g. non-pathogen-lawn envs).
+        # Synthetic fallback: three probes with varying food-gradient
+        # strengths and zero predator gradient. Active when ``env``
+        # is None, ``probe_ring`` is unset, or the env has no
+        # stationary predators (e.g. non-pathogen-lawn envs).
         return [
             BrainParams(
                 food_gradient_strength=0.3,
@@ -1088,7 +1086,7 @@ class EvolutionLoop:
         probe_ring_cfg: ProbeRingConfig,
         stam_state: tuple[float, ...] | None,
     ) -> list[BrainParams]:
-        """Build the M6.11 env-derived probe ring for F0 substrate extraction.
+        """Build the env-derived probe ring for F0 substrate extraction.
 
         Returns an empty list when the env has no stationary predators
         (caller falls back to the legacy synthetic-probe path). Each
@@ -1590,7 +1588,7 @@ class EvolutionLoop:
                     # (success_rate + survival_rate + deaths + ...).
                     # Single per-session file; workers append. Used by
                     # the decision-gate machinery (T1 envelope check,
-                    # T3 M6-floor-to-beat, post-hoc aggregator). Only
+                    # T3 floor-to-beat, post-hoc aggregator). Only
                     # ``LearnedPerformanceFitness`` accepts it; other
                     # fitness functions (incl. test stubs) get ``None``
                     # so the worker's signature-dispatch elides the

--- a/packages/quantum-nematode/quantumnematode/evolution/transgenerational_inheritance.py
+++ b/packages/quantum-nematode/quantumnematode/evolution/transgenerational_inheritance.py
@@ -28,12 +28,10 @@ methods:
   collide on disk if a future config ever mixes them.
 - ``kind()`` — returns the new literal ``"transgenerational"``.
 
-This module ships ONLY the strategy skeleton + Protocol conformance.
-The F0 substrate extraction pipeline (writing the ``.tei.pt`` after
-F0 weight capture + telemetry pass) and the worker tuple extension +
-``fitness.evaluate`` kwarg forwarding are follow-up additions tracked
-in the OpenSpec change under ``openspec/changes/add-transgenerational-
-memory/``.
+This module ships the strategy skeleton + Protocol conformance. The
+F0 substrate extraction pipeline (writing the ``.tei.pt`` after F0
+weight capture + telemetry pass), the worker tuple extension, and
+``fitness.evaluate`` kwarg forwarding live in adjacent modules.
 """
 
 from __future__ import annotations

--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -282,13 +282,13 @@ class ForagingConfig(BaseModel):
     no_respawn: bool = False
     satiety_food_threshold: float | None = Field(default=None, gt=0.0, le=1.0)
     # Minimum Euclidean distance from any predator at which food may
-    # spawn. Default 0 preserves byte-equivalence with the legacy
-    # food-placement behaviour. The M6.9+ env-geometry fix
-    # (smoke pass 3 finding) sets this to ``damage_radius + N`` so the
-    # env genuinely admits a forage-without-dying policy — without the
-    # constraint, food can spawn inside a predator's damage zone and
-    # PPO cannot find a middle-ground policy between "approach food"
-    # and "avoid predator" regardless of reward shape.
+    # spawn. Default 0 preserves the original food-placement
+    # behaviour where food can spawn anywhere a predator is not
+    # at the same cell. Setting this to ``damage_radius + N`` makes
+    # the env genuinely admit a forage-without-dying policy —
+    # without the constraint, food can spawn inside a predator's
+    # damage zone and PPO cannot find a middle-ground policy between
+    # "approach food" and "avoid predator" regardless of reward shape.
     min_food_predator_distance: int = Field(default=0, ge=0)
 
     def to_params(self) -> ForagingParams:
@@ -1071,11 +1071,11 @@ def _check_one_input_feature(name: str, known: set[str]) -> str | None:
 
 
 class BiasNetworkConfig(BaseModel):
-    """M6.9+ sensory-conditional bias-network architecture sub-block.
+    """Sensory-conditional bias-network architecture sub-block.
 
     Optional sub-block on :class:`TransgenerationalConfig`. When
-    absent, the substrate falls back to the M6 legacy constant
-    ``logit_bias`` path (byte-equivalent).
+    absent, the substrate falls back to the constant ``logit_bias``
+    path.
 
     Attributes
     ----------
@@ -1146,7 +1146,7 @@ class BiasNetworkConfig(BaseModel):
 
 
 class SafeProbesConfig(BaseModel):
-    """M6.9+ safe-position probe configuration sub-block.
+    """Safe-position probe configuration sub-block.
 
     Optional sub-block on :class:`ProbeRingConfig`. When present, the
     F0 probe builder emits additional probes at positions FAR from
@@ -1154,9 +1154,9 @@ class SafeProbesConfig(BaseModel):
     food-gradient strengths. Without these, all probes sit at the
     danger-zone boundary and the substrate's bias-network MLP fits
     an unconditional "near-predator → avoid" bias rather than a
-    *conditional* response (the pilot-1 failure mode at K=0:
-    substrate captured "always-LEFT" with no food/predator
-    discrimination).
+    *conditional* response — the failure mode is the substrate
+    capturing "always-LEFT" at K=0 with no food/predator
+    discrimination.
 
     Attributes
     ----------
@@ -1179,7 +1179,7 @@ class SafeProbesConfig(BaseModel):
 
 
 class ProbeRingConfig(BaseModel):
-    """M6.9+ env-derived F0 probe-ring configuration sub-block.
+    """Env-derived F0 probe-ring configuration sub-block.
 
     Optional sub-block on :class:`TransgenerationalConfig`. When
     absent the loader defaults to the canonical 8-position ring at
@@ -1239,12 +1239,11 @@ class TransgenerationalConfig(BaseModel):
         F2=0.36 / F3=0.216 cascade under ``decay_shape: geometric``.
     decay_shape : Literal["geometric", "linear", "sigmoid"]
         Selects the per-generation decay schedule. Default
-        ``"geometric"`` preserves M6 byte-equivalence (multiplicative
-        decay each generation). ``"linear"`` reaches zero at
+        ``"geometric"`` applies multiplicative decay each generation.
+        ``"linear"`` reaches zero at
         ``lineage_depth = 1 / (1 - decay_factor)``; ``"sigmoid"``
         uses a slow-then-fast schedule. Biology is silent on shape;
-        non-default values are sensitivity-analysis options for
-        M6.9+ pilot pivots.
+        non-default values are sensitivity-analysis options.
     extraction_seed : int
         Seed for the F0 telemetry pass (``extract_from_brain``). A
         fixed sentinel default (``424242``) keeps F0 extractions
@@ -1254,13 +1253,13 @@ class TransgenerationalConfig(BaseModel):
         overrides. Each entry MUST reference a generation in
         ``[0, evolution.generations)`` exactly once.
     bias_network : BiasNetworkConfig | None
-        Optional M6.9+ sensory-conditional bias-network architecture.
-        When ``None`` (default), the substrate uses the M6 legacy
-        constant ``logit_bias`` path (byte-equivalent).
+        Optional sensory-conditional bias-network architecture.
+        When ``None`` (default), the substrate uses the constant
+        ``logit_bias`` path.
     probe_ring : ProbeRingConfig | None
-        Optional M6.9+ env-derived F0 probe-ring configuration.
-        When ``None`` (default), the F0 substrate-extraction
-        pipeline uses the M6 legacy synthetic-probe path.
+        Optional env-derived F0 probe-ring configuration. When
+        ``None`` (default), the F0 substrate-extraction pipeline
+        uses the synthetic-probe path.
     """
 
     enabled: bool
@@ -1447,19 +1446,17 @@ class EvolutionConfig(BaseModel):
     # Fitness primary-metric selector: which scalar the optimizer + the
     # decision-gate machinery consume per eval. Three options:
     #
-    # - ``"composite"`` (default): preserves the M3/M6 legacy fitness
+    # - ``"composite"`` (default): legacy fitness shape
     #   ``success_rate * (1 - fitness_survival_weight * death_rate)``.
-    #   Byte-equivalent to the prior single-metric path. Backwards-
-    #   compatible: existing M3/M4/M5/M6 configs continue to work
+    #   Backwards-compatible — existing configs continue to work
     #   without YAML changes.
     # - ``"success_rate"``: raw ``successes / L_eval`` (fraction of
     #   eval episodes terminating in ``COMPLETED_ALL_FOOD``). Pure
     #   foraging-success measure; ignores ``fitness_survival_weight``.
     # - ``"survival_rate"``: ``1 - deaths / L_eval`` (fraction of
-    #   eval episodes NOT terminating in ``HEALTH_DEPLETED``). The
-    #   spec primary metric for the M6.9+ PR-A pathogen-avoidance
-    #   campaign — the decision gate (T1 envelope, T3 M6 floor,
-    #   cross-arm primary verdict) is specified against this metric.
+    #   eval episodes NOT terminating in ``HEALTH_DEPLETED``). Used
+    #   as the primary metric for pathogen-avoidance campaigns
+    #   where the decision gate is specified against this metric.
     #   Ignores ``fitness_survival_weight``.
     #
     # Only ``LearnedPerformanceFitness`` honours the dispatch;
@@ -1683,10 +1680,9 @@ class EvolutionConfig(BaseModel):
                 "transgenerational: block to the evolution: config with "
                 "at minimum: enabled: true, decay_factor (float, default "
                 "0.6), and lawn_schedule. The bias_network and probe_ring "
-                "sub-blocks are optional (default None). See the OpenSpec "
-                "change 'add-tei-prior-on-m3' for the composed-mode "
-                "schema, or the archived change "
-                "'add-transgenerational-memory-redesign' for pure-TEI."
+                "sub-blocks are optional (default None). The composed-mode "
+                "schema layers the substrate on top of trained weights; "
+                "the pure-substrate mode runs without weight inheritance."
             )
             raise ValueError(msg)
         return self

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_evaluation_metrics.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_evaluation_metrics.py
@@ -1,4 +1,4 @@
-"""Tests for Phase 4 evaluation metrics (territorial_index, alarm_response_rate)."""
+"""Tests for evaluation metrics (territorial_index, alarm_response_rate)."""
 
 from __future__ import annotations
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_reward_calculator.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_reward_calculator.py
@@ -308,12 +308,12 @@ class TestPredatorEvasionReward:
 
 
 class TestGradientOnlyRewardMode:
-    """Validate the ``reward_mode='gradient_only'`` M6.10 audit-B remediation.
+    """Validate the ``reward_mode='gradient_only'`` path.
 
     Under ``gradient_only`` the distance-scaled evasion term and the
     first-step flat-fallback are both dropped; only the contact
     penalty at ``dist <= 1`` fires. ``default`` mode preserves the
-    M3 / M4 / M5 / M6 byte-equivalent behaviour.
+    distance-scaled evasion behaviour.
     """
 
     def _make_predator_env(self, agent_pos, predator_positions, *, in_danger=True):
@@ -492,7 +492,7 @@ class TestGradientOnlyRewardMode:
             RewardConfig(reward_mode="sparse")  # type: ignore[arg-type]
 
     # -----------------------------------------------------------------
-    # gradient_proximity mode (M6.10 audit-B remediation v2)
+    # gradient_proximity mode
     # -----------------------------------------------------------------
 
     def _make_predator_env_with_concentration(

--- a/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_transgenerational_memory.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/agent/test_transgenerational_memory.py
@@ -51,8 +51,7 @@ def test_construction_clamps_bias_values() -> None:
 
     Matches the spec scenario "Substrate construction clamps bias values".
     The exact constant is read from the module so this test follows the
-    constant if it's tuned (e.g., the M6.9+ pilot-2 critique raised it from
-    2.0 to 6.0 to prevent fresh-init F1+ saturation).
+    constant if it's tuned.
     """
     clamp_val = LOGIT_BIAS_CLAMP
     # Pick values that straddle the clamp on both sides + an in-range value.
@@ -115,13 +114,13 @@ def test_dataclass_is_frozen() -> None:
 
 
 def test_clamp_constant_in_acceptable_range() -> None:
-    """``LOGIT_BIAS_CLAMP`` SHALL be a positive float in the expected M6.9+ range.
+    """``LOGIT_BIAS_CLAMP`` SHALL be a positive float in the expected range.
 
-    The exact value is tuned per pilot evidence (originally 2.0 = e^2 ~ 7.4x
-    Boltzmann cap; raised to 6.0 = e^6 ~ 403x after M6.9+ pilot-2 critique
-    flagged saturation as the mechanical bottleneck for fresh-init F1+
-    substrate application). The constant is positive AND finite AND
-    bounded above so a strong bias cannot collapse exploration entirely.
+    The exact value is tuned per pilot evidence (originally 2.0
+    = e^2 ≈ 7.4x Boltzmann cap; raised to 6.0 = e^6 ≈ 403x after
+    saturation evidence at fresh-init F1+). The constant is positive
+    AND finite AND bounded above so a strong bias cannot collapse
+    exploration entirely.
     """
     assert LOGIT_BIAS_CLAMP > 0.0
     assert LOGIT_BIAS_CLAMP <= 10.0  # sane upper bound; e^10 ~22k is plenty
@@ -424,7 +423,7 @@ def test_extract_from_brain_rejects_empty_probe_params() -> None:
 
 
 # ---------------------------------------------------------------------------
-# M6.9+ sensory-conditional bias-network tests
+# Sensory-conditional bias-network tests
 # ---------------------------------------------------------------------------
 
 
@@ -513,7 +512,7 @@ def test_bias_network_apply_to_logits_uses_clamp() -> None:
 
 
 def test_bias_network_apply_to_logits_returns_legacy_when_none() -> None:
-    """``bias_network is None`` SHALL fall back to ``logits + logit_bias`` (M6 legacy)."""
+    """``bias_network is None`` SHALL fall back to ``logits + logit_bias``."""
     sub = _f0(torch.tensor([0.5, 0.0, 0.0, 0.0], dtype=torch.float32))
     logits = torch.zeros(4, dtype=torch.float32)
     # sensory_input passed but ignored.
@@ -578,8 +577,8 @@ def test_build_sensory_input_handles_none_with_zero() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_inherit_from_geometric_decay_byte_equivalent_to_m6() -> None:
-    """``decay_shape='geometric'`` (default) SHALL produce M6 byte-equivalent cascade."""
+def test_inherit_from_geometric_decay_matches_multiplicative_cascade() -> None:
+    """``decay_shape='geometric'`` (default) SHALL produce a multiplicative cascade."""
     f0 = _f0(torch.tensor([1.0, -1.0, 0.5, 0.0], dtype=torch.float32))
     f1 = TransgenerationalMemory.inherit_from([f0], decay_factor=0.6)
     f2 = TransgenerationalMemory.inherit_from([f1], decay_factor=0.6)
@@ -718,7 +717,7 @@ def test_save_load_round_trip_preserves_bias_network(tmp_path: Path) -> None:
 
 
 def test_save_load_round_trip_legacy_path_remains_byte_equivalent(tmp_path: Path) -> None:
-    """When ``bias_network is None`` round-trip SHALL preserve M6 byte-equivalent payload shape."""
+    """When ``bias_network is None`` round-trip SHALL preserve the constant-form payload shape."""
     sub = _f0(torch.tensor([0.5, -0.3, 0.0, 0.1], dtype=torch.float32))
     path = tmp_path / "f0_legacy.tei.pt"
     save(sub, path)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_lstmppo_transgenerational_prior.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_lstmppo_transgenerational_prior.py
@@ -1,7 +1,6 @@
 """Unit tests for the LSTMPPO ``tei_prior`` integration.
 
-Covers the eight scenarios from the OpenSpec change's lstm-ppo-brain
-delta:
+Covers eight scenarios:
 
 (a) Default ``tei_prior=None`` byte-equivalent to pre-TEI baseline.
 (b) ``bias=[+2, 0, 0, 0]`` elevates empirical action-0 probability
@@ -489,12 +488,12 @@ def test_learn_with_none_tei_prior_runs_without_assertion() -> None:
 
 
 # ---------------------------------------------------------------------------
-# M6.9+ substrate-form tei_prior (TransgenerationalMemory with bias_network)
+# Substrate-form tei_prior (TransgenerationalMemory with bias_network)
 # ---------------------------------------------------------------------------
 
 
 def _make_substrate_with_constant_bias(bias_tensor: torch.Tensor) -> Any:
-    """Construct a TransgenerationalMemory with the M6 legacy logit_bias path (no bias_network)."""
+    """Construct a TransgenerationalMemory with the constant logit_bias path (no bias_network)."""
     from quantumnematode.agent.transgenerational_memory import TransgenerationalMemory
 
     return TransgenerationalMemory(

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_env.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_env.py
@@ -3022,18 +3022,17 @@ class TestMultiAgentPredatorTargeting:
 class TestMinFoodPredatorDistance:
     """Test min_food_predator_distance constraint on food placement.
 
-    The M6.9+ env-geometry fix (smoke pass 3 finding) — without this
-    constraint food can spawn inside or adjacent to a predator's
-    damage zone and the PPO agent cannot find a middle-ground
-    "forage-while-avoiding" policy regardless of reward shape.
+    Without this constraint food can spawn inside or adjacent to a
+    predator's damage zone and the PPO agent cannot find a middle-
+    ground "forage-while-avoiding" policy regardless of reward shape.
     """
 
     def test_default_zero_preserves_legacy_behaviour(self):
         """``min_food_predator_distance=0`` SHALL not affect food placement.
 
-        Byte-equivalence with the pre-M6.9+ env: foods may spawn
-        anywhere predators are not at the same cell. M3 / M4 / M5 / M6
-        reproduction tests rely on this default.
+        Default behaviour: foods may spawn anywhere predators are not
+        at the same cell. Seed-replay reproduction tests rely on this
+        default.
         """
         env = DynamicForagingEnvironment(
             grid_size=20,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_f0_substrate_pipeline.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_f0_substrate_pipeline.py
@@ -310,7 +310,7 @@ def test_f0_extraction_happy_path_writes_substrate_and_gcs_pt_files(tmp_path: Pa
 
 # ---------------------------------------------------------------------------
 # B1 / B2 regression: F0 extraction forwards YAML bias_network spec
-# + extraction_seed (the M6.9+ correctness gate).
+# + extraction_seed (correctness gate).
 # ---------------------------------------------------------------------------
 
 
@@ -378,11 +378,11 @@ def test_f0_extraction_forwards_bias_network_spec_from_config(
     extractor receives ``bias_network_spec`` + ``input_features``
     matching it.
 
-    Without this wiring, the M6.9+ ``tei_on`` arm silently regresses
-    to M6 behaviour (constant ``logit_bias``, ``bias_network=None``)
-    and the original "3-of-4 bit-identical substrate" attractor
-    re-appears across calibration seeds. This test pins the call-site
-    contract using a spy on ``extract_from_brain``.
+    Without this wiring, the ``tei_on`` arm silently regresses to
+    constant-bias behaviour (``logit_bias`` only, ``bias_network=None``)
+    and the "3-of-4 bit-identical substrate" attractor re-appears
+    across calibration seeds. This test pins the call-site contract
+    using a spy on ``extract_from_brain``.
     """
     from unittest.mock import patch
 
@@ -456,14 +456,14 @@ def test_f0_extraction_forwards_bias_network_spec_from_config(
     assert captured_kwargs["rng_seed"] == 98765
 
 
-def test_f0_extraction_legacy_path_when_bias_network_absent(tmp_path: Path) -> None:
-    """B1 negative: when ``cfg.transgenerational.bias_network is None``, the legacy M6 path runs.
+def test_f0_extraction_constant_form_when_bias_network_absent(tmp_path: Path) -> None:
+    """B1 negative: ``cfg.transgenerational.bias_network is None`` → constant-form path.
 
     Forward-compatibility / backwards-compat: a transgenerational
     config without an explicit ``bias_network`` block falls back to
-    the M6 constant ``logit_bias`` extraction path. The call-site
-    MUST pass ``bias_network_spec=None`` so ``extract_from_brain``
-    dispatches the legacy branch (``input_features=()``).
+    the constant ``logit_bias`` extraction path. The call-site MUST
+    pass ``bias_network_spec=None`` so ``extract_from_brain``
+    dispatches the constant-form branch (``input_features=()``).
     """
     from unittest.mock import patch
 
@@ -544,8 +544,9 @@ def test_f0_extraction_legacy_path_when_bias_network_absent(tmp_path: Path) -> N
 def test_f0_substrate_diversity_across_seeds_with_bias_network(tmp_path: Path) -> None:
     """B1 + B2 end-to-end: four ``extraction_seed`` values produce diverse substrates.
 
-    This is the regression gate against the original M6 incident
-    (3-of-4 calibration seeds extracting bit-identical substrates).
+    This is the regression gate against the substrate-diversity
+    incident (3-of-4 calibration seeds extracting bit-identical
+    substrates).
     Once B1 forwards the YAML ``bias_network`` spec AND B2 forwards
     the YAML ``extraction_seed``, four runs with distinct seeds
     SHALL produce substrates whose pairwise CoV (per the T2
@@ -598,12 +599,13 @@ def test_f0_substrate_diversity_across_seeds_with_bias_network(tmp_path: Path) -
         assert loop._tei_f0_substrate_path is not None
         substrates.append(load_substrate(loop._tei_f0_substrate_path))
 
-    # All four substrates SHALL have a populated bias_network (M6.9+ path).
+    # All four substrates SHALL have a populated bias_network
+    # (sensory-conditional path).
     assert all(s.bias_network is not None for s in substrates)
 
     # Pairwise CoV is non-zero on the flattened state_dict — substrate
-    # is NOT bit-identical across seeds. The original M6 attractor
-    # signature would surface as CoV == 0 for at least one pair here.
+    # is NOT bit-identical across seeds. The attractor signature
+    # would surface as CoV == 0 for at least one pair here.
     def _flat(s: TransgenerationalMemory) -> torch.Tensor:
         assert s.bias_network is not None
         return torch.cat(

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_lamarckian_transgenerational_inheritance.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_lamarckian_transgenerational_inheritance.py
@@ -202,8 +202,8 @@ def test_checkpoint_path_matches_lamarckian(tmp_path: Path) -> None:
     The composed strategy owns the WEIGHTS checkpoint path; the substrate
     ``.tei.pt`` path is owned by the F0 substrate-extraction pipeline as a
     separate concern. This test pins that the strategy's
-    ``checkpoint_path`` returns the ``.pt`` (M3) path, NOT the ``.tei.pt``
-    (TEI substrate) path.
+    ``checkpoint_path`` returns the ``.pt`` (weights) path, NOT the
+    ``.tei.pt`` (TEI substrate) path.
     """
     composed = LamarckianTransgenerationalInheritance()
     lamarckian = LamarckianInheritance()

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_learned_fitness.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_learned_fitness.py
@@ -537,7 +537,7 @@ def test_tei_prior_source_corrupted_substrate_raises_operator_friendly(
 
 
 # ---------------------------------------------------------------------------
-# fitness_metric dispatch (M6.9+ spec primary-metric selector)
+# fitness_metric dispatch — primary-metric selector
 # ---------------------------------------------------------------------------
 
 
@@ -591,7 +591,7 @@ def _patch_runs(success_count: int, death_count: int, eval_count: int):
 
 
 def test_fitness_metric_default_composite_is_byte_equivalent() -> None:
-    """``fitness_metric`` defaults to ``composite``; preserves M3/M6 byte-equivalence."""
+    """``fitness_metric`` defaults to ``composite``; preserves the legacy composite formula."""
     sim_config = _make_sim_config_with_schema(learn_eps=2, eval_eps=4)
     sim_config = _patched_evolution_config(
         sim_config,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_probe_ring.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_probe_ring.py
@@ -1,13 +1,13 @@
-"""Unit tests for the M6.11 env-derived F0 probe-ring helpers.
+"""Unit tests for the env-derived F0 probe-ring helpers.
 
-Covers the spec scenarios under "Env-Derived F0 Probe Ring" in
-``openspec/changes/add-transgenerational-memory-redesign/specs/evolution-framework/spec.md``:
+Covers:
 - probe ring uses env predator positions
 - configurable count and radius_offset
 - pure helper for gradient computation (``_compute_probe_gradient``)
-
-Plus task-3.5 angular-distribution, food-gradient-variants doubling,
-no-env-mutation invariant, and empty-predators fallback.
+- angular distribution
+- food-gradient-variants doubling
+- no-env-mutation invariant
+- empty-predators fallback
 
 The ring builder is exercised at the ``_build_f0_probe_params`` level
 via mock envs + mock predators (avoiding the full env construction
@@ -113,7 +113,7 @@ def test_sample_ring_offsets_downsamples_evenly() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Ring builder: _build_f0_probe_params under the M6.11 env-derived path
+# Ring builder: _build_f0_probe_params under the env-derived path
 # ---------------------------------------------------------------------------
 
 
@@ -219,10 +219,11 @@ def test_probe_ring_configurable_count_and_radius_offset() -> None:
 def test_probe_ring_exact_manhattan_distance_at_default_count_8() -> None:
     """At the default count=8 every probe SHALL sit at exact L1 distance == damage_radius + offset.
 
-    Regression test for the M6.11 Manhattan-ring rewrite (replaced an
-    earlier Euclidean cos/sin projection that produced variable Manhattan
-    distances 5-8 at radius=5 for the 8-position ring). The L1 ring at
-    radius=5 has 4*5=20 perimeter cells; count=8 down-samples evenly.
+    Regression test for the Manhattan-ring builder (replaces an
+    earlier Euclidean cos/sin projection that produced variable
+    Manhattan distances 5-8 at radius=5 for the 8-position ring).
+    The L1 ring at radius=5 has 4*5=20 perimeter cells; count=8
+    down-samples evenly.
     """
     loop = _make_loop_with_probe_ring(_probe_ring_config(count=8, radius_offset=1))
     env = _make_mock_env([_make_mock_predator((10, 10), damage_radius=4)])
@@ -277,8 +278,8 @@ def test_probe_ring_include_food_gradient_variants_doubles_count() -> None:
     assert len(nonzero_food) == 8
 
 
-def test_probe_ring_falls_back_to_legacy_when_no_probe_ring_config() -> None:
-    """When ``probe_ring is None`` the builder SHALL emit the M6 legacy 3-probe path."""
+def test_probe_ring_falls_back_to_synthetic_when_no_probe_ring_config() -> None:
+    """When ``probe_ring is None`` the builder SHALL emit the synthetic 3-probe path."""
     loop = _make_loop_with_probe_ring(probe_ring=None)
     env = _make_mock_env([_make_mock_predator((10, 10), damage_radius=3)])
 
@@ -326,7 +327,7 @@ def test_probe_ring_does_not_mutate_env() -> None:
 
 
 # ---------------------------------------------------------------------------
-# safe_probes path (M6.9+ pilot-2 fix — conditional bias-network response)
+# safe_probes path — conditional bias-network response
 # ---------------------------------------------------------------------------
 
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_transgenerational_smoke.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_transgenerational_smoke.py
@@ -203,7 +203,7 @@ def test_build_per_gen_sim_config_returns_base_when_disabled(tmp_path: Path) -> 
     """
     sim_config = _sim_config_with_predators()
     # The pairing validator pins ``enabled=false`` to ``inheritance=none``,
-    # so this construction matches the TEI-off control arm of the M6
+    # so this construction matches the TEI-off control arm of the
     # paired-arm ablation.
     transgenerational = _tei_config(enabled=False, generations=2)
     loop = _make_loop(

--- a/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
@@ -726,7 +726,7 @@ class TestTransgenerationalConfig:
             )
 
     def test_decay_shape_default_is_geometric(self) -> None:
-        """``decay_shape`` defaults to ``"geometric"`` (M6 byte-equivalent)."""
+        """``decay_shape`` defaults to ``"geometric"``."""
         cfg = TransgenerationalConfig(
             enabled=True,
             lawn_schedule=self._make_schedule(1),
@@ -745,7 +745,7 @@ class TestTransgenerationalConfig:
             )
 
     def test_bias_network_defaults_when_block_absent(self) -> None:
-        """When ``bias_network`` is absent the loader SHALL fall back to M6 legacy path."""
+        """When ``bias_network`` is absent the loader SHALL fall back to constant logit-bias."""
         cfg = TransgenerationalConfig(
             enabled=True,
             lawn_schedule=self._make_schedule(1),


### PR DESCRIPTION
## Summary

- Strip milestone identifiers (M3/M4/M5/M6/M6.9+/M6.10/M6.11/M4.5/M4.6), project Phase N refs, and OpenSpec change-path references from implementation code and non-campaign tests.
- Planning-doc identifiers belong in planning artefacts; implementation code should describe what it does, not the milestone that produced it.
- 25 files modified, net 20 lines smaller. No semantic changes.

## Scope

**In scope:**
- All files under \`packages/quantum-nematode/quantumnematode/\` (15 production files)
- Non-campaign tests under \`packages/quantum-nematode/tests/quantumnematode_tests/\` (10 test files)

**Deliberately kept (domain terms, not project refs):**
- LR-schedule \"Phase 1: Warmup\" / \"Phase 2: Decay\" in [lstmppo.py](packages/quantum-nematode/quantumnematode/brain/arch/lstmppo.py), [qliflstm.py](packages/quantum-nematode/quantumnematode/brain/arch/qliflstm.py), [_reservoir_lstm_base.py](packages/quantum-nematode/quantumnematode/brain/arch/_reservoir_lstm_base.py)
- \"Phase 1: covering predators\" algorithm step in [multi_agent.py](packages/quantum-nematode/quantumnematode/agent/multi_agent.py)

**Out of scope (follow-up branches will address):**
- \`scripts/campaigns/**\` — campaign scripts whose names ARE the milestone identity
- Campaign-specific aggregator tests (test_aggregate_*, test_baldwin_f1_postpilot_eval)
- Documentation files (logbooks, roadmap, OpenSpec changes) — \`tmp/\` ref cleanup will follow

## Notable renames

Two tests whose names contained milestone identifiers were renamed to describe what they actually assert:

- \`test_inherit_from_geometric_decay_byte_equivalent_to_m6\` → \`test_inherit_from_geometric_decay_matches_multiplicative_cascade\`
- \`test_f0_extraction_legacy_path_when_bias_network_absent\` → \`test_f0_extraction_constant_form_when_bias_network_absent\`

Verified neither old name is referenced elsewhere.

## Review fixes incorporated

Independent review caught two info-loss issues in the rewrites; both addressed:

1. \`LOGIT_BIAS_CLAMP\` history (2.0 → 6.0 saturation evidence) restored without milestone refs.
2. \"empirically trades for\" anchor added in [reward_calculator.py](packages/quantum-nematode/quantumnematode/agent/reward_calculator.py) where \"smoke pass 2\" was dropped.

Reviewer also recommended restoring \`openspec/changes/...\` pointers in production code as \"design discoverability\" — **rejected**: the rule explicitly names \`openspec\` as a planning-doc reference to keep out of implementation code.

## Test plan

- [x] All 476 affected tests pass (\`pytest -m \"not nightly\"\` on the 11 touched test files)
- [x] Pre-commit hooks pass (ruff check, ruff format, pyright, tests)
- [x] No remaining planning refs in in-scope files (verified by independent regex audit)
- [x] All 25 edited files parse via \`ast.parse\` — no broken docstrings or syntax breakage
- [x] Diff contains no re-introduced planning refs on \`+\` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comments and docstrings across the codebase to clarify current implementation terminology and remove outdated version references.

* **Tests**
  * Renamed test functions for improved clarity (e.g., "legacy" → "synthetic/constant form").

* **Chores**
  * Removed legacy version and phase references from documentation throughout the project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SyntheticBrains/nematode/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->