### PR TITLE
openspec: continuous-substrate fidelity renderer (plan)

### DIFF
--- a/openspec/changes/add-continuous-fidelity-renderer/.openspec.yaml
+++ b/openspec/changes/add-continuous-fidelity-renderer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/add-continuous-fidelity-renderer/design.md
+++ b/openspec/changes/add-continuous-fidelity-renderer/design.md
@@ -1,0 +1,133 @@
+## Context
+
+The continuous-2D environment (`env/continuous_2d.py`) stores the worm's float truth in
+`AgentState.pos_continuous` + `heading_rad`, float `env.foods`, and a `Continuous2DParams`
+(`world_size_mm` default 50; `grid_size = round(world_size_mm)`). All field getters
+(`get_food_concentration`, `get_predator_concentration`, `get_temperature`,
+`get_oxygen_concentration`, `get_separated_gradients`, pheromone) now accept real-valued
+positions. The adaptive sensor lives on the agent (`agent._adaptive_food`) with a private
+`_integrator.background`. The klinotaxis head-sweep sample points are produced by the pure
+function `agent._continuous_lateral_offsets(pos, heading_rad, sweep, grid_size)`.
+
+The existing pygame renderer (`env/pygame_renderer.py`) is grid-coupled: `render_frame` and
+every `_render_*` method use an integer **scrolling** viewport and
+`_cell_to_pixel(grid_x:int, grid_y:int, viewport)` (y inverted over a cell count). It was made
+float-safe for T6 only by snapping continuous state to cells. The multi-agent path already
+demonstrates the clean decoupling pattern: a frozen `AgentRenderState` snapshot built by the
+orchestrator, so the renderer never reads agent internals.
+
+`pygame` (optional `pixel` extra) and `matplotlib` (main dep) are already available;
+`imageio`/`ffmpeg` are not.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A continuous-substrate pygame renderer with sub-cell worm motion, a full-arena plate view,
+  configurable zoom, and at least full feature-parity with the grid renderer.
+- Four fidelity overlays (concentration heatmap, gradient quiver, klinotaxis + predator sensor
+  zones, adaptive-sensor readout).
+- Decoupling from agent internals via a frozen render-state snapshot + a public adaptive
+  accessor.
+- Single-frame PNG export + offline matplotlib figure helpers (trajectory / heatmap / quiver).
+
+**Non-Goals:**
+
+- gif/mp4 animation export (would add a media-encoding dependency) — deferred.
+- Multi-agent-continuous rendering — deferred (needs a parallel snapshot builder in
+  `multi_agent.py`).
+- Any change to the grid `PygameRenderer` behaviour (it stays byte-unchanged), the headless
+  path, 3D, or a web/game-engine stack.
+
+## Decisions
+
+### D1 — A sibling `Continuous2DRenderer`, not a subclass; a `world→pixel` map, not an extended `_cell_to_pixel`
+
+`PygameRenderer`'s methods are hardwired to the integer scrolling viewport and the cell-count
+y-inversion. Subclassing would force fragile overrides of nearly every method. Instead add a
+**sibling** `Continuous2DRenderer` in the same module that reuses the module-level helpers
+(`create_sprites`, `create_zone_overlay`, `draw_body_segment`, the status-bar text logic) and
+provides its own `_world_to_pixel(x, y)`:
+
+```text
+px = x * pixels_per_mm
+py = (world_size_mm - y) * pixels_per_mm   # y-up → y-down over the world height
+```
+
+The view is the **whole arena** (no agent-following scroll — the worm is a point on a plate),
+window = `world_size_mm * pixels_per_mm` square + `STATUS_BAR_HEIGHT`. `pixels_per_mm` is a
+constructor arg (default ~12 → a 600×600 plate) so zoom is tunable. **Alternative rejected:**
+extending `_cell_to_pixel` to accept floats — it still carries the scrolling-viewport semantics
+that are wrong for a plate view.
+
+### D2 — Concentration heatmap via field-sampling + matplotlib colormap + `surfarray`
+
+Sample the selected field getter over an N×N lattice spanning the arena, normalise, apply a
+`matplotlib.cm` colormap → RGBA uint8 array → `pygame.surfarray.make_surface` → scale to the
+window → alpha-blit. This is the dense-array analogue of the existing per-cell alpha-blit
+pattern (`_render_temperature_zones`, `_render_pheromone_overlay`). N is configurable (default
+~64) to bound the per-frame field-call cost. The field is selectable (food default; also
+predator / temperature / oxygen / pheromone). **Note:** the heatmap (raw field value) and the
+ported categorical *zone* bands (comfort/danger) are complementary and both selectable, so they
+don't collide by default.
+
+### D3 — Decouple via a frozen `ContinuousRenderState` snapshot + a public adaptive accessor
+
+Mirror the `AgentRenderState` pattern. Add a frozen `ContinuousRenderState` dataclass holding
+`pos`, `heading_rad`, `left_sample`/`right_sample` (klinotaxis), `sweep`, `adaptive_background`,
+`adaptive_readout`, `adaptive_mode`, and the existing status fields. The **agent** builds it in
+`_render_step_continuous` (calling `_continuous_lateral_offsets` itself, reading the adaptive
+state via a new public accessor). The renderer reads only the snapshot + `env` (for
+fields/foods/predators) — never `agent` privates. To avoid reaching into `_integrator`, add a
+public `AdaptiveChemosensor.background` property (delegating to the already-public
+`LeakyIntegrator.background`) and a `last_readout` field set in `adapt()`.
+
+### D4 — Gradient quiver is coarse + keyboard-toggleable, off by default
+
+A full-resolution quiver would issue O(N²) field calls per frame at 30 FPS. Use a coarse
+lattice (e.g. 12×12) and gate it behind a keyboard toggle (mirroring the existing pheromone
+`P`-key toggle), default off, so the live path stays responsive.
+
+### D5 — PNG + matplotlib figures now; gif/mp4 deferred
+
+Ship a single-frame continuous PNG (extend `scripts/export_screenshot.py` with an
+`SDL_VIDEODRIVER=dummy` headless capture) and a new `report/continuous_figures.py`
+(`plot_trajectory`, `plot_field_heatmap` via `imshow`, `plot_gradient_quiver` via matplotlib
+`quiver`) — the offline analogue of the live overlays, used for logbook/validation figures.
+matplotlib is already a dep, so no new dependency. gif/mp4 (needs `imageio`) is deferred to a
+follow-up.
+
+### D6 — Theme selection via a new `Theme.PIXEL_CONTINUOUS` value
+
+An explicit new enum value (plus a `--theme pixel_continuous` choice and a render-dispatch
+branch in `agent.py`) is discoverable and matches the existing theme selection axis.
+**Alternative rejected:** auto-detecting the continuous env under `PIXEL` — implicit, couples
+renderer choice to env type. The renderer is action-mode-agnostic (reads `pos_continuous`,
+populated on both discrete and continuous-action paths).
+
+## Risks / Trade-offs
+
+- **Heatmap/quiver per-frame cost** (N² field calls) → bound N (heatmap ~64, quiver ~12), make
+  quiver toggle-off-by-default; the heatmap can also be a keyboard toggle.
+- **pygame video backend in CI** → tests use `SDL_VIDEODRIVER=dummy` + the existing
+  `requires_pygame` skip guard (as `test_multi_agent_renderer.py` / `export_screenshot.py` do).
+- **Drift from the grid renderer** (two renderers to maintain) → reuse the shared module
+  helpers (`create_sprites`/`create_zone_overlay`/`draw_body_segment`/status logic) rather than
+  duplicating; the grid renderer is untouched.
+- **Snapshot vs live state** → the snapshot is rebuilt every render step from current agent/env
+  state, so it can't go stale within a frame.
+
+## Migration Plan
+
+- Purely additive: new theme value, new renderer class, new snapshot/accessor, new figure
+  module. Existing `PIXEL`/`headless`/text themes and the grid renderer are unchanged.
+- Rollback: `--theme pixel`/`headless` continue to work exactly as before.
+
+## Open Questions
+
+- **Zoom config location** — `pixels_per_mm` on the renderer constructor (renderer-local) vs on
+  `Continuous2DParams` (config-exposed). Lean renderer-local with an optional config override;
+  decide during implementation (affects whether `continuous-2d-environment` is a modified
+  capability).
+- **Heatmap default field + colormap** — food + a perceptually-uniform map (viridis);
+  finalise during implementation.

--- a/openspec/changes/add-continuous-fidelity-renderer/design.md
+++ b/openspec/changes/add-continuous-fidelity-renderer/design.md
@@ -52,7 +52,6 @@ y-inversion. Subclassing would force fragile overrides of nearly every method. I
 renderer re-implements them in continuous coordinates (the status-bar field-formatting can be
 extracted to a shared free function to avoid divergence; the zone overlays become arena-region
 fills rather than the grid's 32×32 per-cell blits). It provides its own `_world_to_pixel(x, y)`:
-provides its own `_world_to_pixel(x, y)`:
 
 ```text
 px = x * pixels_per_mm

--- a/openspec/changes/add-continuous-fidelity-renderer/design.md
+++ b/openspec/changes/add-continuous-fidelity-renderer/design.md
@@ -45,8 +45,13 @@ orchestrator, so the renderer never reads agent internals.
 
 `PygameRenderer`'s methods are hardwired to the integer scrolling viewport and the cell-count
 y-inversion. Subclassing would force fragile overrides of nearly every method. Instead add a
-**sibling** `Continuous2DRenderer` in the same module that reuses the module-level helpers
-(`create_sprites`, `create_zone_overlay`, `draw_body_segment`, the status-bar text logic) and
+**sibling** `Continuous2DRenderer` in the same module. It reuses the module-level helper
+*functions* (`create_sprites`, `draw_body_segment`, and the `create_zone_overlay` zone
+*colours*); the status bar and zone overlays are renderer *methods* on `PygameRenderer`
+(`_render_status_bar`, `_render_temperature_zones`, …) — not free helpers — so the continuous
+renderer re-implements them in continuous coordinates (the status-bar field-formatting can be
+extracted to a shared free function to avoid divergence; the zone overlays become arena-region
+fills rather than the grid's 32×32 per-cell blits). It provides its own `_world_to_pixel(x, y)`:
 provides its own `_world_to_pixel(x, y)`:
 
 ```text
@@ -66,7 +71,11 @@ Sample the selected field getter over an N×N lattice spanning the arena, normal
 `matplotlib.cm` colormap → RGBA uint8 array → `pygame.surfarray.make_surface` → scale to the
 window → alpha-blit. This is the dense-array analogue of the existing per-cell alpha-blit
 pattern (`_render_temperature_zones`, `_render_pheromone_overlay`). N is configurable (default
-~64) to bound the per-frame field-call cost. The field is selectable (food default; also
+~64) to bound the per-frame field-call cost. **Caching:** an N×N lattice is ~N² field calls per
+frame, each summing over all sources — too much at 30 FPS to recompute every frame. The field
+is static within an episode except when sources change (food consumed/respawned, predators
+move), so **cache the sampled lattice and recompute only on a source-change signal** (or on a
+coarse cadence / the selected-field switch). The field is selectable (food default; also
 predator / temperature / oxygen / pheromone). **Note:** the heatmap (raw field value) and the
 ported categorical *zone* bands (comfort/danger) are complementary and both selectable, so they
 don't collide by default.
@@ -82,11 +91,17 @@ fields/foods/predators) — never `agent` privates. To avoid reaching into `_int
 public `AdaptiveChemosensor.background` property (delegating to the already-public
 `LeakyIntegrator.background`) and a `last_readout` field set in `adapt()`.
 
-### D4 — Gradient quiver is coarse + keyboard-toggleable, off by default
+### D4 — Gradient quiver is coarse + keyboard-toggleable, off by default; the continuous renderer needs its own keyboard event handling
 
 A full-resolution quiver would issue O(N²) field calls per frame at 30 FPS. Use a coarse
-lattice (e.g. 12×12) and gate it behind a keyboard toggle (mirroring the existing pheromone
-`P`-key toggle), default off, so the live path stays responsive.
+lattice (e.g. 12×12), default off, gated behind a keyboard toggle.
+
+**Caveat:** the keyboard-toggle the grid renderer has (the pheromone `P`-key) lives only in the
+**multi-agent** event pump (`_pump_multi_agent_events`); the **single-agent** path
+(`render_frame` / `pump_events`) only handles window-close. So the continuous (single-agent)
+renderer must **add its own keyboard event handling** — this is new code, not a reuse: a key
+toggle for the quiver, and (optionally) keys to switch the heatmap field and toggle the heatmap.
+The window-close handling can follow the existing `pump_events` shape.
 
 ### D5 — PNG + matplotlib figures now; gif/mp4 deferred
 

--- a/openspec/changes/add-continuous-fidelity-renderer/proposal.md
+++ b/openspec/changes/add-continuous-fidelity-renderer/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The continuous-2D substrate shipped its physics (float sources, Euclidean/continuous-field sensing, static Fick-shaped gradient geometry, the adaptive/biphasic chemosensory sensor), but the **fidelity renderer was deferred as a non-gating seed**. Today the only way to watch a continuous run is the existing pygame `PIXEL` renderer, which was merely made *float-safe* — it **snaps the continuous worm and sources to integer cells** and shows **none of the new fidelity** (no concentration field, no gradient geometry, no sensor state). So the substrate that the architecture comparison will run on cannot be visually inspected, demonstrated, or turned into the spatial figures the upcoming real-worm behavioural validation needs.
+
+This change builds a proper continuous-substrate renderer: sub-cell worm motion on a full-arena plate view, with the chemosensory fidelity (concentration heatmap, gradient field, sensor zones, adaptive-sensor state) overlaid — and the offline matplotlib figures (trajectory / field / quiver) for logbooks.
+
+## What Changes
+
+- **A `Continuous2DRenderer`** (sibling of the existing `PygameRenderer`) that renders the continuous-2D arena at sub-cell fidelity via a `world→pixel` map with a configurable pixels-per-mm zoom and a **full-arena, non-scrolling** view. The worm renders as a point + heading line (continuous `heading_rad`).
+- **Feature parity** with the grid renderer, ported to continuous coordinates: background, temperature zones, oxygen zones, stationary-predator toxic zones, and the full status bar — nothing the grid theme shows is lost.
+- **Four new fidelity overlays:** a **concentration-field heatmap** (selectable field; matplotlib colormap via `surfarray`), a **gradient quiver** (coarse-grid arrows; keyboard-toggleable, off by default for perf), **klinotaxis sensor zones** (the head-sweep sample points) + **predator detection/damage rings**, and an **adaptive-sensor readout** (background, readout, mode) in the status bar.
+- **A new `Theme.PIXEL_CONTINUOUS`** value selecting the renderer (explicit `--theme pixel_continuous`).
+- **Clean state exposure:** a frozen `ContinuousRenderState` snapshot (mirroring the existing `AgentRenderState` decoupling pattern) + a public `AdaptiveChemosensor.background` accessor, so the renderer never reaches into agent internals.
+- **Static figure helpers** (`report/continuous_figures.py`: trajectory / field heatmap / gradient quiver) for logbook/validation figures, and a continuous **PNG** export path in `scripts/export_screenshot.py`.
+- **Out of scope (deferred):** gif/mp4 animation export (would add an `imageio`/`ffmpeg` dependency) and the **multi-agent** continuous render path (needs a parallel snapshot builder) — both documented as follow-ups.
+
+## Capabilities
+
+### New Capabilities
+
+- `continuous-fidelity-renderer`: A pygame renderer for the continuous-2D substrate — `world→pixel` sub-cell mapping with a full-arena view and configurable zoom; grid-renderer feature parity (background, temperature/oxygen/toxic zones, status bar) ported to continuous coordinates; and four fidelity overlays (concentration heatmap, gradient quiver, klinotaxis + predator sensor zones, adaptive-sensor readout). Selected via `Theme.PIXEL_CONTINUOUS`; fed a frozen `ContinuousRenderState` snapshot so it stays decoupled from agent internals. Includes a single-frame PNG export and offline matplotlib figure helpers.
+
+### Modified Capabilities
+
+None. The pixels-per-mm zoom is renderer-local (a `Continuous2DRenderer` constructor argument), so no existing capability's requirements change. If a follow-up exposes the zoom on `Continuous2DParams`, that becomes a small `continuous-2d-environment` amendment then.
+
+## Impact
+
+- **Code:** new `env/pygame_renderer.py` `Continuous2DRenderer` + `ContinuousRenderState`; `env/theme.py` (`PIXEL_CONTINUOUS`); `agent/agent.py` render dispatch + `_render_step_continuous` snapshot builder; `agent/adaptive_sensor.py` public `background` + `last_readout`; `scripts/run_simulation.py` (`--theme` choice + selection); `scripts/export_screenshot.py` (continuous PNG); new `report/continuous_figures.py`.
+- **Dependencies:** none new — `pygame` (the optional `pixel` extra) and `matplotlib` (main dep) are already present; `imageio`/`ffmpeg` are explicitly deferred.
+- **Substrate / brains:** the existing grid `PygameRenderer` is byte-unchanged; the renderer is action-mode-agnostic (reads `pos_continuous`/`heading_rad`, populated on both discrete and continuous-action paths). Headless/batch runs are unaffected.
+- **Cross-tranche:** realises the deferred `T6.render` seed and produces the spatial figures the real-worm behavioural validation (next L2 pass) references.
+- **Out of scope:** gif/mp4 export, multi-agent-continuous rendering, a web/game-engine stack (against the batch/headless/reproducibility posture).

--- a/openspec/changes/add-continuous-fidelity-renderer/specs/continuous-fidelity-renderer/spec.md
+++ b/openspec/changes/add-continuous-fidelity-renderer/specs/continuous-fidelity-renderer/spec.md
@@ -1,0 +1,164 @@
+## ADDED Requirements
+
+### Requirement: Continuous renderer selection
+
+The system SHALL provide a `Theme.PIXEL_CONTINUOUS` theme that selects a continuous-substrate
+renderer for the continuous-2D environment, alongside the existing themes. The grid `PIXEL`
+renderer and the `HEADLESS` path SHALL be unaffected.
+
+#### Scenario: Continuous theme selected
+
+- **WHEN** a single-agent simulation on a continuous-2D environment runs with `--theme pixel_continuous`
+- **THEN** the system SHALL create the continuous renderer (`Continuous2DRenderer`) and render each step against it
+
+#### Scenario: Existing themes unchanged
+
+- **WHEN** a simulation runs with `--theme pixel` or `--theme headless`
+- **THEN** the grid `PygameRenderer` / headless behaviour SHALL be byte-unchanged from before this capability
+
+### Requirement: World-to-pixel mapping with full-arena view and zoom
+
+The continuous renderer SHALL map real-valued world coordinates (millimetres) to pixels via a
+`world→pixel` transform with a configurable pixels-per-mm zoom, render the **whole arena**
+without an agent-following scroll, and invert the y-axis (world y-up → screen y-down) over the
+world height. The worm SHALL be drawn at its real-valued `pos_continuous` (sub-cell), not
+snapped to a grid cell.
+
+#### Scenario: Sub-cell position mapping
+
+- **WHEN** the worm is at a fractional position (e.g. `(10.4, 20.7)` mm)
+- **THEN** it SHALL be drawn at the corresponding sub-cell pixel location (not rounded to a cell)
+
+#### Scenario: Full arena visible
+
+- **WHEN** the renderer is created for a `world_size_mm` arena
+- **THEN** the drawing surface SHALL span the whole arena (`world_size_mm * pixels_per_mm` per side, plus the status bar) with no scrolling viewport
+
+### Requirement: Grid-renderer feature parity
+
+The continuous renderer SHALL render, in continuous coordinates, every layer the grid pixel
+renderer shows so no information is lost: the background, the temperature comfort/danger zone
+overlays, the oxygen zone overlays, the stationary-predator toxic (damage-radius) zone, the
+food and predator sprites, the worm, and the full status bar (step, food, HP, satiety,
+danger state, temperature + zone, oxygen + zone).
+
+#### Scenario: Parity overlays render
+
+- **WHEN** a continuous run has thermotaxis, aerotaxis, or stationary predators enabled
+- **THEN** the corresponding temperature-zone, oxygen-zone, and toxic-zone overlays SHALL render in continuous coordinates with the same categorical colours as the grid renderer
+
+#### Scenario: Status bar parity
+
+- **WHEN** the continuous renderer draws the status bar
+- **THEN** it SHALL show the same fields as the grid renderer's status bar (step/max, food/target, HP, satiety, danger state, temperature + zone name, oxygen + zone name)
+
+### Requirement: Worm rendering with continuous heading
+
+The continuous renderer SHALL draw the worm as a marker at `pos_continuous` plus a heading
+indicator derived from the continuous `heading_rad` (rather than the grid renderer's four-way
+`Direction` head sprite).
+
+#### Scenario: Heading indicator follows continuous heading
+
+- **WHEN** the worm has heading `heading_rad`
+- **THEN** the heading indicator SHALL point along `heading_rad` and rotate smoothly as the heading changes
+
+### Requirement: Concentration-field heatmap overlay
+
+The continuous renderer SHALL provide a concentration-field heatmap that samples a selectable
+field getter over a lattice spanning the arena, maps values through a colormap, and alpha-blits
+the result. The default field SHALL be the food concentration; predator / temperature / oxygen
+/ pheromone fields SHALL be selectable. The lattice resolution SHALL be bounded so the
+per-frame cost stays acceptable.
+
+#### Scenario: Food heatmap by default
+
+- **WHEN** the heatmap overlay is enabled
+- **THEN** it SHALL sample `get_food_concentration` over the arena lattice and render a colormapped, alpha-blended field showing the gradient geometry (e.g. Fick vs exponential)
+
+#### Scenario: Selectable field
+
+- **WHEN** a different field (predator / temperature / oxygen / pheromone) is selected for the heatmap
+- **THEN** the heatmap SHALL sample that field's getter instead
+
+### Requirement: Gradient quiver overlay
+
+The continuous renderer SHALL provide a gradient-vector (quiver) overlay sampling the gradient
+on a coarse lattice and drawing up-gradient arrows whose length reflects gradient strength. It
+SHALL be keyboard-toggleable and default to off to keep the live render responsive.
+
+#### Scenario: Quiver toggled on
+
+- **WHEN** the quiver overlay is toggled on
+- **THEN** the renderer SHALL draw coarse-lattice arrows from `get_separated_gradients` pointing up-gradient, scaled by gradient strength
+
+#### Scenario: Quiver off by default
+
+- **WHEN** the renderer starts
+- **THEN** the quiver overlay SHALL be off until toggled
+
+### Requirement: Sensor-zone overlays
+
+The continuous renderer SHALL draw the klinotaxis head-sweep sample points (left/right,
+perpendicular to heading at the configured sweep amplitude) and predator detection/damage
+range rings around each predator.
+
+#### Scenario: Klinotaxis sample points
+
+- **WHEN** klinotaxis sensing is active
+- **THEN** the renderer SHALL draw the left and right head-sweep sample points relative to the worm's heading and sweep amplitude
+
+#### Scenario: Predator range rings
+
+- **WHEN** predators are present
+- **THEN** the renderer SHALL draw detection-radius and damage-radius rings around each predator at the world-scaled radii
+
+### Requirement: Adaptive-sensor readout
+
+When the adaptive chemosensory sensor is enabled, the continuous renderer SHALL display its
+state — the tracked background, the current readout value, and the readout mode — in the status
+bar.
+
+#### Scenario: Adaptive readout shown
+
+- **WHEN** the adaptive sensor is enabled
+- **THEN** the status bar SHALL include the tracked background, the current readout, and the readout mode (e.g. fold_change / contrast / log)
+
+#### Scenario: Adaptive disabled
+
+- **WHEN** the adaptive sensor is disabled
+- **THEN** the adaptive readout SHALL be omitted (no error)
+
+### Requirement: Decoupled render-state snapshot
+
+The continuous renderer SHALL be fed a frozen render-state snapshot (`ContinuousRenderState`)
+built by the agent/orchestrator each step, and SHALL read only that snapshot and the
+environment (for fields, food, and predators) — never the agent's internal sensor objects. A
+public accessor SHALL expose the adaptive sensor's tracked background so the snapshot builder
+does not reach into private integrator state.
+
+#### Scenario: Renderer reads only the snapshot + env
+
+- **WHEN** the renderer renders a frame
+- **THEN** it SHALL obtain worm pose, klinotaxis sample points, and adaptive-sensor state from the `ContinuousRenderState` snapshot, not from agent private attributes
+
+#### Scenario: Public adaptive accessor
+
+- **WHEN** the snapshot is built
+- **THEN** the adaptive background SHALL be read via a public accessor on the adaptive sensor (not its private integrator)
+
+### Requirement: Continuous frame export and offline figures
+
+The change SHALL provide a single-frame PNG export of a continuous render (headless-capable via
+a dummy SDL video driver) and offline matplotlib figure helpers — trajectory, field heatmap,
+and gradient quiver — for logbook/validation figures. Animated (gif/mp4) export is out of scope.
+
+#### Scenario: PNG export
+
+- **WHEN** the continuous screenshot export is run
+- **THEN** it SHALL render one continuous frame headlessly and save it as a PNG
+
+#### Scenario: Offline figures
+
+- **WHEN** an offline figure helper is called with a continuous environment / trajectory
+- **THEN** it SHALL produce the corresponding matplotlib figure (trajectory, field heatmap, or gradient quiver) without requiring a display

--- a/openspec/changes/add-continuous-fidelity-renderer/tasks.md
+++ b/openspec/changes/add-continuous-fidelity-renderer/tasks.md
@@ -16,16 +16,17 @@ export/figures, then tests.
 ## 2. Continuous renderer skeleton + grid-renderer parity
 
 - [ ] 2.1 New sibling `Continuous2DRenderer` (`env/pygame_renderer.py`): `__init__(world_size_mm, pixels_per_mm=~12, ...)`, full-arena window sizing, `_world_to_pixel(x, y)` (mm→pixel, y-inversion). Grid `PygameRenderer` byte-unchanged.
-- [ ] 2.2 Parity layers ported to continuous coords, reusing the shared module helpers: background; temperature zones; oxygen zones; stationary-predator toxic zones; the full status bar (`_render_status_bar` fields). Reuse `create_zone_overlay` colours + the status-bar text logic.
+- [ ] 2.2 Parity layers ported to continuous coords: background; temperature zones; oxygen zones; stationary-predator toxic zones; the full status bar. Reuse `create_zone_overlay` *colours* (zone overlays become arena-region fills, not 32×32 cell blits); the status bar + zone overlays are `PygameRenderer` *methods*, so re-implement them for continuous coords (optionally extract the status-bar field-formatting to a shared free function to avoid divergence).
 - [ ] 2.3 Entities: food + predator sprites blit centered at `_world_to_pixel`; the worm as a marker + heading line from `heading_rad`.
 - [ ] 2.4 `agent/agent.py`: render-dispatch branch for `Theme.PIXEL_CONTINUOUS` → `_get_continuous_renderer()` + `_render_step_continuous()` (builds the `ContinuousRenderState` snapshot — calls `_continuous_lateral_offsets`, reads the adaptive accessor). Mirrors `_get_pygame_renderer`/`_render_step_pygame`.
 
 ## 3. Fidelity overlays
 
-- [ ] 3.1 Concentration heatmap: sample a selectable field getter over an N×N lattice (default food, N~64) → `matplotlib.cm` colormap → `pygame.surfarray` surface → scaled alpha-blit. Bounded N; keyboard-selectable field.
-- [ ] 3.2 Gradient quiver: coarse lattice (~12×12) → `get_separated_gradients` arrows scaled by strength; keyboard-toggle (mirror the pheromone `P` toggle), default off.
+- [ ] 3.1 Concentration heatmap: sample a selectable field getter over an N×N lattice (default food, N~64) → `matplotlib.cm` colormap → `pygame.surfarray` surface → scaled alpha-blit. **Cache the sampled lattice** and recompute only on a source-change signal (food consumed/respawned, predators moved) or a field-selector switch — not every frame.
+- [ ] 3.2 Gradient quiver: coarse lattice (~12×12) → `get_separated_gradients` arrows scaled by strength; default off.
 - [ ] 3.3 Sensor zones: klinotaxis left/right sample points (from the snapshot) + sweep marker; predator detection/damage rings (`pygame.draw.circle` at radius·zoom); optional contact cone.
 - [ ] 3.4 Adaptive-sensor readout appended to the status bar (background, readout, mode) from the snapshot.
+- [ ] 3.5 **Keyboard + window event handling for the continuous renderer** (NEW — the single-agent renderer has none today; the grid pheromone `P`-toggle is multi-agent-only): window-close (follow the existing `pump_events` shape) + a quiver toggle key + optional heatmap-toggle / field-selector keys.
 
 ## 4. Export + offline figures
 

--- a/openspec/changes/add-continuous-fidelity-renderer/tasks.md
+++ b/openspec/changes/add-continuous-fidelity-renderer/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Continuous-Substrate Fidelity Renderer
+
+Implements the `add-continuous-fidelity-renderer` change. Realises the deferred
+`phase6-tracking` **T6.render** seed (non-gating). Single-agent only; multi-agent-continuous +
+gif/mp4 export are documented follow-ups. Order is dependency-first: selection + decoupling
+scaffolding, then the renderer skeleton + parity layers, then the fidelity overlays, then
+export/figures, then tests.
+
+## 1. Theme selection + decoupled state scaffolding
+
+- [ ] 1.1 Add `Theme.PIXEL_CONTINUOUS` to `env/theme.py` (+ a `THEME_SYMBOLS` entry mirroring the `PIXEL` block).
+- [ ] 1.2 Add `pixel_continuous` to the `scripts/run_simulation.py` `--theme` choices + the renderer-selection branch (single-agent path).
+- [ ] 1.3 Add a public `AdaptiveChemosensor.background` property (delegating to `LeakyIntegrator.background`) + a `last_readout` field set in `adapt()` (`agent/adaptive_sensor.py`).
+- [ ] 1.4 Add a frozen `ContinuousRenderState` dataclass (`env/pygame_renderer.py`): `pos`, `heading_rad`, `left_sample`/`right_sample`, `sweep`, `adaptive_background`/`adaptive_readout`/`adaptive_mode`, + status fields (HP, satiety, foods_collected/target, in_danger, temperature + zone, oxygen + zone, step/max).
+
+## 2. Continuous renderer skeleton + grid-renderer parity
+
+- [ ] 2.1 New sibling `Continuous2DRenderer` (`env/pygame_renderer.py`): `__init__(world_size_mm, pixels_per_mm=~12, ...)`, full-arena window sizing, `_world_to_pixel(x, y)` (mm→pixel, y-inversion). Grid `PygameRenderer` byte-unchanged.
+- [ ] 2.2 Parity layers ported to continuous coords, reusing the shared module helpers: background; temperature zones; oxygen zones; stationary-predator toxic zones; the full status bar (`_render_status_bar` fields). Reuse `create_zone_overlay` colours + the status-bar text logic.
+- [ ] 2.3 Entities: food + predator sprites blit centered at `_world_to_pixel`; the worm as a marker + heading line from `heading_rad`.
+- [ ] 2.4 `agent/agent.py`: render-dispatch branch for `Theme.PIXEL_CONTINUOUS` → `_get_continuous_renderer()` + `_render_step_continuous()` (builds the `ContinuousRenderState` snapshot — calls `_continuous_lateral_offsets`, reads the adaptive accessor). Mirrors `_get_pygame_renderer`/`_render_step_pygame`.
+
+## 3. Fidelity overlays
+
+- [ ] 3.1 Concentration heatmap: sample a selectable field getter over an N×N lattice (default food, N~64) → `matplotlib.cm` colormap → `pygame.surfarray` surface → scaled alpha-blit. Bounded N; keyboard-selectable field.
+- [ ] 3.2 Gradient quiver: coarse lattice (~12×12) → `get_separated_gradients` arrows scaled by strength; keyboard-toggle (mirror the pheromone `P` toggle), default off.
+- [ ] 3.3 Sensor zones: klinotaxis left/right sample points (from the snapshot) + sweep marker; predator detection/damage rings (`pygame.draw.circle` at radius·zoom); optional contact cone.
+- [ ] 3.4 Adaptive-sensor readout appended to the status bar (background, readout, mode) from the snapshot.
+
+## 4. Export + offline figures
+
+- [ ] 4.1 `scripts/export_screenshot.py`: `_export_continuous(output_path)` (set `SDL_VIDEODRIVER=dummy`, stage a `Continuous2DEnvironment`, render one frame, `pygame.image.save`); update the module docstring + a `--continuous` flag.
+- [ ] 4.2 New `report/continuous_figures.py`: `plot_trajectory`, `plot_field_heatmap` (matplotlib `imshow` over the lattice), `plot_gradient_quiver` (matplotlib `quiver`) — headless static figures for logbooks.
+
+## 5. Tests
+
+- [ ] 5.1 `tests/.../env/test_continuous_renderer.py` (guard with the existing `requires_pygame` skip + `SDL_VIDEODRIVER=dummy`): `_world_to_pixel` math (origin / corner / centre, y-inversion, zoom scaling).
+- [ ] 5.2 Snapshot builder: left/right klinotaxis sample points match a direct `_continuous_lateral_offsets` call for a known `(pos, heading, sweep)`; `AdaptiveChemosensor.background` returns the integrator background.
+- [ ] 5.3 Smoke render: build the renderer (dummy driver) + render one frame on a staged `Continuous2DEnvironment`; assert no exception + expected `_screen` dimensions.
+- [ ] 5.4 Offline figures: generate trajectory / heatmap / quiver PNGs headlessly; assert files written + non-empty.
+
+## 6. Docs, tracker, pre-merge gate
+
+- [ ] 6.1 Tick `phase6-tracking` **T6.render** + the roadmap T6 row note (renderer no longer deferred); brief usage note (the `--theme pixel_continuous` command + `--continuous` screenshot).
+- [ ] 6.2 `openspec validate add-continuous-fidelity-renderer --strict` clean; full suite (`uv run pytest -m "not nightly"`) green.
+- [ ] 6.3 Targeted `pre-commit run --files <changed>` clean; full `pre-commit run -a` before push; open PR.


### PR DESCRIPTION
**Draft — planning artifact, no code.** Authored + self-reviewed OpenSpec change for the continuous-substrate fidelity renderer, realising the deferred `T6.render` seed (logbook 028 § Deferrals). Implementation lands in follow-up PRs against this change.

## Why
The continuous-2D substrate shipped its physics (float sources, continuous-field sensing, Fick gradients, the adaptive sensor) but the renderer was deferred — the existing pixel theme only got *float-safe* (snaps the worm + sources to cells) and shows **none** of the new fidelity. This change plans a proper continuous renderer so the substrate can be inspected/demoed and turned into the spatial figures the real-worm validation needs.

## Scope (confirmed with the user)
- New `Continuous2DRenderer` (sibling of `PygameRenderer`): `world→pixel` full-arena view + configurable zoom; **grid-renderer feature parity** (background, temperature/oxygen/toxic zones, full status bar) ported to continuous coords; worm = point + continuous-heading line.
- **Four fidelity overlays:** concentration heatmap (selectable field; matplotlib colormap via surfarray, cached), gradient quiver (coarse, keyboard-toggle, off by default), klinotaxis + predator sensor zones, adaptive-sensor readout.
- New `Theme.PIXEL_CONTINUOUS`; a frozen `ContinuousRenderState` snapshot + public `AdaptiveChemosensor.background` accessor for decoupling; PNG export + offline matplotlib figures.
- **Single-agent only**; **no new deps** (pygame + matplotlib already present). gif/mp4 export + multi-agent-continuous are documented follow-ups.

## Artifacts
- `proposal.md` — new capability `continuous-fidelity-renderer`; no modified capabilities (renderer-local zoom).
- `design.md` — D1 sibling/world→pixel, D2 cached surfarray heatmap, D3 snapshot decoupling + adaptive accessor, D4 coarse toggleable quiver + new keyboard handling, D5 PNG/matplotlib (gif deferred), D6 new theme value.
- `specs/continuous-fidelity-renderer/spec.md` — 11 ADDED requirements (selection, world→pixel/full-arena/zoom, grid parity, continuous-heading worm, heatmap, quiver, sensor zones, adaptive readout, decoupled snapshot, export/figures) with scenarios.
- `tasks.md` — 6 groups; ticks `phase6-tracking` T6.render.

## Self-review (`nematode-review-spec`)
No blocking findings; all file/API/dep references verified against the codebase. Applied: corrected the quiver-toggle framing (single-agent renderer needs **new** keyboard handling — the pheromone P-toggle is multi-agent-only) + added task 3.5; clarified status-bar/zone reuse boundaries; added heatmap caching (N² field calls/frame too heavy uncached). `openspec validate --strict` clean; markdownlint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive spec, design, proposal and task docs for a new continuous-fidelity renderer: full-arena continuous rendering with configurable pixels-per-mm zoom, selectable overlays (concentration heatmaps, gradient quivers, sensor zones), adaptive sensor readout, status bar parity, and single-frame PNG/offline figure export.  
  * Included OpenSpec configuration entry for the change set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->