### PR TITLE
chore(tests): mark heavy evolution-loop tests as slow to speed up pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,6 @@ repos:
     hooks:
       - id: pytest
         name: tests
-        entry: uv run pytest -m "not smoke and not nightly"
+        entry: uv run pytest -m "not smoke and not nightly and not slow"
         language: system
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ Quantum Nematode simulates a simplified C. elegans navigating dynamic environmen
 
 - Install: `uv sync --extra cpu --extra torch`
 - Test (default, excludes nightly): `uv run pytest -m "not nightly"`
+- Test (pre-commit subset, fast): `uv run pytest -m "not smoke and not nightly and not slow"`
+- Test (slow integration only): `uv run pytest -m slow -v`
 - Test (smoke only): `uv run pytest -m smoke -v`
 - Test (nightly E2E only): `uv run pytest -m nightly -v`
 - Test (all, including nightly): `uv run pytest`
@@ -56,13 +58,14 @@ Quantum Nematode simulates a simplified C. elegans navigating dynamic environmen
 
 ## Testing
 
-Three tiers:
+Four tiers:
 
-1. **Unit/Integration** — Default pytest, runs on commits
-2. **Smoke** (`@pytest.mark.smoke`) — CLI end-to-end, runs on PRs
-3. **Nightly** (`@pytest.mark.nightly`) — Full training benchmarks, runs daily
+1. **Unit/Integration** — Default pytest, runs on commits via pre-commit
+2. **Slow** (`@pytest.mark.slow`) — Heavy in-process integration (real `EvolutionLoop` runs etc.), excluded from pre-commit, run before push
+3. **Smoke** (`@pytest.mark.smoke`) — CLI end-to-end, runs on PRs
+4. **Nightly** (`@pytest.mark.nightly`) — Full training benchmarks, runs daily
 
-Always run `uv run pytest -m "not nightly"` after changes. Run `uv run pre-commit run -a` before committing.
+Pre-commit runs only the fast tier (`not smoke and not nightly and not slow`). Run `uv run pytest -m "not nightly"` (includes slow + smoke) after substantive changes, especially when touching `evolution/`, and `uv run pre-commit run -a` before committing.
 
 ## Pull Requests
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_baldwin_f1_postpilot_eval.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_baldwin_f1_postpilot_eval.py
@@ -31,6 +31,8 @@ from quantumnematode.evolution.encoders import HyperparameterEncoder, build_birt
 from quantumnematode.evolution.genome import Genome
 from quantumnematode.utils.config_loader import SimulationConfig, load_simulation_config
 
+pytestmark = pytest.mark.slow
+
 PROJECT_ROOT = Path(__file__).resolve().parents[5]
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "campaigns" / "baldwin_f1_postpilot_eval.py"
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_coevolution.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_coevolution.py
@@ -52,6 +52,8 @@ from quantumnematode.utils.config_loader import (
     SimulationConfig,
 )
 
+pytestmark = pytest.mark.slow
+
 
 def _build_minimal_sim_config(  # noqa: PLR0913 — kwargs map 1:1 to CoevolutionConfig fields
     *,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_early_stop.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_early_stop.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     from quantumnematode.evolution.genome import Genome
     from quantumnematode.utils.config_loader import SimulationConfig
 
+pytestmark = pytest.mark.slow
+
 PROJECT_ROOT = Path(__file__).resolve().parents[5]
 MLPPPO_CONFIG = PROJECT_ROOT / "configs/scenarios/foraging/mlpppo_small_oracle.yml"
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_f0_substrate_pipeline.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_f0_substrate_pipeline.py
@@ -17,14 +17,11 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 from quantumnematode.evolution.encoders import MLPPPOEncoder
 from quantumnematode.evolution.fitness import EpisodicSuccessRate
-
-if TYPE_CHECKING:
-    import pytest
 from quantumnematode.evolution.inheritance import (
     BaldwinInheritance,
     LamarckianInheritance,
@@ -39,6 +36,8 @@ from quantumnematode.utils.config_loader import (
     EvolutionConfig,
     load_simulation_config,
 )
+
+pytestmark = pytest.mark.slow
 
 PROJECT_ROOT = Path(__file__).resolve().parents[5]
 MLPPPO_CONFIG = PROJECT_ROOT / "configs/scenarios/foraging/mlpppo_small_oracle.yml"

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_m613_smoke.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_m613_smoke.py
@@ -49,6 +49,8 @@ from quantumnematode.utils.config_loader import (
 if TYPE_CHECKING:
     from quantumnematode.utils.config_loader import SimulationConfig
 
+pytestmark = pytest.mark.slow
+
 PROJECT_ROOT = Path(__file__).resolve().parents[5]
 MLPPPO_CONFIG = PROJECT_ROOT / "configs/scenarios/foraging/mlpppo_small_oracle.yml"
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_smoke.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_smoke.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from quantumnematode.evolution.genome import Genome
     from quantumnematode.utils.config_loader import SimulationConfig
 
+pytestmark = pytest.mark.slow
+
 PROJECT_ROOT = Path(__file__).resolve().parents[5]
 MLPPPO_CONFIG = PROJECT_ROOT / "configs/scenarios/foraging/mlpppo_small_oracle.yml"
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_transgenerational_smoke.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/evolution/test_loop_transgenerational_smoke.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
+import pytest
 from quantumnematode.evolution.encoders import MLPPPOEncoder
 from quantumnematode.evolution.fitness import EpisodicSuccessRate
 from quantumnematode.evolution.inheritance import InheritanceStrategy, NoInheritance
@@ -34,8 +35,9 @@ from quantumnematode.utils.config_loader import (
 )
 
 if TYPE_CHECKING:
-    import pytest
     from quantumnematode.utils.config_loader import SimulationConfig
+
+pytestmark = pytest.mark.slow
 
 PROJECT_ROOT = Path(__file__).resolve().parents[5]
 MLPPPO_CONFIG = PROJECT_ROOT / "configs/scenarios/foraging/mlpppo_small_oracle.yml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,4 +166,5 @@ addopts = "-n auto"
 markers = [
     "smoke: Smoke tests that run entry-point scripts (excluded from pre-commit)",
     "nightly: Nightly regression tests against benchmarks (slow)",
+    "slow: Heavy integration tests (e.g. real EvolutionLoop runs) — excluded from pre-commit, run before push",
 ]


### PR DESCRIPTION
## Summary

- Phase 5 added ~160s of in-process `EvolutionLoop` integration tests that ran on every commit, pushing pre-commit wall-time to ~3m25s.
- Register a new `slow` pytest marker, tag the 7 evolution test files that run real loops/training, and exclude `slow` from the pre-commit pytest entry.
- The slow tier still runs in CI on PRs (via the existing `not nightly` selector), so coverage isn't lost — only the local commit feedback loop is.

## Impact

| | Before | After |
|---|---|---|
| Pre-commit total | ~205s | **47s** (~4.4× faster) |
| Fast pytest tier | 189s | **33s** (~5.7× faster) |
| Slow tier (CI / on-demand) | — | 244s (131 tests, gated) |
| Tests covered locally | 2949 | 2818 fast + 131 slow = 2949 (no loss) |

Files marked `slow` (real `EvolutionLoop` integration, all added during Phase 5):
- `evolution/test_loop_smoke.py`, `test_loop_m613_smoke.py`, `test_loop_transgenerational_smoke.py`
- `evolution/test_early_stop.py`, `test_coevolution.py`
- `evolution/test_f0_substrate_pipeline.py`, `test_baldwin_f1_postpilot_eval.py`

`evolution/test_loop_probe_ring.py` was considered and **not** marked — its tests are <50ms each; the 5s wall-time is just import overhead.

## Test plan

- [x] `uv run pre-commit run -a` passes locally (47s)
- [x] `uv run pytest -m "not smoke and not nightly and not slow"` — 2818 tests pass in 33s
- [x] `uv run pytest -m slow` — 131 tests pass in 244s
- [x] `uv run pytest -m "not nightly"` — full local non-nightly tier still passes
- [ ] CI green on PR (will be verified after this PR opens — confirms `not nightly` continues to pick up slow tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test suite into four tiers, including a new slow-running integration test category marked for selective execution.
  * Updated pre-commit hook to skip slow tests, resulting in faster local validation.

* **Documentation**
  * Updated testing guidance to reflect new four-tier test classification system and pre-commit behavior.

* **Chores**
  * Added pytest marker configuration for slow tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SyntheticBrains/nematode/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->