### PR TITLE
Connectome rewired-null control — review nitpick follow-ups (#264)

### DIFF
--- a/packages/quantum-nematode/quantumnematode/connectome/rewiring.py
+++ b/packages/quantum-nematode/quantumnematode/connectome/rewiring.py
@@ -146,9 +146,11 @@ def rewire_degree_preserving(
     """
     chem_edges = [(s.pre, s.post) for s in connectome.chemical_synapses]
     gap_edges = [(g.neuron_a, g.neuron_b) for g in connectome.gap_junctions]
-    # The swap assumes a SIMPLE input graph (no parallel edges) - the weight dicts below key on the
-    # edge tuple and would silently collapse duplicates. The Cook loader dedups both edge types, so
-    # this is a guard against a hand-built/alternate-loader fixture, not a live path.
+    # Guard against PARALLEL edges only (the weight dicts below key on the edge tuple and would
+    # silently collapse duplicates). Self-loops (autapses) are intentionally NOT rejected: the real
+    # Cook connectome contains 38 chemical autapses, they are legitimate structure, and the swap
+    # preserves their degree contribution (an in+out on the diagonal). The Cook loader dedups both
+    # edge types, so this is a guard against a hand-built/alternate-loader fixture, not a live path.
     if len(set(chem_edges)) != len(chem_edges) or len(set(gap_edges)) != len(gap_edges):
         msg = "rewire_degree_preserving requires a simple connectome (no duplicate/parallel edges)"
         raise ValueError(msg)

--- a/packages/quantum-nematode/tests/quantumnematode_tests/analysis/test_connectome_structure_controls.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/analysis/test_connectome_structure_controls.py
@@ -4,9 +4,12 @@ import sys
 from pathlib import Path
 
 # The analysis script lives in scripts/analysis/ and imports sibling helper modules, so put that
-# directory on the path before importing it.
-_ANALYSIS_DIR = Path(__file__).resolve().parents[5] / "scripts" / "analysis"
-sys.path.insert(0, str(_ANALYSIS_DIR))
+# directory on the path first. Locate it by walking up to the repo root (robust to this test's
+# nesting depth) rather than a hardcoded parent index.
+_root = Path(__file__).resolve()
+while _root != _root.parent and not (_root / "scripts" / "analysis").is_dir():
+    _root = _root.parent
+sys.path.insert(0, str(_root / "scripts" / "analysis"))
 
 import connectome_structure_controls as csc  # noqa: E402  # pyright: ignore[reportMissingImports]
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/analysis/test_connectome_structure_controls.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/analysis/test_connectome_structure_controls.py
@@ -9,7 +9,11 @@ from pathlib import Path
 _root = Path(__file__).resolve()
 while _root != _root.parent and not (_root / "scripts" / "analysis").is_dir():
     _root = _root.parent
-sys.path.insert(0, str(_root / "scripts" / "analysis"))
+_analysis_dir = _root / "scripts" / "analysis"
+if not _analysis_dir.is_dir():  # fail fast rather than surface an opaque ModuleNotFoundError later
+    msg = f"could not locate scripts/analysis walking up from {Path(__file__).resolve()}"
+    raise RuntimeError(msg)
+sys.path.insert(0, str(_analysis_dir))
 
 import connectome_structure_controls as csc  # noqa: E402  # pyright: ignore[reportMissingImports]
 
@@ -89,3 +93,31 @@ def test_load_parses_manifest(tmp_path):
     arms = csc.load(manifest)
     assert arms["wild_type"][1] == 100.0
     assert arms["rewired_null"][1] == 100.0
+
+
+def test_load_warns_on_malformed_line_and_unknown_arm(tmp_path, capsys):
+    """A bad-shape line and an unknown arm both WARN (not silently dropped) and are skipped."""
+    a = _out_file(tmp_path, ["SUCCESS"] * 8)
+    manifest = tmp_path / "_manifest.txt"
+    manifest.write_text(f"wild_type 1 {a}\nwild_type notaseed {a}\nwild_typo 2 {a}\n")
+    arms = csc.load(manifest)
+    warned = capsys.readouterr().out
+    assert "skipping malformed manifest line" in warned  # non-int seed
+    assert "unknown arm" in warned  # typo'd arm
+    assert arms["wild_type"] == {1: 100.0}  # only the valid line stored
+
+
+def test_load_warns_on_duplicate_seed_and_last_wins(tmp_path, capsys):
+    """A duplicate (arm, seed) entry WARNs and the later value overwrites the earlier."""
+    hi = _out_file(tmp_path, ["SUCCESS"] * 8)  # 100%
+    lo = tmp_path / "lo.out"
+    lo.write_text(
+        "\n".join(
+            f"Run: {i}   Status: FAILED  Reason: x Steps: 1 Eaten: 3/10  " for i in range(1, 9)
+        ),
+    )
+    manifest = tmp_path / "_manifest.txt"
+    manifest.write_text(f"wild_type 1 {hi}\nwild_type 1 {lo}\n")
+    arms = csc.load(manifest)
+    assert "duplicate manifest entry" in capsys.readouterr().out
+    assert arms["wild_type"][1] == 0.0  # the later (lo) value wins

--- a/scripts/analysis/connectome_structure_controls.py
+++ b/scripts/analysis/connectome_structure_controls.py
@@ -3,7 +3,7 @@
 Compares the wild-type *C. elegans* connectome against a **degree-preserving rewired-null** on the
 continuous integrated-C3 cell across paired seeds. Reads each run's plateau-tail (final-quarter)
 ranked success from the ``run_simulation`` ``.out`` - **reusing the committed ranking metric**
-(``t7_continuous_ranking._plateau_tail``), so this control is measured identically to the 029 ranking
+(``t7_continuous_ranking.plateau_tail``), so this control is measured identically to the 029 ranking
 - and reports the paired-seed delta (wild-type - rewired) with the committed paired-seed Wilcoxon +
 80% bootstrap CI + BH-FDR layer.
 
@@ -29,7 +29,7 @@ from pathlib import Path
 import numpy as np
 
 # Reuse the committed metric + statistics layers verbatim (identical methodology to the 029 ranking).
-from t7_continuous_ranking import _plateau_tail
+from t7_continuous_ranking import plateau_tail
 from weight_search_architecture_ranking import bh_fdr, paired_seed_wilcoxon_bootstrap
 
 REPO = Path(__file__).resolve().parents[2]
@@ -45,25 +45,35 @@ _SIG_Q = 0.05
 
 def _success(out_path: Path) -> float | None:
     """Plateau-tail full-clear success % for one run (the 029 ranked metric), or None."""
-    result = _plateau_tail(out_path)
+    result = plateau_tail(out_path)
     return None if result is None else result[0]
 
 
 def load(manifest: Path) -> dict[str, dict[int, float]]:
-    """Return ``{arm: {seed: success}}`` from an ``<arm> <seed> <out_path>`` manifest."""
+    """Return ``{arm: {seed: success}}`` from an ``<arm> <seed> <out_path>`` manifest.
+
+    Blank / ``#``-comment lines are skipped silently; any other line that fails the
+    ``<arm> <int seed> <out>`` shape, or a duplicate ``(arm, seed)`` overwrite, is reported so
+    analysis issues stay traceable rather than silently dropped.
+    """
     arms: dict[str, dict[int, float]] = {}
-    for line in manifest.read_text().splitlines():
+    for raw in manifest.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
         parts = line.split()
-        if (
-            len(parts) != 3 or not parts[1].isdigit()
-        ):  # `<arm> <int seed> <out>`; skip anything else
+        if len(parts) != 3 or not parts[1].isdigit():  # expected: `<arm> <int seed> <out>`
+            print(f"  WARN: skipping malformed manifest line: {raw!r}")
             continue
         arm, seed, out_path = parts[0], int(parts[1]), Path(parts[2])
         success = _success(REPO / out_path)
         if success is None:
             print(f"  WARN {arm} seed {seed}: no parseable plateau in {out_path} - dropped")
             continue
-        arms.setdefault(arm, {})[seed] = success
+        seeds = arms.setdefault(arm, {})
+        if seed in seeds:
+            print(f"  WARN {arm} seed {seed}: duplicate manifest entry - overwriting previous")
+        seeds[seed] = success
     return arms
 
 

--- a/scripts/analysis/connectome_structure_controls.py
+++ b/scripts/analysis/connectome_structure_controls.py
@@ -66,6 +66,9 @@ def load(manifest: Path) -> dict[str, dict[int, float]]:
             print(f"  WARN: skipping malformed manifest line: {raw!r}")
             continue
         arm, seed, out_path = parts[0], int(parts[1]), Path(parts[2])
+        if arm not in (_WILD, _REWIRED):  # a typo'd arm would be silently ignored by analyse()
+            print(f"  WARN: skipping manifest line with unknown arm {arm!r}: {raw!r}")
+            continue
         success = _success(REPO / out_path)
         if success is None:
             print(f"  WARN {arm} seed {seed}: no parseable plateau in {out_path} - dropped")

--- a/scripts/analysis/t7_continuous_ranking.py
+++ b/scripts/analysis/t7_continuous_ranking.py
@@ -90,6 +90,15 @@ def _plateau_tail(out_path: Path) -> tuple[float, float] | None:
     return 100.0 * float(np.mean(succ[-tail:])), float(np.mean(foods[-tail:]))
 
 
+def plateau_tail(out_path: Path) -> tuple[float, float] | None:
+    """Public entry point for the plateau-tail ranked metric (see :func:`_plateau_tail`).
+
+    Stable cross-module API so other analyses (e.g. the connectome-structure controls) can reuse the
+    exact 029 ranked metric without importing the private helper.
+    """
+    return _plateau_tail(out_path)
+
+
 def _ppo_metrics(experiment_id: str, out_path: Path) -> dict | None:
     """Per-seed metrics: plateau-tail success + foods (from the .out) + JSON convergence/sub-metrics.
 


### PR DESCRIPTION
Small follow-up to #264 (merged), addressing the PR review nitpicks on the connectome rewired-null control. No behaviour change — the DEGREE-STATISTICS verdict is unaffected.

## Fixed

- **Public metric API** — `t7_continuous_ranking` now exposes a public `plateau_tail` wrapper; the control harness imports that instead of the private `_plateau_tail` (drops the cross-module private coupling).
- **Manifest diagnostics** — `load()` skips blank/`#`-comment lines silently but now WARNs on any other malformed line and on a duplicate `(arm, seed)` overwrite, so analysis issues stay traceable.
- **Robust test path** — the harness test locates `scripts/analysis/` by walking up to the repo root, not a hardcoded `parents[5]`.
- **Self-loop clarification** — a comment at the rewiring simple-graph guard documents that chemical self-loops (autapses) are intentionally permitted.

## Skipped (with reasons)

- **Config rename** (variant before sensing) — the `_klinotaxis_rewired_null` order matches the committed siblings `_ars_depletion` / `_no_respawn_control`; renaming would break consistency with them.
- **Reject self-loops** — the real Cook connectome has **38 chemical autapses**; a reject guard would crash the live rewired-null pipeline. They're legitimate structure and the swap preserves their degree contribution.

## Gates

Full `pytest -m "not nightly"` → 4090 passed; full `pre-commit run -a` clean; `openspec validate --specs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public plateau-tail ranking metric entry point for reuse across analyses.
* **Bug Fixes**
  * Improved manifest loading to ignore blank/comment lines, validate expected fields, and emit warnings for malformed entries, unknown arms, and failed plateau-tail parsing.
  * Duplicate `(arm, seed)` entries are now detected and explicitly warned before the later value overwrites the earlier one.
* **Tests**
  * Updated test setup to locate the analysis scripts more robustly across directory layouts and added coverage for warning/skip/overwrite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->