### PR TITLE
fix(openspec): repair 18 main specs left structurally invalid by past archives

### DIFF
--- a/openspec/specs/configuration-system/spec.md
+++ b/openspec/specs/configuration-system/spec.md
@@ -443,8 +443,6 @@ The configuration system SHALL support an aerotaxis configuration section for de
 - **THEN** both SHALL be parsed and initialized independently
 - **AND** both OxygenField and TemperatureField SHALL coexist in the environment
 
-## ADDED Requirements
-
 ### Requirement: Sensing Configuration Schema
 
 The configuration system SHALL support a sensing configuration section for selecting sensing modes and STAM parameters.
@@ -637,6 +635,8 @@ The configuration system SHALL support an optional `multi_agent` section for mul
 
 ### Requirement: Multi-Agent Config Parameters
 
+The configuration system SHALL apply default values for multi-agent parameters (`food_competition`, `social_detection_radius`, `termination_policy`, `min_agent_distance`) when they are not explicitly specified.
+
 #### Scenario: Default Parameters
 
 - `food_competition` defaults to "first_arrival" (valid: "first_arrival", "random")
@@ -646,7 +646,7 @@ The configuration system SHALL support an optional `multi_agent` section for mul
 
 ### Requirement: Per-Agent Configuration
 
-Each agent supports: `id`, `brain`, `weights_path`, `social_phenotype`.
+The configuration system SHALL support per-agent configuration where each agent accepts `id`, `brain`, `weights_path`, and `social_phenotype` fields.
 
 #### Scenario: Shared vs Per-Agent Config
 
@@ -655,10 +655,16 @@ Each agent supports: `id`, `brain`, `weights_path`, `social_phenotype`.
 
 ### Requirement: Multi-Agent Model Persistence
 
+The system SHALL persist per-agent model files for multi-agent runs while preserving the single-agent persistence filename.
+
+#### Scenario: Model File Naming
+
 - Multi-agent saves: `final_agent_0.pt`, `final_agent_1.pt`, etc.
 - Single-agent saves: `final.pt` (unchanged)
 
 ### Requirement: Multi-Agent CSV Export
+
+The system SHALL export per-agent results and an aggregate summary as CSV files for multi-agent runs.
 
 #### Scenario: Per-Agent Results
 
@@ -684,11 +690,19 @@ The environment config SHALL support pheromone parameters.
 
 ### Requirement: SensingConfig Pheromone and Aggregation Modes
 
+The configuration system SHALL support pheromone and aggregation sensing modes on `SensingConfig`, defaulting them to ORACLE and translating them to temporal variants with STAM auto-enabled for non-oracle modes.
+
+#### Scenario: Pheromone and Aggregation Mode Handling
+
 - `pheromone_food_mode`, `pheromone_alarm_mode`, `pheromone_aggregation_mode` all default to ORACLE
 - `apply_sensing_mode()` translates oracle modules to temporal variants when non-oracle
 - `validate_sensing_config()` auto-enables STAM for derivative/temporal modes
 
 ### Requirement: Social Feeding Configuration
+
+The configuration system SHALL support an `environment.social_feeding` block with `enabled`, `decay_reduction`, and `solitary_decay` fields, applying the documented defaults and sharing its detection radius with `multi_agent.social_detection_radius`.
+
+#### Scenario: Social Feeding Block
 
 - `environment.social_feeding` block with `enabled`, `decay_reduction`, `solitary_decay`
 - Defaults: disabled, decay_reduction=0.7, solitary_decay=1.0
@@ -696,12 +710,18 @@ The environment config SHALL support pheromone parameters.
 
 ### Requirement: Per-Agent Social Phenotype
 
+The configuration system SHALL support a per-agent `AgentConfig.social_phenotype` field accepting "social" (default) or "solitary", defaulting all agents to "social" in homogeneous configs.
+
+#### Scenario: Social Phenotype Field
+
 - `AgentConfig.social_phenotype`: "social" (default) or "solitary"
 - Homogeneous configs default all agents to "social"
 
 ### Requirement: Evaluation Scenario Configs
 
 Scenario configs SHALL exist for multi-agent evaluation campaigns.
+
+#### Scenario: Evaluation Campaign Configs
 
 - Single-agent baselines for both oracle and temporal modes with environment params matching multi-agent configs
 - Agent scaling series (1, 2, 5, 10 agents) on identical grid with identical parameters

--- a/openspec/specs/crh-brain/spec.md
+++ b/openspec/specs/crh-brain/spec.md
@@ -4,7 +4,7 @@
 
 Define the requirements for the Classical Reservoir Hybrid (CRH) brain architecture. CRH uses a fixed classical Echo State Network (ESN) reservoir with configurable feature channels and a PPO-trained classical actor-critic readout. It serves as both a quantum ablation control for QRH (matching feature dimension and architecture) and a standalone benchmark architecture filling the "classical fixed reservoir + PPO readout" niche.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: CRH Brain Architecture
 

--- a/openspec/specs/crh-qlstm-brain/spec.md
+++ b/openspec/specs/crh-qlstm-brain/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# crh-qlstm-brain Specification
+
+## Purpose
+
+Provide a CRH-QLSTM brain that pairs a classical CRH reservoir (Echo State Network) feature extractor with a QLIF-LSTM temporal readout, sharing all non-reservoir behavior with QRH-QLSTM so the two can serve as a controlled quantum-vs-classical reservoir ablation.
+
+## Requirements
 
 ### Requirement: CRH-QLSTM brain type registration
 

--- a/openspec/specs/environment-simulation/spec.md
+++ b/openspec/specs/environment-simulation/spec.md
@@ -277,6 +277,8 @@ The system SHALL provide three preset configurations for curriculum learning: sm
 
 ### Requirement: Brain Architecture Compatibility
 
+Any existing brain type SHALL operate unchanged with a dynamic environment, receiving the same observation format and producing the same action outputs without requiring brain code changes.
+
 #### Scenario: Brain Architecture Compatibility
 
 - **GIVEN** any existing brain type (modular, qmodular, mlp, qmlp, spiking)
@@ -664,8 +666,6 @@ The system SHALL use consistent, documented symbols for predators across all ren
 
 <!-- Synced from change: add-temporal-sensing-and-stam -->
 
-## ADDED Requirements
-
 ### Requirement: Scalar Food Concentration
 
 The environment SHALL compute scalar food concentration at a given position as the sum of exponential decay magnitudes from all active food sources, without directional information.
@@ -803,13 +803,17 @@ The environment SHALL manage per-agent mutable state via an `AgentState` datacla
 
 ### Requirement: Agent Registry
 
+The environment SHALL maintain a registry of agents keyed by agent_id and SHALL register new agents with minimum-separation spawn placement.
+
+#### Scenario: Registry Structure and Registration
+
 - `self.agents`: `dict[str, AgentState]` keyed by agent_id
 - `add_agent(agent_id, position, max_body_length, min_distance)` creates and registers agents
 - Poisson disk sampling with minimum separation for spawn placement
 
 ### Requirement: Position-Parameterized Methods
 
-All environment methods provide `*_for(agent_id)` variants: `move_agent_for`, `reached_goal_for`, `consume_food_for`, `apply_predator_damage_for`, `apply_temperature_effects_for`, `apply_oxygen_effects_for`, `is_agent_at_boundary_for`, `is_agent_in_damage_radius_for`, `get_separated_gradients_for`, etc.
+All environment methods SHALL provide `*_for(agent_id)` variants: `move_agent_for`, `reached_goal_for`, `consume_food_for`, `apply_predator_damage_for`, `apply_temperature_effects_for`, `apply_oxygen_effects_for`, `is_agent_at_boundary_for`, `is_agent_in_damage_radius_for`, `get_separated_gradients_for`, etc.
 
 #### Scenario: Backward Compatible Originals
 
@@ -817,13 +821,17 @@ All environment methods provide `*_for(agent_id)` variants: `move_agent_for`, `r
 
 ### Requirement: Predator Multi-Target Pursuit
 
+Pursuit predators SHALL chase the nearest alive agent by Manhattan distance, excluding terminated agents from targeting.
+
+#### Scenario: Nearest-Target Pursuit
+
 - Pursuit predators chase the nearest alive agent (Manhattan distance)
 - Terminated agents excluded from targeting
 - Single-agent: identical to current behavior
 
 ### Requirement: Pheromone Field System
 
-Dynamic pheromone concentration fields using point-source exponential decay.
+The environment SHALL provide dynamic pheromone concentration fields using point-source exponential decay.
 
 #### Scenario: Concentration
 
@@ -840,6 +848,10 @@ Dynamic pheromone concentration fields using point-source exponential decay.
 
 ### Requirement: Pheromone Emission
 
+The environment SHALL emit pheromone sources for food consumption, predator damage, and aggregation, and SHALL be a no-op when pheromones are disabled or the field is not configured.
+
+#### Scenario: Emission Triggers
+
 - `emit_food_pheromone()`: adds FOOD_MARKING source on food consumption
 - `emit_alarm_pheromone()`: adds ALARM source on predator damage
 - `emit_aggregation_pheromone()`: adds AGGREGATION source (continuous, every step)
@@ -847,7 +859,7 @@ Dynamic pheromone concentration fields using point-source exponential decay.
 
 ### Requirement: Social Feeding System
 
-Satiety decay reduction when agents are near conspecifics (npr-1 mediated).
+The environment SHALL reduce satiety decay when agents are near conspecifics (npr-1 mediated).
 
 #### Scenario: Social Phenotype
 
@@ -863,7 +875,7 @@ Satiety decay reduction when agents are near conspecifics (npr-1 mediated).
 
 ### Requirement: Aggregation Pheromone Field
 
-Third PheromoneType (AGGREGATION) with continuous emission by all alive agents.
+The environment SHALL provide a third PheromoneType (AGGREGATION) with continuous emission by all alive agents.
 
 #### Scenario: Field Creation
 
@@ -874,6 +886,10 @@ Third PheromoneType (AGGREGATION) with continuous emission by all alive agents.
 - `update_pheromone_fields()` prunes aggregation field alongside food and alarm
 
 ### Requirement: Satiety Decay Multiplier
+
+`SatietyManager.decay_satiety` SHALL accept a multiplier that scales the satiety decay rate, defaulting to preserve original behavior.
+
+#### Scenario: Multiplier Scaling
 
 - `SatietyManager.decay_satiety(multiplier=1.0)` — default preserves original behavior
 - Multiplier < 1.0 reduces decay; > 1.0 increases; clamped at zero

--- a/openspec/specs/food-spatial-persistence/spec.md
+++ b/openspec/specs/food-spatial-persistence/spec.md
@@ -1,85 +1,123 @@
+# food-spatial-persistence Specification
+
 ## Purpose
 
 Defines requirements for food spatial persistence via configurable hotspot regions, satiety-gated food collection, and static food mode, enabling meaningful food-marking pheromone evaluation.
 
-## MODIFIED Requirement: Food Spawning with Hotspot Bias
+## Requirements
 
-- WHEN `ForagingParams` is configured with `food_hotspots` and `food_hotspot_bias > 0`
+### Requirement: Food Spawning with Hotspot Bias
 
-- THEN food spawning (both initial placement and respawn) SHALL use the hotspot bias probability to decide between hotspot-biased and uniform random candidate generation
+Food spawning SHALL use the hotspot bias probability to decide between hotspot-biased and uniform random candidate generation when hotspots and a positive bias are configured, and SHALL behave identically to uniform random placement otherwise.
 
-- AND hotspot-biased candidates SHALL be sampled from an exponential distribution centered on a randomly selected hotspot, with decay controlled by `food_hotspot_decay`
+#### Scenario: Hotspot bias configured
 
-- AND hotspot selection SHALL be weighted by the hotspot `weight` values (higher weight = more spawns near that hotspot)
+- **WHEN** `ForagingParams` is configured with `food_hotspots` and `food_hotspot_bias > 0`
 
-- AND candidates SHALL be clamped to grid bounds
+- **THEN** food spawning (both initial placement and respawn) SHALL use the hotspot bias probability to decide between hotspot-biased and uniform random candidate generation
 
-- AND all existing constraints (`min_food_distance`, `agent_exclusion_radius`) SHALL still be enforced on hotspot-biased candidates
+- **AND** hotspot-biased candidates SHALL be sampled from an exponential distribution centered on a randomly selected hotspot, with decay controlled by `food_hotspot_decay`
 
-- WHEN `ForagingParams` has `food_hotspots=None` or `food_hotspot_bias=0.0`
+- **AND** hotspot selection SHALL be weighted by the hotspot `weight` values (higher weight = more spawns near that hotspot)
 
-- THEN food spawning SHALL behave identically to current uniform random placement
+- **AND** candidates SHALL be clamped to grid bounds
 
-## ADDED Requirement: Satiety-Gated Food Collection
+- **AND** all existing constraints (`min_food_distance`, `agent_exclusion_radius`) SHALL still be enforced on hotspot-biased candidates
 
-- WHEN `ForagingParams.satiety_food_threshold` is set (not None)
+#### Scenario: No hotspot bias configured
 
-- AND an agent attempts to consume food
+- **WHEN** `ForagingParams` has `food_hotspots=None` or `food_hotspot_bias=0.0`
 
-- THEN the food consumption logic SHALL check the agent's current satiety against `satiety_food_threshold * max_satiety`
+- **THEN** food spawning SHALL behave identically to current uniform random placement
 
-- AND if the agent's satiety exceeds this value, food collection SHALL be refused (food remains on the grid, agent receives no satiety restoration)
+### Requirement: Satiety-Gated Food Collection
 
-- AND the agent SHALL still occupy the food cell without consuming it
+When a satiety food threshold is set, food consumption SHALL be refused for agents whose satiety exceeds the threshold, and food collection SHALL behave identically to current behavior when no threshold is set.
 
-- WHEN food competition is resolved in multi-agent mode
+#### Scenario: Agent attempts to consume food while gated
 
-- THEN sated agents (satiety > threshold) SHALL be excluded from the contested map before competition resolution
+- **WHEN** `ForagingParams.satiety_food_threshold` is set (not None)
 
-- AND food at a position with only sated agents SHALL remain on the grid unconsumed
+- **AND** an agent attempts to consume food
 
-- WHEN an agent is on food but cannot eat due to satiety gate
+- **THEN** the food consumption logic SHALL check the agent's current satiety against `satiety_food_threshold * max_satiety`
 
-- THEN the reward calculator SHALL NOT award the goal bonus for that step (callers pass `can_eat=False` to `calculate_reward()`; the parameter defaults to True for backward compatibility)
+- **AND** if the agent's satiety exceeds this value, food collection SHALL be refused (food remains on the grid, agent receives no satiety restoration)
 
-- WHEN `ForagingParams.satiety_food_threshold` is None (default)
+- **AND** the agent SHALL still occupy the food cell without consuming it
 
-- THEN food collection SHALL behave identically to current behavior (no satiety gate)
+#### Scenario: Food competition with sated agents
 
-## MODIFIED Requirement: Food Respawn after Consumption
+- **WHEN** food competition is resolved in multi-agent mode
 
-- WHEN food is consumed and `ForagingParams.no_respawn` is False (default)
+- **THEN** sated agents (satiety > threshold) SHALL be excluded from the contested map before competition resolution
 
-- THEN `spawn_food()` SHALL spawn a replacement food item using the same hotspot bias logic as initial placement
+- **AND** food at a position with only sated agents SHALL remain on the grid unconsumed
 
-- WHEN food is consumed and `ForagingParams.no_respawn` is True
+#### Scenario: Reward when agent cannot eat due to satiety gate
 
-- THEN no replacement food SHALL be spawned
+- **WHEN** an agent is on food but cannot eat due to satiety gate
 
-- AND the food count on the grid SHALL decrease permanently
+- **THEN** the reward calculator SHALL NOT award the goal bonus for that step (callers pass `can_eat=False` to `calculate_reward()`; the parameter defaults to True for backward compatibility)
 
-## ADDED Requirement: Food Hotspot Configuration
+#### Scenario: No satiety threshold configured
 
-- WHEN a YAML config specifies `food_hotspots`
+- **WHEN** `ForagingParams.satiety_food_threshold` is None (default)
 
-- THEN each hotspot SHALL be a list of `[x, y, weight]` where x and y are grid coordinates and weight is a positive float controlling relative spawn density
+- **THEN** food collection SHALL behave identically to current behavior (no satiety gate)
 
-- AND the config loader SHALL validate that hotspot coordinates are within grid bounds
+### Requirement: Food Respawn after Consumption
 
-- AND `food_hotspot_bias` SHALL be validated as a float in range [0.0, 1.0]
+When food is consumed, a replacement SHALL be spawned using the same hotspot bias logic as initial placement unless no-respawn mode is enabled, in which case no replacement SHALL be spawned.
 
-- AND `food_hotspot_decay` SHALL be validated as a positive float
+#### Scenario: Respawn enabled
 
-## ADDED Requirement: FoodHotspot Type
+- **WHEN** food is consumed and `ForagingParams.no_respawn` is False (default)
 
-- WHEN `FoodHotspot` type is used
+- **THEN** `spawn_food()` SHALL spawn a replacement food item using the same hotspot bias logic as initial placement
 
-- THEN it SHALL be defined as `tuple[int, int, float]` matching the existing `TemperatureSpot` and `OxygenSpot` patterns
+#### Scenario: Respawn disabled
 
-## ADDED Requirement: Hotspot Bias Composition
+- **WHEN** food is consumed and `ForagingParams.no_respawn` is True
 
-- WHEN both `food_hotspot_bias` and `safe_zone_food_bias` are configured
+- **THEN** no replacement food SHALL be spawned
 
-- THEN the biases SHALL compose independently: hotspot bias controls the sampling distribution, safe zone bias acts as a rejection filter afterward
+- **AND** the food count on the grid SHALL decrease permanently
 
-- AND neither bias SHALL override or disable the other
+### Requirement: Food Hotspot Configuration
+
+A YAML config that specifies `food_hotspots` SHALL define each hotspot as a `[x, y, weight]` list and SHALL validate hotspot coordinates and bias/decay parameters.
+
+#### Scenario: YAML config specifies food hotspots
+
+- **WHEN** a YAML config specifies `food_hotspots`
+
+- **THEN** each hotspot SHALL be a list of `[x, y, weight]` where x and y are grid coordinates and weight is a positive float controlling relative spawn density
+
+- **AND** the config loader SHALL validate that hotspot coordinates are within grid bounds
+
+- **AND** `food_hotspot_bias` SHALL be validated as a float in range [0.0, 1.0]
+
+- **AND** `food_hotspot_decay` SHALL be validated as a positive float
+
+### Requirement: FoodHotspot Type
+
+The `FoodHotspot` type SHALL be defined as `tuple[int, int, float]` matching the existing `TemperatureSpot` and `OxygenSpot` patterns.
+
+#### Scenario: FoodHotspot type used
+
+- **WHEN** `FoodHotspot` type is used
+
+- **THEN** it SHALL be defined as `tuple[int, int, float]` matching the existing `TemperatureSpot` and `OxygenSpot` patterns
+
+### Requirement: Hotspot Bias Composition
+
+When both `food_hotspot_bias` and `safe_zone_food_bias` are configured, the biases SHALL compose independently and neither SHALL override or disable the other.
+
+#### Scenario: Both biases configured
+
+- **WHEN** both `food_hotspot_bias` and `safe_zone_food_bias` are configured
+
+- **THEN** the biases SHALL compose independently: hotspot bias controls the sampling distribution, safe zone bias acts as a rejection filter afterward
+
+- **AND** neither bias SHALL override or disable the other

--- a/openspec/specs/hybrid-quantum-brain/spec.md
+++ b/openspec/specs/hybrid-quantum-brain/spec.md
@@ -4,7 +4,7 @@
 
 Define the requirements for the Hierarchical Hybrid Quantum Brain architecture that combines a QSNN reflex layer (QLIF quantum circuits with surrogate gradient REINFORCE) with a classical cortex MLP (PPO training) for multi-objective decision-making. The architecture uses mode-gated fusion to let the cortex modulate trust in the quantum reflex, enabling both reactive foraging and strategic predator evasion.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Hierarchical Architecture
 

--- a/openspec/specs/klinotaxis-sensing/spec.md
+++ b/openspec/specs/klinotaxis-sensing/spec.md
@@ -1,48 +1,66 @@
+# klinotaxis-sensing Specification
+
 ## Purpose
 
 Defines requirements for klinotaxis (head-sweep) sensing mode providing local spatial gradient information via lateral concentration sampling, enabling biologically accurate chemotaxis and pheromone trail-following.
 
-## ADDED Requirement: Klinotaxis Sensing Mode
+## Requirements
 
-- WHEN `SensingMode.KLINOTAXIS` is selected for a modality
+### Requirement: Klinotaxis Sensing Mode
 
-- THEN the system SHALL sample concentration at the agent's position (center), 1 cell perpendicular-left of heading (left), and 1 cell perpendicular-right of heading (right)
+When `SensingMode.KLINOTAXIS` is selected for a modality, the system SHALL sample concentration at the agent's center, perpendicular-left, and perpendicular-right positions, compute the lateral gradient as `right - left`, compute the temporal derivative via STAM, and auto-enable STAM whenever any modality uses klinotaxis.
 
-- AND the lateral gradient SHALL be computed as `right - left`
+#### Scenario: Lateral and temporal sampling under klinotaxis
 
-- AND the temporal derivative SHALL be computed via STAM (same as derivative mode)
+- **WHEN** `SensingMode.KLINOTAXIS` is selected for a modality
 
-- AND STAM SHALL be auto-enabled when any modality uses klinotaxis
+- **THEN** the system SHALL sample concentration at the agent's position (center), 1 cell perpendicular-left of heading (left), and 1 cell perpendicular-right of heading (right)
 
-## ADDED Requirement: Head-Sweep Geometry
+- **AND** the lateral gradient SHALL be computed as `right - left`
 
-- WHEN computing lateral offsets for a given heading direction
+- **AND** the temporal derivative SHALL be computed via STAM (same as derivative mode)
 
-- THEN UP heading SHALL use left=(x-1,y), right=(x+1,y)
+- **AND** STAM SHALL be auto-enabled when any modality uses klinotaxis
 
-- AND RIGHT heading SHALL use left=(x,y+1), right=(x,y-1)
+### Requirement: Head-Sweep Geometry
 
-- AND DOWN heading SHALL use left=(x+1,y), right=(x-1,y)
+When computing lateral offsets for a given heading direction, the system SHALL apply the heading-specific left/right offsets, reuse the last non-STAY heading for STAY, and clamp all positions to grid bounds [0, grid_size-1].
 
-- AND LEFT heading SHALL use left=(x,y-1), right=(x,y+1)
+#### Scenario: Heading-specific lateral offsets
 
-- AND STAY heading SHALL use the last non-STAY heading direction
+- **WHEN** computing lateral offsets for a given heading direction
 
-- AND positions SHALL be clamped to grid bounds [0, grid_size-1]
+- **THEN** UP heading SHALL use left=(x-1,y), right=(x+1,y)
 
-## ADDED Requirement: Klinotaxis Sensory Modules
+- **AND** RIGHT heading SHALL use left=(x,y+1), right=(x,y-1)
 
-- WHEN a klinotaxis sensory module extracts features
+- **AND** DOWN heading SHALL use left=(x+1,y), right=(x-1,y)
 
-- THEN it SHALL produce CoreFeatures with classical_dim=3:
+- **AND** LEFT heading SHALL use left=(x,y-1), right=(x,y+1)
+
+- **AND** STAY heading SHALL use the last non-STAY heading direction
+
+- **AND** positions SHALL be clamped to grid bounds [0, grid_size-1]
+
+### Requirement: Klinotaxis Sensory Modules
+
+Klinotaxis sensory modules SHALL produce CoreFeatures with classical_dim=3 (strength, angle, binary), and `apply_sensing_mode()` SHALL substitute the configured oracle modules with their klinotaxis variants.
+
+#### Scenario: Feature extraction produces classical_dim=3
+
+- **WHEN** a klinotaxis sensory module extracts features
+
+- **THEN** it SHALL produce CoreFeatures with classical_dim=3:
 
   - strength: scalar concentration at agent position (same as temporal)
   - angle: `tanh(lateral_gradient * lateral_scale)` normalized to [-1, 1]
   - binary: `tanh(dC/dt * derivative_scale)` normalized to [-1, 1]
 
-- WHEN the following oracle modules are configured with klinotaxis mode
+#### Scenario: Oracle module substitution to klinotaxis variants
 
-- THEN `apply_sensing_mode()` SHALL substitute them as follows:
+- **WHEN** the following oracle modules are configured with klinotaxis mode
+
+- **THEN** `apply_sensing_mode()` SHALL substitute them as follows:
 
   - `food_chemotaxis` → `food_chemotaxis_klinotaxis`
   - `nociception` → `nociception_klinotaxis`
@@ -52,33 +70,45 @@ Defines requirements for klinotaxis (head-sweep) sensing mode providing local sp
   - `pheromone_alarm` → `pheromone_alarm_klinotaxis`
   - `pheromone_aggregation` → `pheromone_aggregation_klinotaxis`
 
-## MODIFIED Requirement: apply_sensing_mode Substitution
+### Requirement: apply_sensing_mode Substitution
 
-- WHEN `apply_sensing_mode()` processes a module name
+When `apply_sensing_mode()` processes a module name, it SHALL use explicit mode matching to select the klinotaxis, temporal, or original oracle module, and SHALL preserve existing TEMPORAL and DERIVATIVE mode behavior exactly.
 
-- THEN it SHALL use explicit mode matching:
+#### Scenario: Explicit mode matching for module selection
+
+- **WHEN** `apply_sensing_mode()` processes a module name
+
+- **THEN** it SHALL use explicit mode matching:
 
   - `== KLINOTAXIS` → `*_klinotaxis` module
   - `!= ORACLE and != KLINOTAXIS` → `*_temporal` module (covers TEMPORAL + DERIVATIVE)
   - `== ORACLE` → original oracle module
 
-- AND existing TEMPORAL and DERIVATIVE mode behavior SHALL be preserved exactly
+- **AND** existing TEMPORAL and DERIVATIVE mode behavior SHALL be preserved exactly
 
-## ADDED Requirement: Lateral Scale Configuration
+### Requirement: Lateral Scale Configuration
 
-- WHEN `lateral_scale` is configured on SensingConfig
+When `lateral_scale` is configured on SensingConfig, it SHALL be a positive float (default 50.0), SHALL be passed to BrainParams for use by klinotaxis sensory modules, and SHALL be independent of `derivative_scale`.
 
-- THEN it SHALL be a positive float (default 50.0)
+#### Scenario: lateral_scale configuration and propagation
 
-- AND it SHALL be passed to BrainParams for use by klinotaxis sensory modules
+- **WHEN** `lateral_scale` is configured on SensingConfig
 
-- AND it SHALL be independent of `derivative_scale`
+- **THEN** it SHALL be a positive float (default 50.0)
 
-## ADDED Requirement: BrainParams Lateral Gradient Fields
+- **AND** it SHALL be passed to BrainParams for use by klinotaxis sensory modules
 
-- WHEN klinotaxis mode is active for a modality
+- **AND** it SHALL be independent of `derivative_scale`
 
-- THEN BrainParams SHALL include the corresponding lateral gradient field:
+### Requirement: BrainParams Lateral Gradient Fields
+
+When klinotaxis mode is active for a modality, BrainParams SHALL include the corresponding lateral gradient field, and all lateral gradient fields SHALL default to None when klinotaxis is not active.
+
+#### Scenario: Lateral gradient fields per modality
+
+- **WHEN** klinotaxis mode is active for a modality
+
+- **THEN** BrainParams SHALL include the corresponding lateral gradient field:
 
   - `food_lateral_gradient: float | None`
   - `predator_lateral_gradient: float | None`
@@ -88,4 +118,4 @@ Defines requirements for klinotaxis (head-sweep) sensing mode providing local sp
   - `pheromone_alarm_lateral_gradient: float | None`
   - `pheromone_aggregation_lateral_gradient: float | None`
 
-- AND all lateral gradient fields SHALL default to None when klinotaxis is not active
+- **AND** all lateral gradient fields SHALL default to None when klinotaxis is not active

--- a/openspec/specs/lstm-ppo-brain/spec.md
+++ b/openspec/specs/lstm-ppo-brain/spec.md
@@ -1,6 +1,10 @@
 # lstm-ppo-brain Specification
 
-## ADDED Requirements
+## Purpose
+
+Provide an LSTM/GRU-augmented PPO brain that processes sensory features through a recurrent layer before actor/critic heads, maintaining hidden state across steps within episodes and training via chunk-based truncated backpropagation through time.
+
+## Requirements
 
 ### Requirement: LSTM PPO Brain Architecture
 

--- a/openspec/specs/multi-agent-visualization/spec.md
+++ b/openspec/specs/multi-agent-visualization/spec.md
@@ -1,148 +1,208 @@
+# multi-agent-visualization Specification
+
 ## Purpose
 
 Defines requirements for rendering multi-agent simulations in the Pygame pixel theme, including per-agent colored sprites, viewport agent switching, pheromone concentration overlays, and multi-agent status bar.
 
-## MODIFIED Requirement: Theme Support for Multi-Agent
+## Requirements
 
-- WHEN a multi-agent simulation is started with `--theme pixel`
+### Requirement: Theme Support for Multi-Agent
 
-- THEN the system SHALL create a PygameRenderer and pass it to the MultiAgentSimulation orchestrator
+The system SHALL select the appropriate renderer for a multi-agent simulation based on the requested theme, creating a PygameRenderer for `--theme pixel`, no renderer for `--theme headless`, and falling back to headless mode for any other theme.
 
-- AND the renderer SHALL display all visible agents within the viewport
+#### Scenario: Pixel theme
 
-- WHEN a multi-agent simulation is started with `--theme headless`
+- **WHEN** a multi-agent simulation is started with `--theme pixel`
 
-- THEN no renderer SHALL be created
+- **THEN** the system SHALL create a PygameRenderer and pass it to the MultiAgentSimulation orchestrator
 
-- AND behavior SHALL be identical to current headless multi-agent mode
+- **AND** the renderer SHALL display all visible agents within the viewport
 
-- WHEN a multi-agent simulation is started with any other theme
+#### Scenario: Headless theme
 
-- THEN the system SHALL log a warning
+- **WHEN** a multi-agent simulation is started with `--theme headless`
 
-- AND fall back to headless mode
+- **THEN** no renderer SHALL be created
 
-## ADDED Requirement: Multi-Agent Frame Rendering
+- **AND** behavior SHALL be identical to current headless multi-agent mode
 
-- WHEN `render_multi_agent_frame()` is called with a list of `AgentRenderState` objects
+#### Scenario: Other theme
 
-- THEN the renderer SHALL draw all agents whose positions fall within the viewport bounds, including dead agents
+- **WHEN** a multi-agent simulation is started with any other theme
 
-- AND each agent SHALL be rendered with a distinct color from the 8-color palette based on their `color_index`
+- **THEN** the system SHALL log a warning
 
-- AND dead agents SHALL be rendered with a semi-transparent gray overlay applied on top of the base colored sprite
+- **AND** fall back to headless mode
 
-- WHEN the followed agent's viewport is computed
+### Requirement: Multi-Agent Frame Rendering
 
-- THEN the viewport SHALL be centered on the followed agent's position
+The renderer SHALL draw all agents within the viewport bounds with distinct palette colors and SHALL compute the followed agent's viewport centered on its position while clamping to grid boundaries.
 
-- AND the viewport SHALL clamp to grid boundaries (no wraparound)
+#### Scenario: Render agents in viewport
 
-- AND existing rendering layers (background, temperature zones, oxygen zones, toxic zones, food, predators) SHALL render identically to single-agent mode
+- **WHEN** `render_multi_agent_frame()` is called with a list of `AgentRenderState` objects
 
-## ADDED Requirement: Agent Switching
+- **THEN** the renderer SHALL draw all agents whose positions fall within the viewport bounds, including dead agents
 
-- WHEN the user presses the right arrow key during a multi-agent rendering session
+- **AND** each agent SHALL be rendered with a distinct color from the 8-color palette based on their `color_index`
 
-- THEN the viewport SHALL switch to follow the next agent in the `AgentRenderState` list order (wrapping from last to first)
+- **AND** dead agents SHALL be rendered with a semi-transparent gray overlay applied on top of the base colored sprite
 
-- WHEN the user presses the left arrow key during a multi-agent rendering session
+#### Scenario: Compute followed agent viewport
 
-- THEN the viewport SHALL switch to follow the previous agent in the `AgentRenderState` list order (wrapping from first to last)
+- **WHEN** the followed agent's viewport is computed
 
-- WHEN the user presses number key N (1-9) during a multi-agent rendering session
+- **THEN** the viewport SHALL be centered on the followed agent's position
 
-- THEN the viewport SHALL switch to follow the agent at index N-1 in the `AgentRenderState` list (if present)
+- **AND** the viewport SHALL clamp to grid boundaries (no wraparound)
 
-- AND if index N-1 does not exist, the keypress SHALL be ignored
+- **AND** existing rendering layers (background, temperature zones, oxygen zones, toxic zones, food, predators) SHALL render identically to single-agent mode
 
-- WHEN the followed agent changes via any input method
+### Requirement: Agent Switching
 
-- THEN the status bar SHALL update to show the newly followed agent's metrics
+The renderer SHALL allow the user to switch the followed agent via arrow keys and number keys, SHALL update the status bar and handle followed-agent removal, and SHALL return the current followed agent ID.
 
-- WHEN the followed agent is removed from the `AgentRenderState` list between frames
+#### Scenario: Next agent
 
-- THEN the renderer SHALL fall back to following the first agent in the list
+- **WHEN** the user presses the right arrow key during a multi-agent rendering session
 
-- WHEN `render_multi_agent_frame()` returns
+- **THEN** the viewport SHALL switch to follow the next agent in the `AgentRenderState` list order (wrapping from last to first)
 
-- THEN it SHALL return the current followed agent ID (which may have changed due to keyboard input or fallback)
+#### Scenario: Previous agent
 
-## ADDED Requirement: Colored Agent Sprites
+- **WHEN** the user presses the left arrow key during a multi-agent rendering session
 
-- WHEN tinted head sprites are generated for a color index
+- **THEN** the viewport SHALL switch to follow the previous agent in the `AgentRenderState` list order (wrapping from first to last)
 
-- THEN the system SHALL produce 4 directional sprites (up, down, left, right) tinted to the palette color
+#### Scenario: Jump to agent by number
 
-- AND the sprites SHALL be 32x32 pixels with SRCALPHA transparency
+- **WHEN** the user presses number key N (1-9) during a multi-agent rendering session
 
-- AND the `color_index` SHALL be computed as `agent_index % 8` to support arbitrary agent counts
+- **THEN** the viewport SHALL switch to follow the agent at index N-1 in the `AgentRenderState` list (if present)
 
-- WHEN body segments are rendered for a colored agent
+- **AND** if index N-1 does not exist, the keypress SHALL be ignored
 
-- THEN the body color, outline, and highlight SHALL be tinted to match the agent's palette color
+#### Scenario: Status bar update on switch
 
-- AND the existing `draw_body_segment()` function SHALL accept optional color parameters with backward-compatible defaults
+- **WHEN** the followed agent changes via any input method
 
-## ADDED Requirement: Pheromone Overlay
+- **THEN** the status bar SHALL update to show the newly followed agent's metrics
 
-- WHEN the pheromone overlay is enabled (toggled by 'P' key)
+#### Scenario: Followed agent removed
 
-- THEN the renderer SHALL compute pheromone concentration at each viewport cell for each active pheromone field
+- **WHEN** the followed agent is removed from the `AgentRenderState` list between frames
 
-- AND food pheromone concentration SHALL be displayed as green semi-transparent overlay
+- **THEN** the renderer SHALL fall back to following the first agent in the list
 
-- AND alarm pheromone concentration SHALL be displayed as red semi-transparent overlay
+#### Scenario: Return followed agent ID
 
-- AND aggregation pheromone concentration SHALL be displayed as blue semi-transparent overlay
+- **WHEN** `render_multi_agent_frame()` returns
 
-- AND overlay alpha SHALL be proportional to the concentration value
+- **THEN** it SHALL return the current followed agent ID (which may have changed due to keyboard input or fallback)
 
-- WHEN the pheromone overlay is disabled (default state)
+### Requirement: Colored Agent Sprites
 
-- THEN no pheromone concentration computation or rendering SHALL occur
+The system SHALL generate per-color tinted directional head sprites and SHALL tint body segments to match each agent's palette color, with backward-compatible defaults.
 
-## ADDED Requirement: Viewport Bounds for Arbitrary Agents
+#### Scenario: Tinted head sprites
 
-- WHEN `get_viewport_bounds_for(agent_id)` is called on the environment
-- THEN it SHALL return viewport bounds centered on the specified agent's position
-- AND the bounds SHALL clamp to grid boundaries
-- AND the existing `get_viewport_bounds()` SHALL delegate to `get_viewport_bounds_for(DEFAULT_AGENT_ID)`
+- **WHEN** tinted head sprites are generated for a color index
 
-## ADDED Requirement: Orchestrator Rendering Integration
+- **THEN** the system SHALL produce 4 directional sprites (up, down, left, right) tinted to the palette color
 
-- WHEN `MultiAgentSimulation` is created with a renderer parameter
+- **AND** the sprites SHALL be 32x32 pixels with SRCALPHA transparency
 
-- THEN the renderer field SHALL be a dataclass field typed `PygameRenderer | None = None` with a `TYPE_CHECKING` import guard
+- **AND** the `color_index` SHALL be computed as `agent_index % 8` to support arbitrary agent counts
 
-- AND the renderer SHALL be called once per step via `_render_step()` after all agent effects are applied
+#### Scenario: Tinted body segments
 
-- AND the rendering data SHALL be assembled from `self.env` (current env reference) and per-agent tracking state
+- **WHEN** body segments are rendered for a colored agent
 
-- AND `AgentRenderState.direction` SHALL be converted from the `Direction` enum to its `.value` string when building snapshots
+- **THEN** the body color, outline, and highlight SHALL be tinted to match the agent's palette color
 
-- WHEN the renderer window is closed by the user
+- **AND** the existing `draw_body_segment()` function SHALL accept optional color parameters with backward-compatible defaults
 
-- THEN `renderer.closed` SHALL become True
+### Requirement: Pheromone Overlay
 
-- AND `MultiAgentSimulation` SHALL set a `_renderer_closed` flag and return early from `run_episode()`
+The renderer SHALL compute and display pheromone concentration overlays per viewport cell when the overlay is enabled, and SHALL perform no pheromone computation or rendering when it is disabled.
 
-- AND `_run_multi_agent()` SHALL check `sim.renderer_closed` after each episode and break the run loop
+#### Scenario: Overlay enabled
 
-- AND this SHALL match the single-agent window close behavior
+- **WHEN** the pheromone overlay is enabled (toggled by 'P' key)
 
-- WHEN a multi-agent simulation is started with `--show-last-frame-only`
+- **THEN** the renderer SHALL compute pheromone concentration at each viewport cell for each active pheromone field
 
-- THEN the flag SHALL be ignored for multi-agent rendering (render every frame or not at all)
+- **AND** food pheromone concentration SHALL be displayed as green semi-transparent overlay
 
-## ADDED Requirement: Multi-Agent Status Bar
+- **AND** alarm pheromone concentration SHALL be displayed as red semi-transparent overlay
 
-- WHEN the multi-agent status bar is rendered
+- **AND** aggregation pheromone concentration SHALL be displayed as blue semi-transparent overlay
 
-- THEN it SHALL display the followed agent's full metrics (step, food collected, HP, satiety)
+- **AND** overlay alpha SHALL be proportional to the concentration value
 
-- AND it SHALL display a compact summary line for all agents (ID, food count, alive/dead)
+#### Scenario: Overlay disabled
 
-- AND it SHALL display the agent switcher indicator ("Following: agent_N [N/total]", "\</> to switch, 1-9 to jump")
+- **WHEN** the pheromone overlay is disabled (default state)
 
-- AND lines exceeding the available window width SHALL be word-wrapped across multiple lines, with character-level breaking as fallback for single tokens wider than the window
+- **THEN** no pheromone concentration computation or rendering SHALL occur
+
+### Requirement: Viewport Bounds for Arbitrary Agents
+
+The environment SHALL provide `get_viewport_bounds_for(agent_id)` returning viewport bounds centered on the specified agent and clamped to grid boundaries, with `get_viewport_bounds()` delegating to it for the default agent.
+
+#### Scenario: Bounds for specified agent
+
+- **WHEN** `get_viewport_bounds_for(agent_id)` is called on the environment
+- **THEN** it SHALL return viewport bounds centered on the specified agent's position
+- **AND** the bounds SHALL clamp to grid boundaries
+- **AND** the existing `get_viewport_bounds()` SHALL delegate to `get_viewport_bounds_for(DEFAULT_AGENT_ID)`
+
+### Requirement: Orchestrator Rendering Integration
+
+`MultiAgentSimulation` SHALL integrate the renderer as a typed dataclass field, SHALL invoke it once per step with data assembled from the current env and per-agent tracking state, and SHALL handle renderer window closure consistently with single-agent mode.
+
+#### Scenario: Renderer integration and per-step rendering
+
+- **WHEN** `MultiAgentSimulation` is created with a renderer parameter
+
+- **THEN** the renderer field SHALL be a dataclass field typed `PygameRenderer | None = None` with a `TYPE_CHECKING` import guard
+
+- **AND** the renderer SHALL be called once per step via `_render_step()` after all agent effects are applied
+
+- **AND** the rendering data SHALL be assembled from `self.env` (current env reference) and per-agent tracking state
+
+- **AND** `AgentRenderState.direction` SHALL be converted from the `Direction` enum to its `.value` string when building snapshots
+
+#### Scenario: Renderer window closed
+
+- **WHEN** the renderer window is closed by the user
+
+- **THEN** `renderer.closed` SHALL become True
+
+- **AND** `MultiAgentSimulation` SHALL set a `_renderer_closed` flag and return early from `run_episode()`
+
+- **AND** `_run_multi_agent()` SHALL check `sim.renderer_closed` after each episode and break the run loop
+
+- **AND** this SHALL match the single-agent window close behavior
+
+#### Scenario: Show last frame only flag
+
+- **WHEN** a multi-agent simulation is started with `--show-last-frame-only`
+
+- **THEN** the flag SHALL be ignored for multi-agent rendering (render every frame or not at all)
+
+### Requirement: Multi-Agent Status Bar
+
+The multi-agent status bar SHALL display the followed agent's full metrics, a compact per-agent summary, and an agent switcher indicator, word-wrapping lines that exceed the available window width.
+
+#### Scenario: Status bar rendering
+
+- **WHEN** the multi-agent status bar is rendered
+
+- **THEN** it SHALL display the followed agent's full metrics (step, food collected, HP, satiety)
+
+- **AND** it SHALL display a compact summary line for all agents (ID, food count, alive/dead)
+
+- **AND** it SHALL display the agent switcher indicator ("Following: agent_N [N/total]", "\</> to switch, 1-9 to jump")
+
+- **AND** lines exceeding the available window width SHALL be word-wrapped across multiple lines, with character-level breaking as fallback for single tokens wider than the window

--- a/openspec/specs/multi-agent/spec.md
+++ b/openspec/specs/multi-agent/spec.md
@@ -26,6 +26,8 @@ The system SHALL provide a `MultiAgentSimulation` orchestrator that coordinates 
 
 ### Requirement: Food Competition Resolution
 
+The system SHALL resolve contested food (multiple agents on the same food position) according to the configured competition policy, while agents at different food positions consume independently.
+
 #### Scenario: FIRST_ARRIVAL Policy
 
 - Lexicographically first agent_id wins contested food
@@ -39,6 +41,8 @@ The system SHALL provide a `MultiAgentSimulation` orchestrator that coordinates 
 - Agents at different food positions consume independently (no competition event)
 
 ### Requirement: Agent Termination Policy
+
+The system SHALL apply the configured termination policy (Freeze, Remove, or End All) when an agent terminates, determining whether the agent remains on the grid, is removed, or ends the episode for all agents.
 
 #### Scenario: Freeze (Default)
 
@@ -55,11 +59,17 @@ The system SHALL provide a `MultiAgentSimulation` orchestrator that coordinates 
 
 ### Requirement: Social Proximity Detection
 
+The system SHALL count nearby agents per agent within `social_detection_radius` (Manhattan distance), excluding self and the "default" placeholder, counting frozen agents but not removed agents.
+
+#### Scenario: Proximity Counting
+
 - Nearby agents counted per agent within `social_detection_radius` (Manhattan distance)
 - Self excluded; "default" placeholder excluded
 - Frozen agents counted; removed agents not counted
 
 ### Requirement: Pheromone Emission in Step Loop
+
+The system SHALL emit pheromones during the step loop — food-marking on consumption, alarm on predator damage, and continuous aggregation — and SHALL update the pheromone fields once per step, with all emission and update behavior a no-op when the corresponding feature is disabled.
 
 #### Scenario: Food-Marking on Consumption
 
@@ -79,6 +89,8 @@ The system SHALL provide a `MultiAgentSimulation` orchestrator that coordinates 
 - `update_pheromone_fields(current_step)` called once per step; no-op when pheromones disabled
 
 ### Requirement: Social Feeding in Step Loop
+
+The system SHALL apply social feeding satiety-decay reduction during the step loop when social feeding is enabled and an agent has nearby agents, using the phenotype-appropriate multiplier and incrementing the `social_feeding_events` counter when applied.
 
 #### Scenario: Decay Reduction
 
@@ -177,9 +189,17 @@ The env-side `apply_predator_damage_for` applies a fixed damage tick without ide
 
 ### Requirement: CSV Export of Collective Metrics
 
+The system SHALL export collective metrics to `multi_agent_summary.csv` with the specified columns.
+
+#### Scenario: Summary CSV Columns
+
 - `multi_agent_summary.csv` columns include: run, total_food, competition_events, proximity_events, alive_at_end, mean_success, gini, social_feeding_events, aggregation_index, alarm_evasion_events, food_sharing_events
 
 ### Requirement: Agent Spawn Placement
+
+The system SHALL place agents using Poisson disk sampling with `min_agent_distance` separation, never spawning on food or predator positions, and SHALL fall back to random valid positions on dense grids.
+
+#### Scenario: Placement Strategy
 
 - Poisson disk sampling with `min_agent_distance` separation
 - No agent spawns on food or predator positions
@@ -187,9 +207,17 @@ The env-side `apply_predator_damage_for` applies a fixed damage tick without ide
 
 ### Requirement: Grid Size Validation
 
+The system SHALL enforce a minimum grid size of `max(5, ceil(5 * sqrt(num_agents)))`.
+
+#### Scenario: Minimum Grid Size
+
 - Minimum: `max(5, ceil(5 * sqrt(num_agents)))`
 
 ### Requirement: Reproducible Seeding
+
+The system SHALL derive deterministic per-agent sub-seeds via `blake2b(session_seed + agent_id)` so that runs are reproducible, including that the FIRST_ARRIVAL policy awards the same agent the same contested food across reruns.
+
+#### Scenario: Deterministic Seeding
 
 - Per-agent sub-seeds: `blake2b(session_seed + agent_id)` deterministic
 - FIRST_ARRIVAL policy: same agent wins same contested food across reruns
@@ -197,6 +225,8 @@ The env-side `apply_predator_damage_for` applies a fixed damage tick without ide
 ### Requirement: Territorial Index Metric
 
 MultiAgentEpisodeResult SHALL include a territorial index measuring spatial foraging specialization.
+
+#### Scenario: Territorial Index Computation
 
 - Gini coefficient of per-agent foraging spreads (mean Manhattan distance of food collection positions from centroid)
 - Value in \[0, 1\]: 0 = equal foraging patterns, 1 = maximal specialization
@@ -207,11 +237,17 @@ MultiAgentEpisodeResult SHALL include a territorial index measuring spatial fora
 
 MultiAgentEpisodeResult SHALL include an alarm response rate measuring causal reaction to alarm pheromone emissions.
 
+#### Scenario: Alarm Response Rate Computation
+
 - When alarm emitted at step T by agent A, count nearby agents (within `social_detection_radius`) that change direction within ALARM_RESPONSE_WINDOW (5) steps
 - Rate = direction changes / opportunities; 0.0 when no opportunities
 - Emitting agent excluded from response opportunities
 
 ### Requirement: CSV Export of Evaluation Metrics
+
+The system SHALL include the territorial-index, alarm-response-rate, and per-simulation evaluation columns in the exported CSV files.
+
+#### Scenario: Evaluation CSV Columns
 
 - `multi_agent_summary.csv` SHALL include `territorial_index` and `alarm_response_rate` columns
 - `simulation_results.csv` SHALL include `config_name`, `total_reward`, `success`, `satiety_remaining`, `foods_available` columns

--- a/openspec/specs/qef-brain/spec.md
+++ b/openspec/specs/qef-brain/spec.md
@@ -4,7 +4,7 @@
 
 Define the QEF (Quantum Entangled Features) brain architecture — an entangled PQC feature extractor with configurable cross-modal entanglement topology, hybrid input, learnable feature gating, and classical PPO actor-critic readout.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: QEF Circuit Construction
 

--- a/openspec/specs/qrc-brain/spec.md
+++ b/openspec/specs/qrc-brain/spec.md
@@ -4,7 +4,7 @@
 
 Define the requirements for the Quantum Reservoir Computing (QRC) brain architecture. QRC uses a fixed random quantum reservoir circuit to generate rich feature representations, with only a classical readout network trained via gradient descent. This architecture inherently avoids barren plateau issues that affect parameterized quantum circuits.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: QRC Brain Architecture
 

--- a/openspec/specs/qrh-brain/spec.md
+++ b/openspec/specs/qrh-brain/spec.md
@@ -1,12 +1,14 @@
-# qrh-brain Specification (Delta)
+# qrh-brain Specification
 
 ## Purpose
 
 Refactor QRHBrain to inherit from ReservoirHybridBase, extracting shared PPO readout infrastructure into the base class. No behavioral changes to QRH.
 
-## MODIFIED Requirements
+## Requirements
 
 ### Requirement: QRH Inheritance Refactor
+
+QRHBrain SHALL inherit from `ReservoirHybridBase` and QRHBrainConfig SHALL inherit from `ReservoirHybridBaseConfig`, with shared PPO readout infrastructure provided by the base classes while preserving identical behavior to the pre-refactor version.
 
 #### Scenario: QRH Inherits from ReservoirHybridBase
 

--- a/openspec/specs/qrh-qlstm-brain/spec.md
+++ b/openspec/specs/qrh-qlstm-brain/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# qrh-qlstm-brain Specification
+
+## Purpose
+
+Defines the `qrhqlstm` brain: a quantum reinforcement-learning agent that combines a fixed QRH quantum reservoir as a feature extractor with a QLIF-LSTM temporal readout and an actor-critic head trained via truncated-BPTT recurrent PPO. It specifies the brain's registration, configuration, architecture, training, and lifecycle so it can be selected and run from YAML config.
+
+## Requirements
 
 ### Requirement: QRH-QLSTM brain type registration
 

--- a/openspec/specs/qsnn-ppo-brain/spec.md
+++ b/openspec/specs/qsnn-ppo-brain/spec.md
@@ -6,7 +6,7 @@ Define the requirements for the QSNN-PPO brain architecture. QSNN-PPO pairs a Qu
 
 The QSNN actor reuses shared QLIF neuron infrastructure from `_qlif_layers.py`.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: QSNN-PPO Brain Architecture
 

--- a/openspec/specs/qsnn-reinforce-brain/spec.md
+++ b/openspec/specs/qsnn-reinforce-brain/spec.md
@@ -6,7 +6,7 @@ Define the requirements for the Quantum Spiking Neural Network (QSNN) brain arch
 
 The QSNN Reinforce variant (`QSNNReinforceBrain`) uses REINFORCE policy gradient with surrogate gradient backward pass. Shared QLIF neuron infrastructure is extracted into `_qlif_layers.py` for reuse by other QSNN variants.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: QSNN Brain Architecture
 

--- a/openspec/specs/short-term-associative-memory/spec.md
+++ b/openspec/specs/short-term-associative-memory/spec.md
@@ -1,6 +1,10 @@
 # short-term-associative-memory Specification
 
-## ADDED Requirements
+## Purpose
+
+Provide a short-term associative memory (STAM) that maintains an exponential-decay buffer of recent sensory readings, movements, and actions, and exposes a fixed-size memory state vector (weighted means, temporal derivatives, movement deltas, and action variety) for neural-network input via the sensory module framework.
+
+## Requirements
 
 ### Requirement: STAM Buffer Storage
 

--- a/openspec/specs/temporal-sensing/spec.md
+++ b/openspec/specs/temporal-sensing/spec.md
@@ -1,6 +1,10 @@
 # temporal-sensing Specification
 
-## ADDED Requirements
+## Purpose
+
+Enable biologically realistic temporal sensing by allowing each gradient-based modality (chemotaxis, thermotaxis, nociception, aerotaxis) to operate in oracle, temporal, or derivative mode, replacing spatial-gradient oracle inputs with scalar values and their temporal derivatives. This lets agents infer gradients from movement history while preserving backward compatibility and transparency across all brain architectures.
+
+## Requirements
 
 ### Requirement: Sensing Mode Selection
 


### PR DESCRIPTION
## Summary

Past `openspec archive` runs copied **delta** specs into the **main** specs verbatim, leaving delta-only headers (`## ADDED Requirements`, `## MODIFIED Requirement: X`, etc.) that are invalid in main specs. These headers truncate the parsed `## Requirements` section, so every requirement after them became invisible to `openspec validate`, `list`, and — critically — `archive`, which now **aborts** on the structural error. This blocks archiving *any* completed OpenSpec change.

This PR repairs all **18** affected main specs so every spec validates cleanly again. **Docs/spec hygiene only — no implementation or behaviour changes.**

## What was wrong (two layers)

1. **Structural:** stray delta-only headers in main specs (`## ADDED Requirements`, per-requirement `## ADDED/MODIFIED Requirement: X`, a leftover `(Delta)` title suffix, missing titles/`## Purpose`).
2. **Content (exposed once the structure was fixed):** requirements with no normative SHALL/MUST sentence, or scenario bullets not wrapped in a `#### Scenario:` level-4 header.

## What changed

- **12 brain specs** (crh, crh-qlstm, qrh, qrh-qlstm, qef, qrc, qsnn-ppo, qsnn-reinforce, hybrid-quantum, lstm-ppo, short-term-associative-memory, temporal-sensing): header renames + missing `## Purpose`/title additions; `qrh-brain` needed one synthesized SHALL sentence.
- **3 specs** (klinotaxis-sensing, multi-agent-visualization, food-spatial-persistence): consolidated per-requirement delta headers under one `## Requirements`, wrapped bullet bodies in `#### Scenario:` blocks with bolded WHEN/THEN/AND, added faithful SHALL sentences.
- **3 specs** (multi-agent, configuration-system, environment-simulation): added missing SHALL sentences + scenario wrappers to requirements that the structural bug had hidden.

## Faithfulness

- Every synthesized SHALL sentence is a summary of the requirement's **own** title + existing bullets — no new behaviour introduced.
- Automated check: **zero** backtick-quoted code identifiers / formulas / values dropped from any spec.
- Descriptive→normative conversions are minimal, e.g. `Dynamic pheromone concentration fields…` → `The environment SHALL provide dynamic pheromone concentration fields…`.

## Verification

- All **38** main specs now report `is valid` (full sweep).
- Full `pre-commit run` green (mdformat / markdownlint / tests).

## Why now

Surfaced while trying to archive `add-continuous-2d-and-action-heads` (Phase 6 T5). This unblocks that archive (separate follow-up PR) and every future archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded multi-agent configuration specifications, including visualization, metrics export, and social interaction mechanics
  * Added support for new brain architectures: LSTM-PPO, CRH-QLSTM, and QRH-QLSTM
  * Enhanced sensing modes with klinotaxis and improved temporal sensing capabilities
  * Detailed food spawning behavior with hotspot biasing and satiety-gated consumption rules
  * Clarified multi-agent evaluation metrics, agent placement strategies, and pheromone subsystem behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->