### PR TITLE
docs(logbook): 034 efficiency-axis null — degree-statistics holds on learning speed too

### DIFF
--- a/docs/experiments/logbooks/034-connectome-structure-controls.md
+++ b/docs/experiments/logbooks/034-connectome-structure-controls.md
@@ -7,7 +7,10 @@ the rewired-null is nominally higher). So the connectome's 5th-of-6 standing und
 ([Logbook 029](029-continuous-architecture-ranking.md)) is a property of its connectivity
 **statistics** (degree / sparsity), **not** its specific wiring: a degree-matched random rewiring
 performs the same. The credibility control the connectome half of the 6a synthesis needed — it
-delivers a citable answer.
+delivers a citable answer. The verdict is **robust across axes**: a follow-up efficiency re-analysis
+(learning-curve AUC + episodes-to-competence on the same paired panel) also finds no wild-type
+advantage (n=8, all BH-FDR **q ≥ 0.37**), so the specific wiring buys neither a higher plateau **nor
+faster learning** than a degree-matched rewiring.
 
 **Branch**: `openspec/add-connectome-structure-controls`.
 
@@ -92,6 +95,29 @@ wiring". At n=8 the direction **reverses and vanishes**. Seed 1 was a favourable
 the same connectome seed-variance 029 flagged (wild-type alone spans 35–68% per seed). A live
 demonstration of why n≥8, not n=1, is the bar for this arm.
 
+### Efficiency axis: same verdict (n=8, whole-run learning curves)
+
+The ranked metric above is the final-quarter plateau. A natural follow-up objection: even if the
+*plateau* is degree-statistics, does the specific wiring help the connectome **learn faster** — a
+sample-efficiency / inductive-bias advantage the peak metric would miss? Reading the **whole**
+per-episode series (not just the tail) from the same paired panel forecloses it. No efficiency metric
+shows a significant wild-type advantage:
+
+| metric (n=8 paired) | wild-type | rewired-null | delta (+ = wild better/faster) | BH-FDR q |
+|---|---|---|---|---|
+| learning-curve AUC, full-clear success | 0.46 | 0.44 | +0.022 (wild 6/8) | 0.365 |
+| learning-curve AUC, foods/episode | 7.41 | 7.24 | +0.165 (wild 5/8) | 0.365 |
+| episodes → 30% rolling success | 685 | 967 | +283 (wild 3/8) | 0.422 |
+| episodes → 90% of own foods plateau | 1088 | 1538 | +450 (wild 6/8) | 0.365 |
+
+The point estimates nominally lean wild-type on three of four metrics (the *reverse* nominal lean to
+the peak metric's −3.28), but every one is non-significant at n=8 (all q ≥ 0.37) with mixed per-seed
+direction — the same connectome seed-variance that reversed the single-seed smoke. **The efficiency
+axis agrees with the peak axis: degree-statistics, not wiring.** Cross-arm context from
+[029](029-continuous-architecture-ranking.md): the connectome is not faster-learning than the other
+arms either — the MLP leads on learning-curve AUC and time-to-competence just as it leads on peak, so
+there is no "structural prior → faster learning" story on any comparison run.
+
 ## Analysis
 
 **The connectome's ranking is a degree-statistics result, not a wiring result.** Under PPO weight
@@ -114,6 +140,10 @@ null.
 - **Degree-statistics verdict.** The wild-type connectome is indistinguishable from its
   degree-preserving rewirings (n=8, q=0.770, CI spans 0); its 029 standing reflects connectivity
   statistics, not the specific wiring.
+- **The null holds on the efficiency axis too.** No learning-curve AUC or time-to-competence metric
+  separates wild-type from the rewired-null (n=8, all BH-FDR q ≥ 0.37) — the wiring buys neither a
+  higher plateau nor faster learning, so the credibility control forecloses the inductive-bias/
+  sample-efficiency reframe as well as the peak one.
 - **The single-seed smoke reversed at n=8** — a clean caution against reading connectome results off
   one seed.
 - The **rewiring mechanism is committed, tested, and byte-identical when off** — a reusable
@@ -130,13 +160,18 @@ null.
   consistently"); a chemical-only sensitivity variant was not run (recorded as an option).
 - The **learnable-gap-junction control** (`T7.controls.learnable_gj`, the frozen-electrical-synapse
   fairness question) is a tracked **fast-follow**, deferred from this change.
+- The **efficiency metrics** (learning-curve AUC + threshold-crossing) use a fixed 6000-episode
+  horizon and a 200-episode rolling window; runs that never cross a threshold are right-censored at the
+  horizon. The four metrics are BH-FDR-corrected together; they are a follow-up re-analysis of the
+  existing panel, not a re-run.
 
 ## Next Steps
 
 - [ ] **Learnable-gap-junction control** (`T7.controls.learnable_gj`) — the deferred fast-follow;
   revisit if the 6a-synthesis review raises the frozen-electrical-synapse question.
 - [ ] **6a synthesis (T9a)** rolls this verdict into the connectome section (T9.2 — "document the
-  connectome ranking honestly": 5th of 6, and that standing is degree-statistics not wiring).
+  connectome ranking honestly": 5th of 6, and that standing is degree-statistics not wiring — on both
+  the peak and learning-efficiency axes).
 - [ ] **Real-worm behavioural-chemotaxis validation** (`T7.validation`) — the remaining Phase-6a gate
   (Gate 3 G3.d) before the tranche closes.
 
@@ -148,3 +183,6 @@ null.
   the harness (`scripts/analysis/connectome_structure_controls.py`), and their tests.
 - Supporting analysis (committed): [supporting/034-connectome-structure-controls/](supporting/034-connectome-structure-controls/details.md)
   — the `controls.json` summary + the per-seed CSV + rewiring/matched-init forensics.
+- Efficiency-axis follow-up: the companion harness (`scripts/analysis/connectome_structure_efficiency.py`)
+  reading the **same** paired panel via `t7-connectome-controls/panel_n8/_manifest.txt`; summary committed at
+  [supporting/034-connectome-structure-controls/efficiency.json](supporting/034-connectome-structure-controls/efficiency.json).

--- a/docs/experiments/logbooks/034-connectome-structure-controls.md
+++ b/docs/experiments/logbooks/034-connectome-structure-controls.md
@@ -9,7 +9,7 @@ the rewired-null is nominally higher). So the connectome's 5th-of-6 standing und
 performs the same. The credibility control the connectome half of the 6a synthesis needed — it
 delivers a citable answer. The verdict is **robust across axes**: a follow-up efficiency re-analysis
 (learning-curve AUC + episodes-to-competence on the same paired panel) also finds no wild-type
-advantage (n=8, all BH-FDR **q ≥ 0.37**), so the specific wiring buys neither a higher plateau **nor
+advantage (n=8, all BH-FDR **q ≥ 0.36**), so the specific wiring buys neither a higher plateau **nor
 faster learning** than a degree-matched rewiring.
 
 **Branch**: `openspec/add-connectome-structure-controls`.
@@ -111,7 +111,7 @@ shows a significant wild-type advantage:
 | episodes → 90% of own foods plateau | 1088 | 1538 | +450 (wild 6/8) | 0.365 |
 
 The point estimates nominally lean wild-type on three of four metrics (the *reverse* nominal lean to
-the peak metric's −3.28), but every one is non-significant at n=8 (all q ≥ 0.37) with mixed per-seed
+the peak metric's −3.28), but every one is non-significant at n=8 (all q ≥ 0.36) with mixed per-seed
 direction — the same connectome seed-variance that reversed the single-seed smoke. **The efficiency
 axis agrees with the peak axis: degree-statistics, not wiring.** Cross-arm context from
 [029](029-continuous-architecture-ranking.md): the connectome is not faster-learning than the other
@@ -141,7 +141,7 @@ null.
   degree-preserving rewirings (n=8, q=0.770, CI spans 0); its 029 standing reflects connectivity
   statistics, not the specific wiring.
 - **The null holds on the efficiency axis too.** No learning-curve AUC or time-to-competence metric
-  separates wild-type from the rewired-null (n=8, all BH-FDR q ≥ 0.37) — the wiring buys neither a
+  separates wild-type from the rewired-null (n=8, all BH-FDR q ≥ 0.36) — the wiring buys neither a
   higher plateau nor faster learning, so the credibility control forecloses the inductive-bias/
   sample-efficiency reframe as well as the peak one.
 - **The single-seed smoke reversed at n=8** — a clean caution against reading connectome results off

--- a/docs/experiments/logbooks/supporting/034-connectome-structure-controls/efficiency.json
+++ b/docs/experiments/logbooks/supporting/034-connectome-structure-controls/efficiency.json
@@ -1,0 +1,202 @@
+{
+  "verdict": "degree_statistics",
+  "horizon_episodes": 6000,
+  "rolling_window": 200,
+  "n_paired_seeds": 8,
+  "metrics": {
+    "auc_success": {
+      "higher_is_better": true,
+      "wild_mean": 0.4618541666666667,
+      "rewired_mean": 0.43979166666666664,
+      "wild_minus_rewired_oriented": 0.0220625,
+      "wild_better_seeds": 6,
+      "mean_delta": 0.0220625,
+      "wilcoxon_p": 0.15625,
+      "ci_lo": -0.010166666666666685,
+      "ci_hi": 0.04983541666666667,
+      "n": 8,
+      "per_seed_deltas": [
+        0.07550000000000001,
+        -0.12100000000000005,
+        0.058499999999999996,
+        -0.01100000000000001,
+        0.013999999999999957,
+        0.10200000000000004,
+        0.05683333333333335,
+        0.0016666666666667052
+      ],
+      "bh_fdr_q": 0.3645833333333333
+    },
+    "auc_foods": {
+      "higher_is_better": true,
+      "wild_mean": 7.4063125,
+      "rewired_mean": 7.241770833333333,
+      "wild_minus_rewired_oriented": 0.16454166666666692,
+      "wild_better_seeds": 5,
+      "mean_delta": 0.16454166666666692,
+      "wilcoxon_p": 0.2734375,
+      "ci_lo": -0.04896458333333297,
+      "ci_hi": 0.3494229166666668,
+      "n": 8,
+      "per_seed_deltas": [
+        0.4676666666666671,
+        -0.6688333333333327,
+        0.5386666666666668,
+        -0.06199999999999939,
+        0.009833333333333805,
+        0.6529999999999996,
+        0.4671666666666665,
+        -0.0891666666666664
+      ],
+      "bh_fdr_q": 0.3645833333333333
+    },
+    "episodes_to_30pct_success": {
+      "higher_is_better": false,
+      "wild_mean": 684.5,
+      "rewired_mean": 967.125,
+      "wild_minus_rewired_oriented": 282.625,
+      "wild_better_seeds": 3,
+      "mean_delta": 282.625,
+      "wilcoxon_p": 0.421875,
+      "ci_lo": -48.2625,
+      "ci_hi": 631.1875000000001,
+      "n": 8,
+      "per_seed_deltas": [
+        -117.0,
+        -9.0,
+        1305.0,
+        412.0,
+        -10.0,
+        -251.0,
+        1638.0,
+        -707.0
+      ],
+      "bh_fdr_q": 0.421875
+    },
+    "episodes_to_90pct_foods_plateau": {
+      "higher_is_better": false,
+      "wild_mean": 1088.25,
+      "rewired_mean": 1537.75,
+      "wild_minus_rewired_oriented": 449.5,
+      "wild_better_seeds": 6,
+      "mean_delta": 449.5,
+      "wilcoxon_p": 0.2734375,
+      "ci_lo": -110.32500000000002,
+      "ci_hi": 991.575,
+      "n": 8,
+      "per_seed_deltas": [
+        350.0,
+        -1551.0,
+        1255.0,
+        869.0,
+        693.0,
+        1240.0,
+        2096.0,
+        -1356.0
+      ],
+      "bh_fdr_q": 0.3645833333333333
+    }
+  },
+  "per_seed": {
+    "wild_type": {
+      "1": {
+        "auc_success": 0.462,
+        "auc_foods": 7.5185,
+        "episodes_to_30pct_success": 393.0,
+        "episodes_to_90pct_foods_plateau": 1.0
+      },
+      "2": {
+        "auc_success": 0.42,
+        "auc_foods": 7.253833333333334,
+        "episodes_to_30pct_success": 488.0,
+        "episodes_to_90pct_foods_plateau": 1552.0
+      },
+      "3": {
+        "auc_success": 0.488,
+        "auc_foods": 7.656833333333333,
+        "episodes_to_30pct_success": 676.0,
+        "episodes_to_90pct_foods_plateau": 795.0
+      },
+      "4": {
+        "auc_success": 0.4495,
+        "auc_foods": 7.357166666666667,
+        "episodes_to_30pct_success": 852.0,
+        "episodes_to_90pct_foods_plateau": 1328.0
+      },
+      "5": {
+        "auc_success": 0.5133333333333333,
+        "auc_foods": 7.624333333333333,
+        "episodes_to_30pct_success": 13.0,
+        "episodes_to_90pct_foods_plateau": 590.0
+      },
+      "6": {
+        "auc_success": 0.5835,
+        "auc_foods": 8.147833333333333,
+        "episodes_to_30pct_success": 254.0,
+        "episodes_to_90pct_foods_plateau": 954.0
+      },
+      "7": {
+        "auc_success": 0.42483333333333334,
+        "auc_foods": 7.2545,
+        "episodes_to_30pct_success": 62.0,
+        "episodes_to_90pct_foods_plateau": 37.0
+      },
+      "8": {
+        "auc_success": 0.3536666666666667,
+        "auc_foods": 6.4375,
+        "episodes_to_30pct_success": 2738.0,
+        "episodes_to_90pct_foods_plateau": 3449.0
+      }
+    },
+    "rewired_null": {
+      "1": {
+        "auc_success": 0.3865,
+        "auc_foods": 7.050833333333333,
+        "episodes_to_30pct_success": 276.0,
+        "episodes_to_90pct_foods_plateau": 351.0
+      },
+      "2": {
+        "auc_success": 0.541,
+        "auc_foods": 7.922666666666666,
+        "episodes_to_30pct_success": 479.0,
+        "episodes_to_90pct_foods_plateau": 1.0
+      },
+      "3": {
+        "auc_success": 0.4295,
+        "auc_foods": 7.118166666666666,
+        "episodes_to_30pct_success": 1981.0,
+        "episodes_to_90pct_foods_plateau": 2050.0
+      },
+      "4": {
+        "auc_success": 0.4605,
+        "auc_foods": 7.4191666666666665,
+        "episodes_to_30pct_success": 1264.0,
+        "episodes_to_90pct_foods_plateau": 2197.0
+      },
+      "5": {
+        "auc_success": 0.49933333333333335,
+        "auc_foods": 7.6145,
+        "episodes_to_30pct_success": 3.0,
+        "episodes_to_90pct_foods_plateau": 1283.0
+      },
+      "6": {
+        "auc_success": 0.4815,
+        "auc_foods": 7.494833333333333,
+        "episodes_to_30pct_success": 3.0,
+        "episodes_to_90pct_foods_plateau": 2194.0
+      },
+      "7": {
+        "auc_success": 0.368,
+        "auc_foods": 6.787333333333334,
+        "episodes_to_30pct_success": 1700.0,
+        "episodes_to_90pct_foods_plateau": 2133.0
+      },
+      "8": {
+        "auc_success": 0.352,
+        "auc_foods": 6.526666666666666,
+        "episodes_to_30pct_success": 2031.0,
+        "episodes_to_90pct_foods_plateau": 2093.0
+      }
+    }
+  }
+}

--- a/scripts/analysis/connectome_structure_efficiency.py
+++ b/scripts/analysis/connectome_structure_efficiency.py
@@ -1,0 +1,207 @@
+"""Connectome-structure control, efficiency axis - does the wiring help it *learn faster*.
+
+Companion to ``connectome_structure_controls.py``. That harness answered the **peak** question
+(final-quarter plateau success) and found DEGREE-STATISTICS: the wild-type *C. elegans* connectome is
+indistinguishable from its degree-preserving rewired-null. This harness asks the natural follow-up -
+does the specific wiring confer a **learning-efficiency / inductive-bias** advantage even when the
+peak is the same? - by reading the *whole* per-episode series (not just the plateau tail) from the
+same paired ``.out`` panel and comparing wild-type vs rewired-null on:
+
+- ``auc_success`` - mean full-clear success over the common horizon (the learning integral).
+- ``auc_foods`` - mean foods/episode over the horizon (a finer, less-binary learning signal).
+- ``episodes_to_30pct_success`` - episodes to first cross a 30% rolling full-clear rate.
+- ``episodes_to_90pct_foods_plateau`` - episodes to reach 90% of the run's own foods plateau.
+
+Deltas are oriented so **positive = wild-type better/faster**, then run through the *same* committed
+paired-seed Wilcoxon + 80% bootstrap CI layer as the peak control, with BH-FDR across the four
+metrics. Verdict mirrors the peak control: **SPECIFIC-WIRING (efficiency)** if any metric shows the
+wild-type significantly faster/higher (BH-FDR ``q < 0.05``, positive delta); **DEGREE-STATISTICS**
+if none does (the efficiency axis agrees with the peak axis).
+
+Usage::
+
+    uv run python scripts/analysis/connectome_structure_efficiency.py \
+        --manifest <run-dir>/_manifest.txt --out <run-dir>/efficiency.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import deque
+from pathlib import Path
+
+import numpy as np
+
+# Reuse the committed statistics layer verbatim (identical methodology to the peak control + 029).
+from weight_search_architecture_ranking import bh_fdr, paired_seed_wilcoxon_bootstrap
+
+REPO = Path(__file__).resolve().parents[2]
+
+_WILD = "wild_type"
+_REWIRED = "rewired_null"
+_ROLLING_WINDOW = 200  # episodes; smoothing for the threshold-crossing "learning speed" metrics
+_SUCCESS_THRESHOLD = 0.30  # rolling full-clear rate for episodes_to_30pct_success
+_FOODS_PLATEAU_FRAC = 0.90  # fraction of own foods plateau for episodes_to_90pct_foods_plateau
+_PLATEAU_TAIL_FRAC = 0.25  # final-quarter window defining a run's own plateau (matches the ranking)
+_SIG_Q = 0.05
+
+# Same per-episode line shape the 029 ranking parses: "Run: N Status: S ... Eaten: X/10".
+_RUN_RE = re.compile(r"Run:\s+\d+\s+Status:\s+(\S+).*?Eaten:\s+(\d+)/")
+
+# Per metric: (higher-is-better?) - orients the paired delta so positive = wild-type better/faster.
+_METRICS = {
+    "auc_success": True,
+    "auc_foods": True,
+    "episodes_to_30pct_success": False,
+    "episodes_to_90pct_foods_plateau": False,
+}
+
+
+def _parse_series(out_path: Path) -> tuple[list[float], list[float]]:
+    """Full per-episode (success 0/1, foods 0-10) series from one run's ``.out``."""
+    succ: list[float] = []
+    foods: list[float] = []
+    for line in out_path.read_text(errors="ignore").splitlines():
+        m = _RUN_RE.match(line)
+        if m:
+            succ.append(1.0 if m.group(1) == "SUCCESS" else 0.0)
+            foods.append(float(m.group(2)))
+    return succ, foods
+
+
+def _rolling(xs: list[float], window: int) -> list[float]:
+    out: list[float] = []
+    total = 0.0
+    dq: deque[float] = deque()
+    for x in xs:
+        dq.append(x)
+        total += x
+        if len(dq) > window:
+            total -= dq.popleft()
+        out.append(total / len(dq))
+    return out
+
+
+def _eps_to_threshold(series: list[float], tau: float, horizon: int) -> float:
+    """Episodes to first reach ``tau`` on the rolling window; right-censored at ``horizon``."""
+    for t, v in enumerate(_rolling(series, _ROLLING_WINDOW)):
+        if v >= tau:
+            return float(t + 1)
+    return float(horizon)
+
+
+def _plateau(series: list[float]) -> float:
+    tail = max(1, int(len(series) * _PLATEAU_TAIL_FRAC))
+    return float(np.mean(series[-tail:]))
+
+
+def _run_metrics(out_path: Path, horizon: int) -> dict[str, float]:
+    succ, foods = _parse_series(out_path)
+    succ_h, foods_h = succ[:horizon], foods[:horizon]
+    foods_plateau = _plateau(foods)
+    return {
+        "auc_success": float(np.mean(succ_h)),
+        "auc_foods": float(np.mean(foods_h)),
+        "episodes_to_30pct_success": _eps_to_threshold(succ, _SUCCESS_THRESHOLD, horizon),
+        "episodes_to_90pct_foods_plateau": (
+            _eps_to_threshold(foods, _FOODS_PLATEAU_FRAC * foods_plateau, horizon)
+            if foods_plateau > 0
+            else float(horizon)
+        ),
+    }
+
+
+def _load_runs(manifest: Path) -> dict[str, dict[int, Path]]:
+    arms: dict[str, dict[int, Path]] = {}
+    for raw in manifest.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        arm, seed, out = line.split()
+        arms.setdefault(arm, {})[int(seed)] = REPO / out
+    return arms
+
+
+def analyse(manifest: Path) -> dict:
+    """Wild-type vs rewired-null efficiency comparison from a paired ``.out`` manifest."""
+    runs = _load_runs(manifest)
+    if _WILD not in runs or _REWIRED not in runs:
+        msg = f"manifest must contain both {_WILD!r} and {_REWIRED!r} arms"
+        raise ValueError(msg)
+
+    horizon = min(len(_parse_series(p)[0]) for arm in (_WILD, _REWIRED) for p in runs[arm].values())
+    per_seed = {
+        arm: {seed: _run_metrics(path, horizon) for seed, path in sorted(runs[arm].items())}
+        for arm in (_WILD, _REWIRED)
+    }
+    seeds = sorted(set(per_seed[_WILD]) & set(per_seed[_REWIRED]))
+
+    metrics_out: dict[str, dict] = {}
+    pvals: list[float] = []
+    for name, higher_better in _METRICS.items():
+        deltas = []
+        for s in seeds:
+            w = per_seed[_WILD][s][name]
+            r = per_seed[_REWIRED][s][name]
+            deltas.append((w - r) if higher_better else (r - w))  # positive = wild better/faster
+        stats = paired_seed_wilcoxon_bootstrap(deltas)
+        metrics_out[name] = {
+            "higher_is_better": higher_better,
+            "wild_mean": float(np.mean([per_seed[_WILD][s][name] for s in seeds])),
+            "rewired_mean": float(np.mean([per_seed[_REWIRED][s][name] for s in seeds])),
+            "wild_minus_rewired_oriented": stats["mean_delta"],
+            "wild_better_seeds": sum(1 for d in stats["per_seed_deltas"] if d > 0),
+            **stats,
+        }
+        pvals.append(stats["wilcoxon_p"])
+
+    for (_name, entry), q in zip(metrics_out.items(), bh_fdr(pvals), strict=True):
+        entry["bh_fdr_q"] = q
+
+    specific = any(e["bh_fdr_q"] < _SIG_Q and e["mean_delta"] > 0 for e in metrics_out.values())
+    return {
+        "verdict": "specific_wiring_efficiency" if specific else "degree_statistics",
+        "horizon_episodes": horizon,
+        "rolling_window": _ROLLING_WINDOW,
+        "n_paired_seeds": len(seeds),
+        "metrics": metrics_out,
+        "per_seed": {arm: {str(s): m for s, m in d.items()} for arm, d in per_seed.items()},
+    }
+
+
+def _print_summary(report: dict) -> None:
+    print(
+        f"VERDICT: {report['verdict'].upper()}  "
+        f"(n={report['n_paired_seeds']}, horizon={report['horizon_episodes']} episodes)"
+    )
+    print(f"{'metric':32} {'wild':>9} {'rewired':>9} {'delta(+=wild)':>13} {'q':>7}")
+    for name, e in report["metrics"].items():
+        print(
+            f"{name:32} {e['wild_mean']:>9.2f} {e['rewired_mean']:>9.2f} "
+            f"{e['mean_delta']:>+13.3f} {e['bh_fdr_q']:>7.3f}  "
+            f"wild-better {e['wild_better_seeds']}/{report['n_paired_seeds']}"
+        )
+
+
+def main() -> None:
+    """CLI entry point: analyse the paired panel and optionally write the JSON report."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--manifest",
+        type=Path,
+        default=REPO / "tmp/evaluations/t7-connectome-controls/panel_n8/_manifest.txt",
+    )
+    ap.add_argument("--out", type=Path, default=None, help="write the JSON report to this path")
+    args = ap.parse_args()
+
+    report = analyse(args.manifest)
+    _print_summary(report)
+    if args.out:
+        args.out.write_text(json.dumps(report, indent=2) + "\n")
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/connectome_structure_efficiency.py
+++ b/scripts/analysis/connectome_structure_efficiency.py
@@ -131,12 +131,21 @@ def analyse(manifest: Path) -> dict:
         msg = f"manifest must contain both {_WILD!r} and {_REWIRED!r} arms"
         raise ValueError(msg)
 
-    horizon = min(len(_parse_series(p)[0]) for arm in (_WILD, _REWIRED) for p in runs[arm].values())
+    # Fail fast on any unpaired seed: an extra/missing run would otherwise silently shrink the
+    # shared horizon (the min run length) and distort every metric.
+    wild_seeds, rewired_seeds = set(runs[_WILD]), set(runs[_REWIRED])
+    if wild_seeds != rewired_seeds:
+        msg = (
+            f"paired seed sets differ - wild-only={sorted(wild_seeds - rewired_seeds)}, "
+            f"rewired-only={sorted(rewired_seeds - wild_seeds)}"
+        )
+        raise ValueError(msg)
+    seeds = sorted(wild_seeds)
+
+    horizon = min(len(_parse_series(runs[arm][s])[0]) for arm in (_WILD, _REWIRED) for s in seeds)
     per_seed = {
-        arm: {seed: _run_metrics(path, horizon) for seed, path in sorted(runs[arm].items())}
-        for arm in (_WILD, _REWIRED)
+        arm: {s: _run_metrics(runs[arm][s], horizon) for s in seeds} for arm in (_WILD, _REWIRED)
     }
-    seeds = sorted(set(per_seed[_WILD]) & set(per_seed[_REWIRED]))
 
     metrics_out: dict[str, dict] = {}
     pvals: list[float] = []
@@ -174,14 +183,14 @@ def analyse(manifest: Path) -> dict:
 def _print_summary(report: dict) -> None:
     print(
         f"VERDICT: {report['verdict'].upper()}  "
-        f"(n={report['n_paired_seeds']}, horizon={report['horizon_episodes']} episodes)"
+        f"(n={report['n_paired_seeds']}, horizon={report['horizon_episodes']} episodes)",
     )
     print(f"{'metric':32} {'wild':>9} {'rewired':>9} {'delta(+=wild)':>13} {'q':>7}")
     for name, e in report["metrics"].items():
         print(
             f"{name:32} {e['wild_mean']:>9.2f} {e['rewired_mean']:>9.2f} "
             f"{e['mean_delta']:>+13.3f} {e['bh_fdr_q']:>7.3f}  "
-            f"wild-better {e['wild_better_seeds']}/{report['n_paired_seeds']}"
+            f"wild-better {e['wild_better_seeds']}/{report['n_paired_seeds']}",
         )
 
 


### PR DESCRIPTION
## Summary

Extends the Logbook 034 connectome-structure control from the **peak** axis to the **efficiency** axis. The peak control ([#264](https://github.com/SyntheticBrains/nematode/pull/264)) found the wild-type *C. elegans* connectome indistinguishable from its degree-preserving rewired-null (degree-statistics, not wiring). This adds the natural follow-up objection — *even if the plateau is the same, does the specific wiring help it learn faster (a sample-efficiency / inductive-bias advantage the peak metric would miss)?* — and finds the **same null**.

## Result: DEGREE-STATISTICS on efficiency too (n=8 paired)

| metric | wild-type | rewired-null | Δ (+ = wild better/faster) | BH-FDR q |
|---|---|---|---|---|
| learning-curve AUC, full-clear success | 0.46 | 0.44 | +0.022 (wild 6/8) | 0.365 |
| learning-curve AUC, foods/episode | 7.41 | 7.24 | +0.165 (wild 5/8) | 0.365 |
| episodes → 30% rolling success | 685 | 967 | +283 (wild 3/8) | 0.422 |
| episodes → 90% of own foods plateau | 1088 | 1538 | +450 (wild 6/8) | 0.365 |

No metric separates wild-type from the rewired-null (all q ≥ 0.37; point estimates small and mixed in per-seed sign). The wiring buys neither a higher plateau nor faster learning — foreclosing the inductive-bias / sample-efficiency reframe as well as the peak one.

## Changes

- **New companion harness** `scripts/analysis/connectome_structure_efficiency.py` — reads the *whole* per-episode series from the **same** paired panel (`t7-connectome-controls/panel_n8/`) and reuses the **same** committed paired-seed Wilcoxon + 80% bootstrap + BH-FDR layer as the peak control, so the methodology is identical. Deltas oriented so positive = wild better/faster.
- **Committed summary** `supporting/034-connectome-structure-controls/efficiency.json`, generated by the harness.
- **Logbook 034** folds the finding into Status, Results (new subsection), Conclusions, Limitations, Next Steps, and Data References.

## Provenance / verification

- The re-analysis independently **reproduces the committed peak-panel numbers** (wild 52.8 / rewired 56.1), confirming the efficiency parse is consistent with the peak harness.
- It is a **re-analysis of the existing panel** — no new experiment runs.
- ruff / ruff-format / pyright / mdformat / markdownlint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an efficiency analysis comparing connectome learning performance between wild-type and degree-preserving rewired nulls across paired runs, producing a summary verdict and metric report.
  * The analysis can export a detailed JSON output containing per-seed metric statistics and significance testing results.

* **Documentation**
  * Updated the experiment logbook with follow-up findings showing wild-type remains statistically indistinguishable on learning efficiency (not just plateau performance).
  * Extended conclusions, next steps, and data references to include the new efficiency metric settings and companion results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->