### PR TITLE
docs: strip planning-doc labels from shared-policy implementation code

### DIFF
--- a/packages/quantum-nematode/quantumnematode/brain/arch/_policy.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/_policy.py
@@ -4,11 +4,9 @@ This module factors the action sampling, log-probability, entropy, and PPO
 surrogate terms out of the per-brain copy-paste (MLP-PPO, LSTM-PPO, CfC-PPO,
 connectome-PPO each re-implemented these independently). The helpers preserve
 each brain's *exact* numerics so the migration onto this module is
-byte-equivalent (see ``add-continuous-2d-and-action-heads`` design.md D6 and the
-migration-regression bar).
+byte-equivalent.
 
-The brains use two different RNG streams, and the migration preserves each
-(design.md D6 "Option B"):
+The brains use two different RNG streams, and the migration preserves each:
 
 - MLP-PPO and connectome-PPO use ``torch.distributions.Categorical`` end to end
   → ``categorical_sample_torch`` (rollout) + ``categorical_evaluate_torch``

--- a/packages/quantum-nematode/quantumnematode/brain/arch/cfc_ppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/cfc_ppo.py
@@ -652,8 +652,8 @@ class CfCPPOBrain(ClassicalBrain):
         action_idx = self.rng.choice(self.num_actions, p=action_probs)
         action_name = self.action_set[action_idx]
 
-        # Log probability via the shared torch helper (Option B): sampler above
-        # unchanged; log-prob moves off manual log(softmax)+eps onto torch's
+        # Log probability via the shared torch helper: the numpy sampler above is
+        # unchanged; the log-prob moves off manual log(softmax)+eps onto torch's
         # stabler log_softmax (~1e-7 deviation), consistent with the update path.
         log_prob_t, _entropy_t, _probs_t = categorical_logprob_entropy_torch(
             logits,
@@ -806,8 +806,8 @@ class CfCPPOBrain(ClassicalBrain):
                     motor_out, h = self._cfc_forward(normalized, h)
                     logits = self._logits_from_hidden(motor_out, h)
 
-                    # Shared torch log-prob/entropy for the stored action (Option B;
-                    # differentiable, used inside the BPTT loop).
+                    # Shared torch log-prob/entropy for the stored action
+                    # (differentiable, used inside the BPTT loop).
                     action_idx = int(chunk["actions"][step_idx].item())
                     log_prob, entropy, _probs = categorical_logprob_entropy_torch(
                         logits,

--- a/packages/quantum-nematode/quantumnematode/brain/arch/lstmppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/lstmppo.py
@@ -889,7 +889,7 @@ class LSTMPPOBrain(ClassicalBrain):
         action_idx = self.rng.choice(self.num_actions, p=action_probs)
         action_name = self.action_set[action_idx]
 
-        # Log probability via the shared torch helper (Option B): the numpy
+        # Log probability via the shared torch helper: the numpy
         # sampler above is unchanged so the trajectory is byte-identical; the
         # log-prob moves off the manual log(softmax)+eps onto torch's stabler
         # log_softmax (~1e-7 deviation), consistent with the update path below.
@@ -1047,8 +1047,8 @@ class LSTMPPOBrain(ClassicalBrain):
                     step_bias = chunk["biases"][step_idx]
                     if step_bias is not None:
                         logits = logits + step_bias.to(logits.device)
-                    # Shared torch log-prob/entropy for the stored action (Option B;
-                    # differentiable, used inside the BPTT loop).
+                    # Shared torch log-prob/entropy for the stored action
+                    # (differentiable, used inside the BPTT loop).
                     action_idx = chunk["actions"][step_idx].item()
                     log_prob, entropy, _probs = categorical_logprob_entropy_torch(
                         logits,

--- a/packages/quantum-nematode/quantumnematode/brain/arch/spiking_ppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/spiking_ppo.py
@@ -751,8 +751,8 @@ class SpikingPPOBrain(ClassicalBrain):
         action_idx = self.rng.choice(self.num_actions, p=action_probs)
         action_name = self.action_set[action_idx]
 
-        # Log probability via the shared torch helper (Option B): sampler above
-        # unchanged; log-prob moves onto torch's stabler log_softmax (~1e-7).
+        # Log probability via the shared torch helper: the numpy sampler above is
+        # unchanged; the log-prob moves onto torch's stabler log_softmax (~1e-7).
         log_prob_t, _entropy_t, _probs_t = categorical_logprob_entropy_torch(
             logits,
             int(action_idx),
@@ -920,8 +920,8 @@ class SpikingPPOBrain(ClassicalBrain):
                     # Spiking core forward (differentiable, surrogate slope).
                     logits, state = self._core_forward(features_t, state, slope)
 
-                    # Shared torch log-prob/entropy for the stored action (Option B;
-                    # differentiable, used inside the BPTT loop).
+                    # Shared torch log-prob/entropy for the stored action
+                    # (differentiable, used inside the BPTT loop).
                     action_idx = int(chunk["actions"][step_idx].item())
                     log_prob, entropy, _probs = categorical_logprob_entropy_torch(
                         logits,


### PR DESCRIPTION
## Summary

Per the project convention, implementation **code + docstrings** must not reference planning-doc grouping terms (phase / tranche / task §-numbers, OpenSpec-change names, `design.md`, `Option B`, `Gate`, `Rung`, etc.) — those belong in the planning artefacts (`openspec/changes/...`) only.

The shared action-policy module + the brains migrated onto it (merged earlier in #205) picked up several such labels. This strips them, keeping all the substantive technical content.

## Changes (comment/docstring-only, no behaviour change)
- `brain/arch/_policy.py` — module docstring: drop the `add-continuous-2d-and-action-heads design.md D6` and `design.md D6 "Option B"` references.
- `brain/arch/cfc_ppo.py` / `lstmppo.py` / `spiking_ppo.py` — drop `(Option B)` from the log-prob / entropy migration comments.

## Verification
- `ruff check` / `ruff format` / `pyright` pass.
- 193 brain tests green (`test_policy`, `test_cfcppo`, `test_lstmppo`, `test_spikingppo`).

## Note on scope
The two part-1 *test* files with the same refs (`test_policy.py`, `test_mlpppo_policy_migration.py`) are cleaned on the open continuous-env PR (#207) branch instead — that PR already modifies them, so cleaning them there avoids a merge conflict. This PR is deliberately limited to files **not** touched by #207, so the two are disjoint and conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline documentation and clarified existing comments across core modules for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->