### PR TITLE
chore: generalise pre-existing roadmap-ish labels in implementation

### DIFF
--- a/packages/quantum-nematode/quantumnematode/brain/arch/_reservoir_lstm_base.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/_reservoir_lstm_base.py
@@ -796,12 +796,12 @@ class ReservoirLSTMBase(ClassicalBrain, abc.ABC):
 
         ep = self._episode_count
 
-        # Phase 1: Warmup
+        # Stage 1: Warmup
         if self.lr_warmup_episodes and ep < self.lr_warmup_episodes:
             progress = ep / self.lr_warmup_episodes
             return self.lr_warmup_start + progress * (self.base_actor_lr - self.lr_warmup_start)
 
-        # Phase 2: Decay (offset by warmup duration)
+        # Stage 2: Decay (offset by warmup duration)
         if self.lr_decay_episodes is not None:
             warmup = self.lr_warmup_episodes or 0
             decay_ep = ep - warmup

--- a/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/hybridquantumcortex.py
@@ -9,7 +9,7 @@ expressivity.
 
 Status: HALTED after 9 rounds (32 sessions, 14,600 episodes). The QSNN cortex
 under REINFORCE with surrogate gradients hit a ~40-45% ceiling on 2-predator
-pursuit. See logbook 008 for full evaluation.
+pursuit.
 
 Architecture::
 

--- a/packages/quantum-nematode/quantumnematode/brain/arch/lstmppo.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/lstmppo.py
@@ -1381,12 +1381,12 @@ class LSTMPPOBrain(ClassicalBrain):
 
         ep = self._episode_count
 
-        # Phase 1: Warmup
+        # Stage 1: Warmup
         if self.lr_warmup_episodes and ep < self.lr_warmup_episodes:
             progress = ep / self.lr_warmup_episodes
             return self.lr_warmup_start + progress * (self.base_actor_lr - self.lr_warmup_start)
 
-        # Phase 2: Decay (offset by warmup duration)
+        # Stage 2: Decay (offset by warmup duration)
         if self.lr_decay_episodes is not None:
             warmup = self.lr_warmup_episodes or 0
             decay_ep = ep - warmup

--- a/packages/quantum-nematode/quantumnematode/brain/arch/qliflstm.py
+++ b/packages/quantum-nematode/quantumnematode/brain/arch/qliflstm.py
@@ -1205,12 +1205,12 @@ class QLIFLSTMBrain(ClassicalBrain):
 
         ep = self._episode_count
 
-        # Phase 1: Warmup
+        # Stage 1: Warmup
         if self.lr_warmup_episodes and ep < self.lr_warmup_episodes:
             progress = ep / self.lr_warmup_episodes
             return self.lr_warmup_start + progress * (self.base_actor_lr - self.lr_warmup_start)
 
-        # Phase 2: Decay (offset by warmup duration)
+        # Stage 2: Decay (offset by warmup duration)
         if self.lr_decay_episodes is not None:
             warmup = self.lr_warmup_episodes or 0
             decay_ep = ep - warmup


### PR DESCRIPTION
Small docs-only cleanup (no functional change) — removes ambiguous/planning labels from shipped docstrings/comments, per the convention that roadmap/tracking labels belong in planning artefacts, not implementation code.

## Changes
- LR / entropy schedule comments `# Phase 1: Warmup` / `# Phase 2: Decay` → `# Stage 1` / `# Stage 2` in `brain/arch/lstmppo.py`, `qliflstm.py`, `_reservoir_lstm_base.py`. (These were *algorithmic* stages, not roadmap phases — but "Phase" is the ambiguous term to avoid.)
- `brain/arch/hybridquantumcortex.py` module docstring: dropped the `See logbook 008 for full evaluation.` planning-artefact reference.

## Context
These pre-existing references were surfaced while reviewing the Phase-6-T6 implementation (PR #219). Split into this separate PR to keep that change scoped to its own work.

Lint green (ruff / pyright / pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal refactoring of brain architecture components with improved comment clarity for learning-rate scheduling phases.
  
* **Chores**
  * Updated module documentation and removed outdated reference text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->