### PR TITLE
docs: refresh README + CONTRIBUTING for current project state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ convention = "numpy"
 
 ### Brain Architectures
 
-The project supports 19 brain architectures across quantum, hybrid, classical, and biologically-inspired categories:
+The project supports 24 brain architectures across quantum, hybrid, classical, and biologically-inspired categories:
 
 **Quantum:**
 
@@ -151,39 +151,56 @@ The project supports 19 brain architectures across quantum, hybrid, classical, a
 08. **QRHQLSTMBrain** (`qrhqlstm`): QRH quantum reservoir + QLIF-LSTM temporal readout with recurrent PPO
 09. **CRHQLSTMBrain** (`crhqlstm`): CRH classical reservoir + QLIF-LSTM temporal readout (ablation companion to QRH-QLSTM)
 10. **QEFBrain** (`qef`): Quantum entangled features — configurable cross-modal entanglement topology, Z+ZZ+cos/sin features, PPO readout
+11. **EquivariantQuantumPPOBrain** (`equivariantquantum`): Z2-equivariant data-re-uploading circuit with odd/even-parity latent split and PPO; ships classical-equivariant + symmetry-prior ablation controls
 
 **Hybrid (quantum + classical):**
 
-11. **HybridQuantumBrain** (`hybridquantum`): QSNN reflex + classical cortex + classical critic — best quantum architecture
-12. **HybridClassicalBrain** (`hybridclassical`): Classical ablation control for HybridQuantum
-13. **HybridQuantumCortexBrain** (`hybridquantumcortex`): QSNN reflex + QSNN cortex + classical critic — experimental (halted)
+12. **HybridQuantumBrain** (`hybridquantum`): QSNN reflex + classical cortex + classical critic — best quantum architecture
+13. **HybridClassicalBrain** (`hybridclassical`): Classical ablation control for HybridQuantum
+14. **HybridQuantumCortexBrain** (`hybridquantumcortex`): QSNN reflex + QSNN cortex + classical critic — experimental (halted)
 
 **Classical:**
 
-14. **CRHBrain** (`crh`): Classical reservoir hybrid — ESN reservoir with configurable feature channels, PPO readout; quantum ablation control for QRH
-15. **MLPReinforceBrain** (`mlpreinforce`): MLP with policy gradients (REINFORCE)
-16. **MLPDQNBrain** (`mlpdqn`): MLP with Deep Q-Network
-17. **MLPPPOBrain** (`mlpppo`): MLP actor-critic with PPO — best classical architecture
-18. **LSTMPPOBrain** (`lstmppo`): LSTM/GRU-augmented PPO with chunk-based truncated BPTT — designed for temporal sensing tasks
+15. **CRHBrain** (`crh`): Classical reservoir hybrid — ESN reservoir with configurable feature channels, PPO readout; quantum ablation control for QRH
+16. **MLPReinforceBrain** (`mlpreinforce`): MLP with policy gradients (REINFORCE)
+17. **MLPDQNBrain** (`mlpdqn`): MLP with Deep Q-Network
+18. **MLPPPOBrain** (`mlpppo`): MLP actor-critic with PPO — best classical architecture
+19. **LSTMPPOBrain** (`lstmppo`): LSTM/GRU-augmented PPO with chunk-based truncated BPTT — designed for temporal sensing tasks
+20. **CfCPPOBrain** (`cfcppo`): CfC (Closed-form Continuous-time) liquid network with AutoNCP wiring and continuous-time recurrence, PPO-trained
+21. **FeedforwardGABrain** (`feedforwardga`): Feed-forward network with weights evolved by the GA optimizer (gradient-free); graded episodic-progress fitness for sparse-reward cells
 
 **Biologically-Inspired:**
 
-19. **SpikingReinforceBrain** (`spikingreinforce`): LIF spiking neural network with surrogate gradients
+22. **SpikingReinforceBrain** (`spikingreinforce`): LIF spiking neural network with surrogate gradients
+23. **SpikingPPOBrain** (`spikingppo`): Recurrent adaptive-LIF spiking network with configurable MLP actor head, trained via PPO
+24. **ConnectomePPOBrain** (`connectomeppo`): Connectome-constrained PPO on the real *C. elegans* connectome (Cook et al. 2019 — chemical synapses + gap junctions) with sensor→interneuron→motor projections and multi-hop recurrence
 
-Each brain architecture follows a common interface defined in `quantumnematode.brain.arch`.
+Each brain architecture self-registers via the `@register_brain` decorator and follows a common interface defined in `quantumnematode.brain.arch`. See the [Plugin Developer Guide](docs/architecture/plugin-developer-guide.md) for how to add a new one.
 
 ## 🔧 Development Workflows
 
 ### Running Tests
 
-The project has three tiers of tests:
+The project has four tiers of tests:
 
 #### Unit & Integration Tests (default)
 
-Run automatically on every commit (pre-commit hook) and PR:
+Fast in-process tests. The pre-commit hook runs only this fast tier (excluding `slow`, `smoke`, and `nightly`); run the full non-nightly set after substantive changes:
 
 ```bash
-uv run pytest
+# Fast pre-commit subset
+uv run pytest -m "not smoke and not nightly and not slow"
+
+# Everything except nightly (includes slow + smoke) — run after substantive changes
+uv run pytest -m "not nightly"
+```
+
+#### Slow Integration Tests
+
+Heavy in-process integration (e.g. real `EvolutionLoop` runs). Excluded from the pre-commit hook; run before pushing, especially when touching `evolution/`:
+
+```bash
+uv run pytest -m slow -v
 ```
 
 #### Smoke Tests
@@ -416,7 +433,8 @@ docs/experiments/
     ├── 002-evolutionary-parameter-search.md
     ├── 003-spiking-brain-optimization.md
     ├── ...
-    ├── 008-quantum-brain-evaluation.md
+    ├── 025-weight-search-architecture-ranking.md
+    ├── 026-connectome-forward-vectorisation.md
     └── supporting/              # Detailed appendix data per logbook
         ├── 003/
         └── 008/
@@ -478,44 +496,51 @@ uv run python scripts/run_evolution.py \
   --generations 50
 ```
 
+#### Related Evolution & Analysis Scripts
+
+The `scripts/` directory also includes:
+
+- `run_coevolution.py` — predator-prey co-evolution arms-race campaigns (`CoevolutionLoop`)
+- `run_plasticity_test.py` / `compare_plasticity_results.py` — sequential multi-objective ("plasticity") training and cross-architecture comparison
+- `experiment_query.py` — query and compare tracked experiments
+- `benchmark_submit.py` / `evaluate_submission.py` — submit and validate benchmark results
+- `extract_runs.py`, `export_screenshot.py`, `qef_mi_analysis.py`, `qrh_mi_analysis.py` — artifact extraction, rendering, and mutual-information analysis helpers
+- `manage_jobs.py` — check the status of IBM Quantum / Q-CTRL Qiskit Function jobs by ID
+
 ### Adding New Features
 
-#### Adding a New Brain Architecture
+Brains are added through a self-registering plug-in registry, so adding one
+no longer requires editing a central dispatch. The [Plugin Developer
+Guide](docs/architecture/plugin-developer-guide.md) walks through the full
+workflow; the essentials:
 
-1. Create a new file in `packages/quantum-nematode/quantumnematode/brain/arch/`
-2. Inherit from appropriate base class (`QuantumBrain` or `ClassicalBrain`)
-3. Implement required methods:
-   - `run_brain()`: Execute brain and return actions
-   - `learn()`: Update parameters based on rewards
-   - `update_parameters()`: Low-level parameter updates
-
-Example structure:
+1. Create a new module in `packages/quantum-nematode/quantumnematode/brain/arch/`
+2. Define a Pydantic config class inheriting from `BrainConfig`
+3. Define your brain inheriting from the appropriate base (`QuantumBrain` or `ClassicalBrain`) and decorate it with `@register_brain` so it self-registers at import time:
 
 ```python
-from quantumnematode.brain.arch import QuantumBrain
+from quantumnematode.brain.arch import ClassicalBrain
+from quantumnematode.brain.arch._registry import register_brain
+from quantumnematode.brain.arch.dtypes import BrainConfig, BrainType
 
-class MyNewBrain(QuantumBrain):
-    def run_brain(self, params, reward=None, **kwargs):
-        # Implement brain execution logic
-        pass
-    
-    def learn(self, params, reward, **kwargs):
-        # Implement learning logic
-        pass
-```
-
-4. Add configuration class:
-
-```python
-from quantumnematode.brain.arch.dtypes import BrainConfig
 
 class MyNewBrainConfig(BrainConfig):
     # Define configuration parameters
-    pass
+    ...
+
+
+@register_brain(
+    name="mynewbrain",              # must equal BrainType.MYNEWBRAIN.value
+    config_cls=MyNewBrainConfig,
+    brain_type=BrainType.MYNEWBRAIN,
+    families=("classical",),        # e.g. "classical", "quantum", "spiking"
+)
+class MyNewBrain(ClassicalBrain):
+    ...
 ```
 
-5. Update `__init__.py` files to export new classes
-6. Add tests in the appropriate test directory
+4. Add the matching `BrainType` enum member and wire the module into `brain/arch/__init__.py` and the config loader (see the guide for the exact files)
+5. Add tests in the appropriate test directory
 
 #### Adding New Quantum Modules
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,18 @@ This project simulates a simplified nematode (C. elegans) navigating dynamic for
 - ✅ **Modular Quantum Brain**: Parameterized quantum circuits with 2+ qubits for decision-making
 - ✅ **Classical ML Alternatives**: REINFORCE, PPO, DQN, LSTM/GRU PPO, and spiking neural network brain architectures
 - ✅ **Quantum Learning**: Parameter-shift rule for gradient-based optimization
+- ✅ **Evolutionary Optimization & Inheritance**: CMA-ES, genetic algorithms, and TPE hyperparameter search, plus Lamarckian weight inheritance, Baldwin-effect, and predator-prey co-evolution
+- ✅ **Connectome Substrate**: Connectome-constrained brains on the real *C. elegans* wiring diagram (302 neurons, Cook et al. 2019) with chemical synapses and gap junctions
 - ✅ **Hardware Support**: Classical simulation (AerSimulator) and real quantum hardware (IBM QPU)
 - ✅ **Comprehensive Tracking**: Per-run and session-level metrics, plots, and CSV exports
 - ✅ **Interactive Workflows**: CLI scripts with flexible configuration
 - ✅ **Multi-Agent Visualization**: Real-time Pygame rendering of multi-agent simulations with per-agent colored sprites, viewport agent switching, and pheromone concentration overlays
+- ✅ **Pluggable Architecture Interface**: Self-registering `@register_brain` plug-in registry for adding new brain architectures as comparable rows in one experimental sweep
 - 🚧 **Expandable Framework**: Modular design for research and experimentation
 
 ## 🧠 Brain Architectures
 
-Choose from 19 brain architectures spanning quantum, classical, hybrid, and biologically-inspired approaches:
+Choose from 24 brain architectures spanning quantum, classical, hybrid, and biologically-inspired approaches:
 
 **Quantum:**
 
@@ -44,6 +47,7 @@ Choose from 19 brain architectures spanning quantum, classical, hybrid, and biol
 - **QEFBrain** (qef): Quantum entangled features — parameterized quantum circuit with configurable cross-modal entanglement topology (modality-paired, ring, random), Z+ZZ+cos/sin feature extraction, and PPO-trained classical readout
 - **QRHQLSTMBrain** (qrhqlstm): QRH quantum reservoir with QLIF-LSTM temporal readout — reservoir feature extraction + recurrent PPO with truncated BPTT
 - **CRHQLSTMBrain** (crhqlstm): CRH classical reservoir with QLIF-LSTM temporal readout — classical reservoir ablation companion to QRH-QLSTM
+- **EquivariantQuantumPPOBrain** (equivariantquantum): Z2-equivariant parameterized quantum circuit with data re-uploading and odd/even-parity latent split, PPO-trained — ships with classical-equivariant and symmetry-prior ablation controls to isolate the equivariance and quantum contributions
 
 **Hybrid (Quantum + Classical):**
 
@@ -58,10 +62,14 @@ Choose from 19 brain architectures spanning quantum, classical, hybrid, and biol
 - **LSTMPPOBrain** (lstmppo): LSTM/GRU-augmented PPO with chunk-based truncated BPTT, separate actor/critic optimizers, and entropy decay — designed for temporal sensing tasks where memoryless MLP processing is insufficient. GRU variant recommended (outperforms LSTM across all evaluated environments)
 - **MLPReinforceBrain** (mlpreinforce): Classical multi-layer perceptron with policy gradients (REINFORCE)
 - **MLPDQNBrain** (mlpdqn): Classical MLP with Deep Q-Network (DQN) learning
+- **CfCPPOBrain** (cfcppo): CfC (Closed-form Continuous-time) liquid neural network with AutoNCP wiring and continuous-time recurrent dynamics, PPO-trained — an alternative recurrent substrate for temporal sensing
+- **FeedforwardGABrain** (feedforwardga): Feed-forward network whose weights are evolved by the genetic-algorithm optimizer (gradient-free), with graded episodic-progress fitness for sparse-reward cells
 
 **Biologically-Inspired:**
 
 - **SpikingReinforceBrain** (spikingreinforce): Biologically realistic spiking neural network with LIF neurons and surrogate gradient learning
+- **SpikingPPOBrain** (spikingppo): Recurrent adaptive-LIF spiking network with a configurable MLP actor head, trained via PPO
+- **ConnectomePPOBrain** (connectomeppo): Connectome-constrained PPO on the real *C. elegans* connectome (Cook et al. 2019 hermaphrodite — chemical synapses + gap junctions) with biologically-faithful sensor→interneuron→motor projections and multi-hop recurrence
 
 For full architecture comparison and benchmarks, see [quantum-architectures.md](docs/research/quantum-architectures.md) and [logbook 008](docs/experiments/logbooks/008-quantum-brain-evaluation.md).
 
@@ -371,6 +379,8 @@ See [docs/roadmap.md](docs/roadmap.md) for the comprehensive project roadmap.
 
 ### Recently Completed
 
+- **Evolution & Inheritance**: CMA-ES, genetic-algorithm, and TPE optimization plus Lamarckian weight inheritance across generations (the headline-positive Phase 5 result), with Baldwin-effect, predator-prey co-evolution arms-race, and transgenerational-memory studies
+- **Pluggable Architecture Interface**: Self-registering `@register_brain` plug-in registry admitting MLP, recurrent, spiking, reservoir, quantum, hybrid, GA-evolved, and connectome-constrained brains as comparable rows in one experimental sweep
 - **Multi-Agent Simulations**: Cooperative and competitive foraging with pheromone communication (food-marking, alarm, aggregation), social feeding (npr-1 mediated satiety modulation), food competition policies, collective behavior metrics (aggregation index, alarm evasion, food sharing), and real-time Pygame visualization with per-agent colored sprites and pheromone overlays
 - **Temporal Sensing**: Biologically-accurate sensing replacing oracle spatial gradients — scalar concentration (Mode A) and derivative (Mode B) with STAM temporal memory buffers
 - **LSTM/GRU PPO Brain**: Recurrent architecture with chunk-based truncated BPTT for temporal sensing tasks — achieves oracle-level converged performance with scalar-only sensing
@@ -380,8 +390,9 @@ See [docs/roadmap.md](docs/roadmap.md) for the comprehensive project roadmap.
 
 ### Upcoming Features
 
-- **Evolution & Breeding**: Genetic algorithms, Baldwin effect, co-evolution of predators and prey
-- **Continuous Physics & Connectome**: Continuous 2D movement, realistic locomotion, 302-neuron connectome-constrained architectures
+- **Connectome Substrate** (in progress): Closed-loop learning and evolution on the real *C. elegans* connectome (302 neurons, Cook et al. 2019) as a focal architecture, with NEAT topology search ranking the wild-type connectome against evolved alternatives on klinotaxis, thermotaxis, and predator evasion
+- **Plasticity & Cross-Species Transfer**: Biologically-plausible plasticity (STDP + neuromodulator-modulated) on the connectome, and *P. pacificus* transfer using Cook et al. 2025 connectome data
+- **Continuous Physics**: Continuous 2D movement and realistic locomotion
 - **Advanced Quantum Algorithms**: VQE, QAOA, quantum error mitigation, and hardware deployment
 - **Real-World Validation**: WormBot deployment, C. elegans lab collaborations, cross-organism transfer (Drosophila, zebrafish)
 
@@ -404,8 +415,8 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 ### Areas We Need Help With
 
 - **Quantum Algorithm Development**: New quantum learning techniques for foraging
+- **Connectome & Plasticity**: Connectome-constrained architectures, biologically-plausible plasticity (STDP + neuromodulation), and cross-species transfer
 - **Foraging Environment Extensions**: Food quality variations, food spatial persistence, continuous action spaces
-- **Multi-Agent Evolution**: Genetic algorithms, co-evolution, predator-prey dynamics
 - **Visualization Enhancements**: Agent trail visualization, frame recording/video export, heatmaps
 - **Documentation**: Tutorials and examples for dynamic environments
 - **Testing**: Performance benchmarks and foraging strategy analysis

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ See [docs/roadmap.md](docs/roadmap.md) for the comprehensive project roadmap.
 
 ### Upcoming Features
 
-- **Connectome Substrate** (in progress): Closed-loop learning and evolution on the real *C. elegans* connectome (302 neurons, Cook et al. 2019) as a focal architecture, with NEAT topology search ranking the wild-type connectome against evolved alternatives on klinotaxis, thermotaxis, and predator evasion
+- **Connectome Architecture Comparison** (in progress): Closed-loop learning and evolution on the real *C. elegans* connectome (302 neurons, Cook et al. 2019) as a focal architecture, with NEAT topology search ranking the wild-type connectome against evolved alternatives on klinotaxis, thermotaxis, and predator evasion
 - **Plasticity & Cross-Species Transfer**: Biologically-plausible plasticity (STDP + neuromodulator-modulated) on the connectome, and *P. pacificus* transfer using Cook et al. 2025 connectome data
 - **Continuous Physics**: Continuous 2D movement and realistic locomotion
 - **Advanced Quantum Algorithms**: VQE, QAOA, quantum error mitigation, and hardware deployment

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,7 +95,7 @@ ______________________________________________________________________
 
 ## Current State
 
-Phases 0-5 are complete. The platform now supports: 19 brain architectures spanning quantum, classical, recurrent, spiking, reservoir, and hybrid families; thermotaxis, mechanosensation, aerotaxis, klinotaxis, and pheromone-based sensing; multi-agent dynamics at 5-10 agent scales; CMA-ES and TPE hyperparameter evolution; Lamarckian weight inheritance across generations. The connectome layer, the pluggable architecture interface, and continuous-2D physics are the work of Phase 6.
+Phases 0-5 are complete. The platform now supports: 24 brain architectures spanning quantum, classical, recurrent, spiking, reservoir, hybrid, GA-evolved, and connectome-constrained families; thermotaxis, mechanosensation, aerotaxis, klinotaxis, and pheromone-based sensing; multi-agent dynamics at 5-10 agent scales; CMA-ES and TPE hyperparameter evolution; Lamarckian weight inheritance across generations. The connectome layer, the pluggable architecture interface, and continuous-2D physics are the work of Phase 6.
 
 ### Phase 0 — Foundation & Baselines
 


### PR DESCRIPTION
## Summary

README.md and CONTRIBUTING.md were last updated **2026-04-18** — ~633 commits and 5 brain architectures behind the current codebase. This reconciles them (plus one stale line in `docs/roadmap.md`) against the `@register_brain` registry and AGENTS.md.

## Changes

**README.md**
- Brain count **19 → 24**; added `equivariantquantum`, `cfcppo`, `feedforwardga`, `spikingppo`, `connectomeppo` to their categories
- Features list: added **Evolutionary Optimization & Inheritance**, **Connectome Substrate**, and **Pluggable Architecture Interface**
- Roadmap section: moved **Evolution & Breeding** to *Recently Completed* (Phase 5 done), promoted **Connectome Substrate** to in-progress, refreshed "Areas We Need Help With"

**CONTRIBUTING.md**
- Brain count **19 → 24** (renumbered across categories)
- Testing tiers **three → four** (added `slow` tier; corrected pre-commit subset vs. full-suite commands)
- Rewrote "Adding a New Brain Architecture" for the `@register_brain` plug-in registry; links the [Plugin Developer Guide](docs/architecture/plugin-developer-guide.md)
- Logbook index example **008 → 026**; added new evolution/analysis scripts

**docs/roadmap.md**
- One stale "19 brain architectures" line → 24; added GA-evolved and connectome-constrained families

## Verification

- `pre-commit run --files` (mdformat + markdownlint-cli2) passes
- All new brain identifiers, `BrainType` enum members, registry `name` matches, import paths in the example, test commands, script descriptions, logbook filenames, and the plugin-guide link target verified against the codebase
- Benchmark/leaderboard tables left untouched (match current auto-generated leaderboard)

## Reviewer note

Minor consistency point (not blocking): "Connectome Substrate" appears as ✅ in the Features list (capability shipped) and "(in progress)" in the roadmap (Phase 6 arc open) — different senses of the same label. Left as-is pending preference on wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded supported brain architectures from 19 to 24, adding EquivariantQuantumPPO, CfCPPO, Feedforward GA, Spiking, and Connectome-constrained models
  * Introduced a pluggable architecture registry workflow for adding new brains
  * Updated testing docs to describe four test tiers, revised pytest commands, and pre-commit behavior
  * Enlarged feature docs and roadmap with evolutionary optimization, connectome substrate, plasticity/cross-species transfer, and interactive workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->