### PR TITLE
fix(cfc): entropy annealing for stabilization

### DIFF
--- a/packages/quantum-nematode/quantumnematode/brain/arch/cfc_ppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/cfc_ppo.py
@@ -169,6 +169,33 @@ class CfCBrainConfig(BrainConfig):
             raise ValueError(msg)
         return self
 
+    @model_validator(mode="after")
+    def _validate_entropy_schedule(self) -> CfCBrainConfig:
+        """Require ``entropy_coef_end`` and ``entropy_decay_episodes`` to be set as a pair.
+
+        Setting only one silently disabled annealing (the flat fallback), which is a
+        quiet misconfiguration. Reject the half-set case here so ``_get_entropy_coef``
+        can trust the invariant: either both are ``None`` (flat) or both are set with
+        a positive decay window (anneal).
+        """
+        end = self.entropy_coef_end
+        decay = self.entropy_decay_episodes
+        if (end is None) != (decay is None):
+            msg = (
+                "entropy_coef_end and entropy_decay_episodes must be set together: "
+                "provide both to anneal, or neither for a flat schedule "
+                f"(got entropy_coef_end={end}, entropy_decay_episodes={decay})"
+            )
+            raise ValueError(msg)
+        if end is not None and decay is not None:
+            if end < 0.0:
+                msg = f"entropy_coef_end must be >= 0.0, got {end}"
+                raise ValueError(msg)
+            if decay < 1:
+                msg = f"entropy_decay_episodes must be >= 1 when annealing, got {decay}"
+                raise ValueError(msg)
+        return self
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Rollout Buffer
@@ -696,8 +723,8 @@ class CfCPPOBrain(ClassicalBrain):
         """
         end = self.config.entropy_coef_end
         decay = self.config.entropy_decay_episodes
-        if end is None or decay is None or decay <= 0:
-            return self.config.entropy_coef
+        if end is None or decay is None:
+            return self.config.entropy_coef  # flat schedule (validated: both None together)
         frac = min(1.0, self._episode_count / decay)
         return self.config.entropy_coef + frac * (end - self.config.entropy_coef)
 

--- a/packages/quantum-nematode/quantumnematode/brain/arch/cfc_ppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/cfc_ppo.py
@@ -117,6 +117,8 @@ class CfCBrainConfig(BrainConfig):
     gae_lambda: float = 0.95
     value_loss_coef: float = 0.5
     entropy_coef: float = 0.01
+    entropy_coef_end: float | None = None  # anneal target (with entropy_decay_episodes)
+    entropy_decay_episodes: int | None = None  # episodes to anneal entropy_coef over
     rollout_buffer_size: int = 512
     num_epochs: int = 4
     max_grad_norm: float = 0.5
@@ -683,6 +685,22 @@ class CfCPPOBrain(ClassicalBrain):
             self._perform_ppo_update()
             self.buffer.reset()
 
+    def _get_entropy_coef(self) -> float:
+        """Return the current entropy coefficient (linearly annealed if configured, else flat).
+
+        With ``entropy_coef_end`` and ``entropy_decay_episodes`` set, the coefficient
+        decays linearly from ``entropy_coef`` to ``entropy_coef_end`` over the first
+        ``entropy_decay_episodes`` episodes, then holds at ``entropy_coef_end``. High
+        early entropy breaks the dead-exploration basin; lower late entropy lets the
+        converged policy peak.
+        """
+        end = self.config.entropy_coef_end
+        decay = self.config.entropy_decay_episodes
+        if end is None or decay is None or decay <= 0:
+            return self.config.entropy_coef
+        frac = min(1.0, self._episode_count / decay)
+        return self.config.entropy_coef + frac * (end - self.config.entropy_coef)
+
     def _perform_ppo_update(self) -> None:  # noqa: PLR0915
         """Perform a PPO update with chunk-based truncated BPTT."""
         if len(self.buffer) == 0:
@@ -712,7 +730,7 @@ class CfCPPOBrain(ClassicalBrain):
         )
 
         buffer_len = len(self.buffer)
-        entropy_coef = self.config.entropy_coef
+        entropy_coef = self._get_entropy_coef()
 
         total_policy_loss = 0.0
         total_value_loss = 0.0

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_cfcppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_cfcppo.py
@@ -813,3 +813,25 @@ class TestEntropySchedule:
         assert brain._get_entropy_coef() == pytest.approx(0.02)
         brain._episode_count = 1200  # past the decay window -> clamped at the floor
         assert brain._get_entropy_coef() == pytest.approx(0.02)
+
+    def test_end_without_decay_raises(self) -> None:
+        """entropy_coef_end without entropy_decay_episodes is rejected (no silent flat fallback)."""
+        with pytest.raises(ValueError, match="must be set together"):
+            _make_brain(entropy_coef_end=0.02)
+
+    def test_decay_without_end_raises(self) -> None:
+        """entropy_decay_episodes without entropy_coef_end is rejected (no silent flat fallback)."""
+        with pytest.raises(ValueError, match="must be set together"):
+            _make_brain(entropy_decay_episodes=800)
+
+    def test_non_positive_decay_raises(self) -> None:
+        """A non-positive decay window with a set floor is rejected (0 and negative)."""
+        with pytest.raises(ValueError, match="when annealing"):
+            _make_brain(entropy_coef_end=0.02, entropy_decay_episodes=0)
+        with pytest.raises(ValueError, match="when annealing"):
+            _make_brain(entropy_coef_end=0.02, entropy_decay_episodes=-1)
+
+    def test_negative_end_raises(self) -> None:
+        """A negative entropy floor is rejected."""
+        with pytest.raises(ValueError, match="entropy_coef_end must be >="):
+            _make_brain(entropy_coef_end=-0.01, entropy_decay_episodes=800)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_cfcppo.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/brain/arch/test_cfcppo.py
@@ -790,3 +790,26 @@ class TestProtocolMethods:
         # Setter rejects a wrong-length list.
         with pytest.raises(ValueError, match="action_set must have exactly"):
             brain.action_set = DEFAULT_ACTIONS[:2]
+
+
+class TestEntropySchedule:
+    """The entropy coefficient is flat by default and linearly annealed when configured."""
+
+    def test_flat_when_no_end(self) -> None:
+        """With entropy_coef_end unset, the coefficient stays flat at entropy_coef."""
+        brain = _make_brain(entropy_coef=0.05)
+        assert brain._get_entropy_coef() == pytest.approx(0.05)
+        brain._episode_count = 500
+        assert brain._get_entropy_coef() == pytest.approx(0.05)
+
+    def test_linear_anneal_then_holds(self) -> None:
+        """entropy_coef_end + entropy_decay_episodes -> linear anneal, then hold at the floor."""
+        brain = _make_brain(entropy_coef=0.08, entropy_coef_end=0.02, entropy_decay_episodes=800)
+        brain._episode_count = 0
+        assert brain._get_entropy_coef() == pytest.approx(0.08)
+        brain._episode_count = 400
+        assert brain._get_entropy_coef() == pytest.approx(0.05)
+        brain._episode_count = 800
+        assert brain._get_entropy_coef() == pytest.approx(0.02)
+        brain._episode_count = 1200  # past the decay window -> clamped at the floor
+        assert brain._get_entropy_coef() == pytest.approx(0.02)


### PR DESCRIPTION
## Summary

Stabilises the CfC / liquid brain on the hard integrated cell (food + predator + thermotaxis) by adding an optional entropy-coefficient anneal. Mirrors the LSTMPPO stabilisation precedent (#195), but with the lever that actually applies to a continuous-time recurrent core.

## Problem

On the integrated cell the CfC brain is **recurrent-init-variant**: at a flat low entropy coefficient a fraction of seeds collapse into a dead-exploration basin and never escape (bimodal outcomes — the same failure mode the GRU had pre-#195). A flat low-entropy n=8 run was bimodal with 3/8 seeds collapsed.

The #195 fix for the GRU was **orthogonal recurrent init**. That lever is **not available here**: CfC's continuous-time recurrence (AutoNCP-wired) has no square hidden-to-hidden matrix — the recurrent weights are rectangular, sparsity-masked `ff1/ff2/time_a/time_b` blocks, so there is nothing to orthogonalise. The feasible lever is exploration.

## Fix

Add an optional entropy-coefficient anneal:

- Two new config fields — `entropy_coef_end` and `entropy_decay_episodes`.
- A `_get_entropy_coef()` linear schedule consumed by the PPO update.
- **Flat and byte-equivalent to the prior behaviour when `entropy_coef_end is None`** (no change for existing configs).

A high early entropy forces the late-escaping seeds out of the dead-exploration basin before the decay; the low floor then lets the converged policy peak.

## Result

On the integrated cell, peak-anneal `0.08 -> 0.02` over 800 episodes took the brain from a bimodal **3/8-collapse** run to **0/8**, ceiling restored.

## Tests

- New `TestEntropySchedule` (flat-when-no-end + linear-anneal-then-hold) — 53 tests total.
- `pre-commit` green on both files (ruff, ruff-format, pyright, tests).

## Notes

- The canonical CfC C3 comparison config that *uses* these fields lands on the cross-architecture comparison branch (it depends on this merging first), not here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entropy coefficient annealing: training can now gradually adjust entropy regularization over a configurable episode count, transitioning from an initial value to a target end value. Includes validation for consistent and sensible schedule parameters.

* **Tests**
  * Added comprehensive tests for entropy scheduling behavior, covering flat vs. linear annealing, clamping, and invalid parameter cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->