### PR TITLE
feat(config): warn on unrecognized brain.config keys at load time

### DIFF
--- a/packages/quantum-nematode/quantumnematode/utils/config_loader.py
+++ b/packages/quantum-nematode/quantumnematode/utils/config_loader.py
@@ -2528,7 +2528,42 @@ def load_simulation_config(config_path: str) -> SimulationConfig:
     """
     with Path(config_path).open() as file:
         data = yaml.safe_load(file)
+        _warn_unknown_brain_config_keys(data, config_path)
         return SimulationConfig(**data)
+
+
+def _warn_unknown_brain_config_keys(data: object, config_path: str) -> None:
+    """Warn about ``brain.config`` keys the brain's config class does not declare.
+
+    Unknown keys are silently dropped when the YAML is parsed into the brain config
+    model (Pydantic ignores extras), so a typo'd or dead hyperparameter — e.g. an
+    entropy-schedule key on a brain that does not implement the schedule — passes
+    without effect. Comparing the raw YAML keys against the resolved brain config
+    class's fields here surfaces them at load time, before they silently no-op.
+    """
+    if not isinstance(data, dict):
+        return
+    brain = data.get("brain")
+    if not isinstance(brain, dict):
+        return
+    brain_name = brain.get("name")
+    raw_config = brain.get("config")
+    if not isinstance(brain_name, str) or not isinstance(raw_config, dict):
+        return
+    config_cls = BRAIN_CONFIG_MAP.get(brain_name)
+    if config_cls is None:
+        return  # unknown brain name is reported elsewhere (brain factory / schema validation)
+    unknown = set(raw_config) - set(config_cls.model_fields)
+    if unknown:
+        logger.warning(
+            "Brain config for '%s' in %s declares unrecognized field(s) %s that "
+            "%s does not accept — they are IGNORED (silently dropped). Check for a "
+            "typo or a hyperparameter the brain does not implement.",
+            brain_name,
+            config_path,
+            sorted(unknown),
+            config_cls.__name__,
+        )
 
 
 def configure_brain(

--- a/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
@@ -1400,7 +1400,8 @@ class TestUnknownBrainConfigKeyWarning:
         with caplog.at_level(logging.WARNING):
             _warn_unknown_brain_config_keys({}, "test.yml")  # no brain
             _warn_unknown_brain_config_keys(
-                {"brain": {"name": "nonexistent", "config": {"x": 1}}}, "t.yml",
+                {"brain": {"name": "nonexistent", "config": {"x": 1}}},
+                "t.yml",
             )
             _warn_unknown_brain_config_keys({"brain": {"name": "mlpppo"}}, "test.yml")  # no config
             _warn_unknown_brain_config_keys("not-a-dict", "test.yml")

--- a/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/utils/test_config_loader.py
@@ -22,6 +22,7 @@ from quantumnematode.utils.config_loader import (
     SensingMode,
     ThermotaxisConfig,
     TransgenerationalConfig,
+    _warn_unknown_brain_config_keys,
     apply_sensing_mode,
     validate_sensing_config,
 )
@@ -1360,3 +1361,47 @@ class TestEvolutionConfigComposedInheritancePairing:
         )
         assert cfg.inheritance == "none"
         assert cfg.transgenerational is None
+
+
+class TestUnknownBrainConfigKeyWarning:
+    """`_warn_unknown_brain_config_keys` surfaces silently-dropped brain.config keys."""
+
+    def test_warns_on_unknown_key(self, caplog):
+        """A brain.config key the brain class does not declare emits a warning."""
+        data = {
+            "brain": {
+                "name": "mlpppo",
+                # entropy_coef_end / entropy_decay_episodes are NOT mlpppo fields —
+                # mlpppo does not implement an entropy schedule, so they no-op.
+                "config": {
+                    "entropy_coef": 0.08,
+                    "entropy_coef_end": 0.02,
+                    "entropy_decay_episodes": 800,
+                },
+            },
+        }
+        with caplog.at_level(logging.WARNING):
+            _warn_unknown_brain_config_keys(data, "test.yml")
+        assert "unrecognized field" in caplog.text
+        assert "entropy_coef_end" in caplog.text
+        assert "entropy_decay_episodes" in caplog.text
+
+    def test_silent_on_clean_config(self, caplog):
+        """A config with only recognized fields emits no warning."""
+        data = {
+            "brain": {"name": "mlpppo", "config": {"entropy_coef": 0.08, "learning_rate": 0.0003}},
+        }
+        with caplog.at_level(logging.WARNING):
+            _warn_unknown_brain_config_keys(data, "test.yml")
+        assert "unrecognized field" not in caplog.text
+
+    def test_no_crash_on_missing_or_unknown_brain(self, caplog):
+        """Missing brain block / unknown brain name / non-dict config are handled gracefully."""
+        with caplog.at_level(logging.WARNING):
+            _warn_unknown_brain_config_keys({}, "test.yml")  # no brain
+            _warn_unknown_brain_config_keys(
+                {"brain": {"name": "nonexistent", "config": {"x": 1}}}, "t.yml",
+            )
+            _warn_unknown_brain_config_keys({"brain": {"name": "mlpppo"}}, "test.yml")  # no config
+            _warn_unknown_brain_config_keys("not-a-dict", "test.yml")
+        assert "unrecognized field" not in caplog.text


### PR DESCRIPTION
## Why

Unknown keys under `brain.config` are silently dropped when the YAML is parsed into the brain config model (Pydantic ignores extras), so a typo'd or dead hyperparameter **no-ops with no signal**. This surfaced during T7: the `mlpppo` continuous-C3 config set `entropy_coef_end` / `entropy_decay_episodes`, but `mlpppo` doesn't implement an entropy schedule — so it ran flat the whole time and nobody noticed until a manual dig-in.

## What changed

`load_simulation_config` now compares the raw YAML `brain.config` keys against the resolved brain config class's fields and logs a warning naming any dropped keys, before they silently no-op. (The existing `_resolve_brain_config` warning couldn't catch these — the keys are dropped at the first YAML→model parse, before it runs.)

## Validation

- Fires on `mlpppo`'s `entropy_coef_end`/`entropy_decay_episodes`; silent on clean configs.
- 3 focused tests (unknown key → warns / clean → silent / missing-or-unknown-brain → graceful), all 380 config-loading tests green; ruff + pyright clean.
- **No committed configs touched** — this PR only adds the signal.

## What it surfaces (follow-ups, out of scope here)

Scanning all configs through the new check finds **~71 configs with dropped keys**. The notable one: **`normalize_advantages` on 60+ `mlpppo` configs** — and `mlpppo` has no advantage normalization at all (computes GAE, never normalizes), so that knob has been silently ignored project-wide. Tracked separately (see linked issue) — decide whether to implement advantage normalization or strip the dead key. The T7 `mlpppo` C3 config's dead entropy-schedule keys are cleaned in the T7 ranking PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration loading now scans `brain.config` and warns about unrecognized keys, helping surface typos or unsupported settings earlier.
  * Warnings are only emitted for well-formed `brain.config` blocks, and are gracefully skipped when the brain name is unknown or the configuration is missing/malformed.

* **Tests**
  * Added coverage to verify warning emission for unknown `brain.config` keys, no warnings for recognized keys, and safe behavior when the `brain` section is absent, incomplete, unknown, or not a dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->