### PR TITLE
fix(env): bound continuous turn rate to a realistic max angular velocity

### DIFF
--- a/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/design.md
+++ b/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/design.md
@@ -1,0 +1,32 @@
+# Design
+
+A small env-side kinematic-fidelity fix. Three decisions:
+
+## D1 — Bound at the env rescale, not the brain action space
+
+The brains emit a **normalized** `(speed, turn)` so they stay substrate-independent (the docstring on
+`move_agent_normalized` makes this an explicit design intent); the physical scale is the environment's
+job. The speed already follows this — `speed = speed_norm * max_step_mm`. The turn did not: it was
+hard-coded `turn = turn_norm * math.pi`. So the fix belongs at that exact line — replace `π` with a
+physical `max_turn_rad` — **not** at the brains' `[-1, 1]` bound (bounding the normalized action would
+make the brain env-aware and leave the constant's units ambiguous). This keeps speed and turn symmetric:
+both are normalized in the brain and scaled by an env kinematic parameter (`max_step_mm`, `max_turn_rad`).
+
+## D2 — `max_turn_rad` on `Continuous2DParams` (configurable), default re-validated
+
+It is a `Continuous2DParams` / `Continuous2DConfig` field (like `max_step_mm`, `capture_radius_mm`,
+`predator_damage_radius_mm`), so it is config-settable and sweepable, and the eventual `T7.validation`
+need to match real-worm turn-rate distributions can be met by tuning it. The **default** is chosen by
+re-validation: sweep `max_turn_rad ∈ {0.5, 0.79, 1.05}` rad (≈29°/45°/60° per step) on the C1 MLP
+foraging task, pick the **tightest value that still converges** to the 10-food target (tighter = more
+realistic), and confirm the spin is gone visually. The previous behaviour was `π` (180°/step); the new
+default is far below it.
+
+## D3 — Brains and grid path untouched
+
+No brain change — the normalized `[-1, 1]` turn bound is correct and stays. The continuous sampling /
+log-prob / entropy math is unaffected (it operates on the normalized action). The discrete grid
+environment does not use `move_agent_normalized`, so its cardinal movement is byte-stable. A bound does
+not by itself forbid a low-speed in-place rotation at the max rate; if re-validation shows that residual
+matters, a follow-up (min-speed coupling or turn-change penalty) can be considered — but removing the
+±180°/step reversal is the load-bearing fix.

--- a/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/proposal.md
+++ b/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+On the continuous-2D substrate the worm's action is `(speed, turn)`. Continuous-action brains emit a
+**substrate-independent normalized** action (`speed ∈ [0,1]`, `turn ∈ [-1,1]`); the **environment**
+rescales it to physical units in `move_agent_normalized`. The turn rescale is `turn_rad = turn_norm * π`
+(`continuous_2d.py`), so the effective per-step turn is bounded to **±π rad ≈ ±180° — a full heading
+reversal every step.** Even a *converged* policy therefore visibly **"helicopter"-spins** (a 360° spin in
+~2 steps), which is not biologically plausible: real *C. elegans* crawls with gradual curvature and
+reorients in bounded sharp turns (~15–30°/step), not at 180°/step.
+
+This matters beyond aesthetics: T7's **headline external anchor is the real-worm behavioural-chemotaxis
+validation** (turn-rate vs dC/dt, curving-rate vs bearing — `T7.validation`). A worm with a 180°/step
+turn-rate distribution would directly weaken that comparison — the one thing that gives the continuous
+substrate its biological meaning. Surfaced during the T7 C1 foraging-convergence visual inspection.
+
+## What Changes
+
+- **Bounded turn rate as an env-side kinematic parameter.** Replace the hard-coded `* π` turn rescale
+  with a configurable `Continuous2DParams.max_turn_rad` (a maximum per-step angular velocity in radians,
+  the rotational analogue of `max_step_mm`): `turn_rad = turn_norm * max_turn_rad`. The default is a
+  biologically realistic value (re-validated against C1 foraging convergence + visual inspection), well
+  below the previous π. The brains stay **env-agnostic** — they keep emitting the normalized
+  `turn ∈ [-1, 1]`; the physical turn scale lives in the environment alongside `max_step_mm`.
+- **Configurable per scenario.** `max_turn_rad` is exposed on `Continuous2DConfig` (the YAML
+  `continuous:` block) and threaded through the factory, so the turn realism can be tuned per scenario
+  (e.g. for matching real-worm turn-rate distributions in `T7.validation`).
+- **No brain change; grid path unchanged.** The 5 continuous brains' normalized `[-1, 1]` turn bound is
+  untouched. The discrete grid environment's cardinal-action movement is unaffected and byte-stable.
+- **Re-validation required (downstream).** Bounding the physical turn changes how the worm moves, so the
+  T7 C1 foraging convergence (just established) is re-validated against the new bound — and the
+  helicopter spin confirmed fixed — before the foraging recipe/substrate is locked.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None — this parameterises the existing continuous-2D movement model. -->
+
+### Modified Capabilities
+
+- `continuous-2d-environment`: the "Kinematic continuous movement" requirement specifies the
+  `(speed, turn)` → position update but fixes the physical turn scale at `π` (±180°/step). This change
+  makes the per-step turn bounded to a configurable biologically realistic maximum angular velocity
+  (`max_turn_rad`), applied where the normalized action is rescaled to physical units. Grid byte-stability
+  preserved.
+
+## Impact
+
+- **Code:**
+  - `packages/quantum-nematode/quantumnematode/env/continuous_2d.py` — add
+    `Continuous2DParams.max_turn_rad` (default realistic value); in `move_agent_normalized` rescale
+    `turn = turn_norm * self.continuous.max_turn_rad` (was `* math.pi`).
+  - `packages/quantum-nematode/quantumnematode/utils/config_loader.py` — add
+    `Continuous2DConfig.max_turn_rad` (`Field(default=…, gt=0.0)`) and thread it through
+    `create_env_from_config` into `Continuous2DParams`.
+- **Tests:** `move_agent_normalized` rescales the turn by `max_turn_rad` (turn_norm=1 → heading delta =
+  max_turn_rad); the default is a realistic bound (`0 < default < π`); the config field parses + the
+  factory wires it; grid/discrete path unaffected.
+- **Downstream:** C1 foraging convergence re-validated against the new bound; the real-worm turn-rate
+  validation (`T7.validation`) compares a realistic turn-rate distribution. No new dependencies.

--- a/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/specs/continuous-2d-environment/spec.md
+++ b/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/specs/continuous-2d-environment/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Kinematic continuous movement
+
+The continuous-2D environment SHALL translate a continuous action `(speed, turn)` into a kinematic position update — a heading rotation by the turn angle followed by a forward displacement proportional to speed — bounded by the world extent, replacing the discrete one-cell cardinal-step movement. Continuous-action brains emit a **normalized** action (`speed ∈ [0, 1]`, `turn ∈ [-1, 1]`); the environment SHALL rescale it to physical units — `speed_mm = speed_norm · max_step_mm` and **`turn_rad = turn_norm · max_turn_rad`**, where `max_turn_rad` is a configurable **maximum per-step angular velocity** (the rotational analogue of `max_step_mm`, default `0.5` rad ≈ 29°/step (real C. elegans reorients ~15–30°/step)). The resulting heading SHALL be wrapped to `[−π, π]`. So no single step rotates the heading by more than `max_turn_rad`, and the worm reorients in bounded sharp turns rather than rotating continuously ("helicopter" spinning). The discrete grid environment's cardinal-action movement SHALL remain unchanged and byte-stable.
+
+#### Scenario: Heading-and-displacement update
+
+- **WHEN** an agent emits a normalized continuous action `(speed_norm, turn_norm)`
+- **THEN** the agent's heading rotates by `turn_norm · max_turn_rad` (the resulting heading wrapped to `[−π, π]`) and the agent advances by `speed_norm · max_step_mm` (clamped to `[0, max_step_mm]`) along the new heading
+
+#### Scenario: Turn rate is bounded to a realistic maximum
+
+- **WHEN** a continuous-action brain emits a normalized turn of magnitude up to `1.0`
+- **THEN** the physical heading change for that step is at most `max_turn_rad` radians (default `0.5` rad ≈ 29°/step), so no single step performs a near-full heading reversal
+
+#### Scenario: World-bound clamping
+
+- **WHEN** a movement would take the agent outside the world bounds
+- **THEN** the agent's new position is clamped per-axis to `[0, world_size_mm]` — it advances as far as the bound allows (partial movement), the step is **not** rejected, no error is raised, and the episode continues

--- a/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/tasks.md
+++ b/openspec/changes/archive/2026-06-14-fix-continuous-turn-rate-bound/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## 1. Implementation
+
+- [x] 1.1 Add `max_turn_rad: float` to `Continuous2DParams` (`env/continuous_2d.py`), documented as the
+  max per-step angular velocity (rad), the rotational analogue of `max_step_mm`. Default = the
+  re-validated realistic value (task 3.3).
+- [x] 1.2 In `move_agent_normalized`, rescale `turn = turn_norm * self.continuous.max_turn_rad`
+  (was `turn = turn_norm * math.pi`); update the method docstring (turn maps to `[-max_turn_rad, +max_turn_rad]`).
+- [x] 1.3 Add `Continuous2DConfig.max_turn_rad` (`Field(default=…, gt=0.0)`) in `utils/config_loader.py`
+  and thread it through `create_env_from_config` into `Continuous2DParams`.
+
+## 2. Tests
+
+- [x] 2.1 `move_agent_normalized` rescales turn by `max_turn_rad`: with a configured `max_turn_rad`,
+  `turn_norm = 1.0` rotates the heading by exactly `max_turn_rad` (and `-1.0` by `-max_turn_rad`).
+- [x] 2.2 The default `max_turn_rad` is a realistic bound: `0 < default < math.pi`.
+- [x] 2.3 `Continuous2DConfig.max_turn_rad` parses from YAML and the factory wires it into
+  `Continuous2DParams`.
+- [x] 2.4 Grid/discrete-action path is unaffected (does not use `move_agent_normalized`).
+
+## 3. Validate + gate
+
+- [x] 3.1 `openspec validate fix-continuous-turn-rate-bound --strict`.
+- [x] 3.2 Targeted `pre-commit` on changed files; full `pre-commit run -a` before push;
+  `uv run pytest -m "not nightly"` for the env suite.
+- [x] 3.3 **Re-validation (downstream, recorded in the T7 scratchpad):** sweep `max_turn_rad ∈ {0.5, 0.79, 1.05}` on the C1 MLP foraging task; pick the tightest value that still converges to the
+  10-food target; confirm the helicopter spin is gone on `--theme pixel_continuous`; set that as the
+  `max_turn_rad` default.
+
+**Re-validation result (2026-06-14):** swept {0.5, 0.79, 1.05}; foraging 79/88/100%, but 0.5 (29°) firms to ~98% with entropy 0.05 / ~3000 ep (it was under-trained), and predator evasion at 0.5 vs 1.05 is comparable (survival 60% vs 62%). **Locked the biologically realistic `max_turn_rad = 0.5` rad (~29°/step).** Carry-forward: the C1 foraging recipe gains `entropy_coef 0.05` (or ~3000 ep) at this bound.

--- a/openspec/specs/continuous-2d-environment/spec.md
+++ b/openspec/specs/continuous-2d-environment/spec.md
@@ -27,12 +27,17 @@ The system SHALL provide a continuous-2D environment in which the **agent positi
 
 ### Requirement: Kinematic continuous movement
 
-The continuous-2D environment SHALL translate a continuous action `(speed, turn)` into a kinematic position update — a heading rotation by the turn angle followed by a forward displacement proportional to speed — bounded by the world extent, replacing the discrete one-cell cardinal-step movement.
+The continuous-2D environment SHALL translate a continuous action `(speed, turn)` into a kinematic position update — a heading rotation by the turn angle followed by a forward displacement proportional to speed — bounded by the world extent, replacing the discrete one-cell cardinal-step movement. Continuous-action brains emit a **normalized** action (`speed ∈ [0, 1]`, `turn ∈ [-1, 1]`); the environment SHALL rescale it to physical units — `speed_mm = speed_norm · max_step_mm` and **`turn_rad = turn_norm · max_turn_rad`**, where `max_turn_rad` is a configurable **maximum per-step angular velocity** (the rotational analogue of `max_step_mm`, default `0.5` rad ≈ 29°/step (real C. elegans reorients ~15–30°/step)). The resulting heading SHALL be wrapped to `[−π, π]`. So no single step rotates the heading by more than `max_turn_rad`, and the worm reorients in bounded sharp turns rather than rotating continuously ("helicopter" spinning). The discrete grid environment's cardinal-action movement SHALL remain unchanged and byte-stable.
 
 #### Scenario: Heading-and-displacement update
 
-- **WHEN** an agent emits a continuous action `(speed, turn)`
-- **THEN** the agent's heading rotates by `turn` (clamped to `[−π, π]`) and the agent advances by a displacement proportional to `speed` (clamped to `[0, max]`) along the new heading
+- **WHEN** an agent emits a normalized continuous action `(speed_norm, turn_norm)`
+- **THEN** the agent's heading rotates by `turn_norm · max_turn_rad` (the resulting heading wrapped to `[−π, π]`) and the agent advances by `speed_norm · max_step_mm` (clamped to `[0, max_step_mm]`) along the new heading
+
+#### Scenario: Turn rate is bounded to a realistic maximum
+
+- **WHEN** a continuous-action brain emits a normalized turn of magnitude up to `1.0`
+- **THEN** the physical heading change for that step is at most `max_turn_rad` radians (default `0.5` rad ≈ 29°/step), so no single step performs a near-full heading reversal
 
 #### Scenario: World-bound clamping
 

--- a/packages/quantum-nematode/quantumnematode/env/continuous_2d.py
+++ b/packages/quantum-nematode/quantumnematode/env/continuous_2d.py
@@ -55,6 +55,13 @@ class Continuous2DParams:
     # ``damage_radius`` is <= 0 — the integer grid "same-cell" default is unreachable as a
     # Euclidean distance, so without this fallback continuous predators can never deal damage.
     predator_damage_radius_mm: float = 1.0
+    # Maximum per-step angular velocity (radians) — the rotational analogue of ``max_step_mm``.
+    # The brain's normalized ``turn`` in [-1, 1] is rescaled to [-max_turn_rad, +max_turn_rad] in
+    # ``move_agent_normalized``. Default 0.5 rad (~29 deg/step) — biologically realistic (real
+    # C. elegans reorients ~15-30 deg/step), well below the previous unbounded pi (~180 deg/step
+    # "helicopter" spin). Foraging converges robustly at this bound with the C1 entropy/episode
+    # tuning; predator evasion is comparable to looser bounds (validated T7 C1).
+    max_turn_rad: float = 0.5
 
 
 def _wrap_to_pi(angle: float) -> float:
@@ -239,7 +246,8 @@ class Continuous2DEnvironment(DynamicForagingEnvironment):
         speed_norm : float
             Normalized forward speed in ``[0, 1]`` (mapped to ``[0, max_step_mm]``).
         turn_norm : float
-            Normalized heading change in ``[-1, 1]`` (mapped to ``[-π, π]``).
+            Normalized heading change in ``[-1, 1]`` (mapped to
+            ``[-max_turn_rad, +max_turn_rad]`` — the configured max per-step angular velocity).
         agent_id : str
             The agent to move (defaults to the single/default agent).
 
@@ -251,7 +259,7 @@ class Continuous2DEnvironment(DynamicForagingEnvironment):
         a safety net.
         """
         speed = speed_norm * self.continuous.max_step_mm
-        turn = turn_norm * math.pi
+        turn = turn_norm * self.continuous.max_turn_rad
         self._kinematic_move(self.agents[agent_id], speed, turn)
 
     # ----- float source placement + capture-radius consumption + Euclidean -----

--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -1000,6 +1000,11 @@ class Continuous2DConfig(BaseModel):
     # grid "same-cell" default, unreachable as a Euclidean distance). Default ≈ 1
     # body length. Configurable for predator-difficulty calibration.
     predator_damage_radius_mm: float = Field(default=1.0, ge=0.0)
+    # Maximum per-step angular velocity (radians) — the rotational analogue of max_step_mm.
+    # The brain's normalized turn in [-1, 1] is rescaled to [-max_turn_rad, +max_turn_rad].
+    # Default 0.5 rad (~29 deg/step): biologically realistic (real C. elegans ~15-30 deg/step),
+    # well below the previous pi (~180 deg/step "helicopter" spin). Must be > 0.
+    max_turn_rad: float = Field(default=0.5, gt=0.0)
 
 
 class EnvironmentConfig(BaseModel):
@@ -2877,6 +2882,7 @@ def create_env_from_config(
                 capture_radius_mm=continuous_config.capture_radius_mm,
                 sweep_amplitude_mm=continuous_config.sweep_amplitude_mm,
                 predator_damage_radius_mm=continuous_config.predator_damage_radius_mm,
+                max_turn_rad=continuous_config.max_turn_rad,
             ),
             viewport_size=env_config.viewport_size,
             max_body_length=max_body_length if max_body_length is not None else 6,

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_continuous_2d.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_continuous_2d.py
@@ -291,3 +291,30 @@ class TestGridSubstrateUnchanged:
         env.move_agent(Action.FORWARD)  # discrete cardinal move from centre
         moved = env.agent_pos
         assert abs(moved[0] - start[0]) + abs(moved[1] - start[1]) == 1
+
+
+class TestMaxTurnRate:
+    """The normalized turn is rescaled to physical radians by ``max_turn_rad``."""
+
+    def test_default_is_a_realistic_bound(self) -> None:
+        # Positive and strictly tighter than the [-pi, pi] heading-wrap range — so a
+        # single step cannot perform a near-full heading reversal.
+        assert 0.0 < Continuous2DParams().max_turn_rad < math.pi
+
+    def test_normalized_turn_scaled_by_max_turn_rad(self) -> None:
+        env = Continuous2DEnvironment(
+            continuous=Continuous2DParams(world_size_mm=20.0, max_turn_rad=0.4),
+        )
+        _state(env).heading_rad = 0.0
+        env.move_agent_normalized(speed_norm=0.0, turn_norm=1.0)  # full normalized turn
+        assert _state(env).heading_rad == pytest.approx(0.4)  # == max_turn_rad, not pi
+
+        _state(env).heading_rad = 0.0
+        env.move_agent_normalized(speed_norm=0.0, turn_norm=-1.0)
+        assert _state(env).heading_rad == pytest.approx(-0.4)
+
+    def test_config_field_parses_and_defaults(self) -> None:
+        from quantumnematode.utils.config_loader import Continuous2DConfig
+
+        assert Continuous2DConfig().max_turn_rad == pytest.approx(0.5)
+        assert Continuous2DConfig(max_turn_rad=0.8).max_turn_rad == pytest.approx(0.8)


### PR DESCRIPTION
## Summary

The continuous worm "helicopter"-spun even when converged. Continuous-action brains emit a **normalized** `(speed, turn)`; the env rescales in `move_agent_normalized`, and the turn rescale was `turn = turn_norm * π` → effective **±π rad ≈ ±180°/step** (a full heading reversal every step). That's not biologically plausible and weakens T7's headline external anchor — the **real-worm behavioural-chemotaxis validation** (turn-rate vs dC/dt). Surfaced during the C1 foraging-convergence visual inspection.

## Fix

Replace the hard-coded `* π` with a configurable **`Continuous2DParams.max_turn_rad`** (a maximum per-step angular velocity in radians, the rotational analogue of `max_step_mm`): `turn = turn_norm * max_turn_rad`. **Default `0.5` rad (~29°/step)** — biologically realistic (real *C. elegans* reorients ~15–30°/step). The brains stay **env-agnostic** (normalized `[-1,1]`); the physical turn scale lives in the env alongside `max_step_mm`, and it's configurable per scenario (for real-worm turn-rate matching). Grid/discrete path unchanged.

## Re-validation (the gate)

Swept `max_turn_rad ∈ {0.5, 0.79, 1.05}` on the C1 MLP foraging task (target 10):
- **Foraging:** 0.5 → 79% at 1500 ep, but **~98% with entropy 0.05 / ~3000 ep** (the tighter turn just learns slower — the worm has to plan reorientations earlier); 0.79 → 88%; 1.05 → 100%.
- **Predator evasion** (the coupling concern — heavier turns ↔ fleeing): 0.5 vs 1.05 → survival **60% vs 62%**, comparable. Heavier turns don't hurt evasion.

So the **most realistic value (0.5 rad / 29°) costs nothing** on either behaviour once the cheap robustness lever is applied. Carry-forward: the C1 foraging recipe gains `entropy_coef 0.05` (or ~3000 ep) at this bound — a per-arch tuning detail, not a substrate change.

## Changes

- `Continuous2DParams.max_turn_rad` (default 0.5) + matching `Continuous2DConfig` field + factory wiring
- `move_agent_normalized`: `turn = turn_norm * max_turn_rad` (was `* π`); docstring updated
- Tests: env-side scaling (`turn_norm=1 → heading delta == max_turn_rad`, not π), realistic default, config parse
- OpenSpec change `fix-continuous-turn-rate-bound` (validated `--strict`, archived; canonical spec updated)

## Note

Supersedes an earlier wrong-layer attempt (bounding the *brains'* normalized action, which left the spec/value semantics wrong) — caught in branch review. This bounds at the **env rescale**, the correct layer, keeping brains env-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum turning rate parameter for continuous environments (default 0.5 radians per step).

* **Documentation**
  * Updated continuous-2D environment specification with movement model details.
  * Added design documentation and proposal for continuous movement changes.

* **Tests**
  * Added test suite validating turning rate constraints and parameter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->