### PR TITLE
feat(render): animated, oriented pursuit predator (continuous-2D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ uv run ./scripts/run_simulation.py \
 | **Food** | Green clustered dots | *E. coli* / OP50 bacterial lawns |
 | **Random predator** | Purple branching tendrils | Nematode-trapping fungi (*Arthrobotrys oligospora*) |
 | **Stationary predator** | Purple ring/net structure with toxic zone | Constricting ring traps (*Drechslerella*) |
-| **Pursuit predator** | Orange-red arachnid shape | Predatory mites |
+| **Pursuit predator** | Orange-red mite with a scuttling-leg gait that turns to face its heading and lunges on a strike (continuous-2D) | Predatory mites |
 
 ### Environment Layers
 

--- a/packages/quantum-nematode/quantumnematode/env/pygame_renderer.py
+++ b/packages/quantum-nematode/quantumnematode/env/pygame_renderer.py
@@ -1136,6 +1136,10 @@ _WORM_RESET_JUMP_MM = 3.0  # a pos jump larger than any legal step (<= max_step_
 _WORM_UNDULATION_WAVELENGTH_SEG = 8.0  # body segments per crawl wave
 _WORM_UNDULATION_PHASE_STEP = 0.55  # phase advance per frame (rad) → the wave travels down the body
 _WORM_UNDULATION_AMPLITUDE_FRAC = 0.7  # lateral wiggle as a fraction of the worm radius
+# Pursuit-predator (mite) rendering: leg-gait cadence (phase per gait-frame advance) and
+# the worm-distance (mm) within which it snaps to the strike pose.
+_PREDATOR_GAIT_PHASE_STEP = 1.1
+_PREDATOR_STRIKE_MM = 3.0
 PREDATOR_DETECTION_RING_COLOR = (200, 160, 220)
 PREDATOR_DAMAGE_RING_COLOR = (220, 70, 70)
 QUIVER_ARROW_COLOR = (120, 230, 140)
@@ -1203,6 +1207,10 @@ class Continuous2DRenderer:
             key: sprites[key]
             for key in ("food", "predator_random", "predator_stationary", "predator_pursuit")
         }
+        # Pursuit-predator animation frames (gait cycle + strike pose), scaled per zoom
+        # alongside the static sprites and oriented at draw time by the predator heading.
+        self._pursuit_frames_raw: list[Any] = sprites["predator_pursuit_frames"]
+        self._pursuit_strike_raw: Any = sprites["predator_pursuit_strike"]
         self._sprite_cache: dict[int, dict[str, Any]] = {}
 
         # Camera state: full-arena by default; `C` toggles agent-following. The
@@ -1285,11 +1293,20 @@ class Continuous2DRenderer:
         entity_px = max(10, round(2.0 * ppm))
         cached = self._sprite_cache.get(entity_px)
         if cached is None:
-            cached = {
+            scaled: dict[str, Any] = {
                 key: self._pg.transform.smoothscale(raw, (entity_px, entity_px))
                 for key, raw in self._raw_sprites.items()
             }
-            self._sprite_cache[entity_px] = cached
+            scaled["predator_pursuit_frames"] = [
+                self._pg.transform.smoothscale(f, (entity_px, entity_px))
+                for f in self._pursuit_frames_raw
+            ]
+            scaled["predator_pursuit_strike"] = self._pg.transform.smoothscale(
+                self._pursuit_strike_raw,
+                (entity_px, entity_px),
+            )
+            self._sprite_cache[entity_px] = scaled
+            cached = scaled
         return cached, entity_px
 
     def _cell_rect(self, gx: int, gy: int) -> tuple[int, int, int, int]:
@@ -1683,18 +1700,27 @@ class Continuous2DRenderer:
         if env.predator.enabled:
             from quantumnematode.env.env import PredatorType
 
+            frames = sprites["predator_pursuit_frames"]
+            gait_idx = int(self._undulation_phase / _PREDATOR_GAIT_PHASE_STEP) % len(frames)
             for pred in env.predators:
-                if pred.predator_type == PredatorType.STATIONARY:
-                    sprite = sprites["predator_stationary"]
-                elif pred.predator_type == PredatorType.PURSUIT:
-                    sprite = sprites["predator_pursuit"]
-                else:
-                    sprite = sprites["predator_random"]
                 px, py = pred.pos_continuous or (
                     float(pred.position[0]),
                     float(pred.position[1]),
                 )
                 cx, cy = self._world_to_pixel(px, py)
+                if pred.predator_type == PredatorType.PURSUIT:
+                    # Animated + oriented: pick the gait frame (or strike pose when
+                    # closing on the worm) and rotate it to face the heading.
+                    worm_dist = math.hypot(px - state.pos[0], py - state.pos[1])
+                    striking = worm_dist <= _PREDATOR_STRIKE_MM
+                    base = sprites["predator_pursuit_strike"] if striking else frames[gait_idx]
+                    rotated = self._pg.transform.rotate(base, math.degrees(pred.heading_rad))
+                    self._screen.blit(rotated, rotated.get_rect(center=(cx, cy)))
+                    continue
+                if pred.predator_type == PredatorType.STATIONARY:
+                    sprite = sprites["predator_stationary"]
+                else:
+                    sprite = sprites["predator_random"]
                 self._screen.blit(sprite, (cx - half, cy - half))
 
         # Worm: a path-following, tapered, undulating body trailing the head, then a

--- a/packages/quantum-nematode/quantumnematode/env/pygame_renderer.py
+++ b/packages/quantum-nematode/quantumnematode/env/pygame_renderer.py
@@ -1701,8 +1701,8 @@ class Continuous2DRenderer:
             from quantumnematode.env.env import PredatorType
 
             frames = sprites["predator_pursuit_frames"]
-            gait_idx = int(self._undulation_phase / _PREDATOR_GAIT_PHASE_STEP) % len(frames)
-            for pred in env.predators:
+            gait_base = self._undulation_phase / _PREDATOR_GAIT_PHASE_STEP
+            for i, pred in enumerate(env.predators):
                 px, py = pred.pos_continuous or (
                     float(pred.position[0]),
                     float(pred.position[1]),
@@ -1710,9 +1710,11 @@ class Continuous2DRenderer:
                 cx, cy = self._world_to_pixel(px, py)
                 if pred.predator_type == PredatorType.PURSUIT:
                     # Animated + oriented: pick the gait frame (or strike pose when
-                    # closing on the worm) and rotate it to face the heading.
+                    # closing on the worm) and rotate it to face the heading. The
+                    # per-predator index offset desynchronises multiple mites' gaits.
                     worm_dist = math.hypot(px - state.pos[0], py - state.pos[1])
                     striking = worm_dist <= _PREDATOR_STRIKE_MM
+                    gait_idx = int(gait_base + i) % len(frames)
                     base = sprites["predator_pursuit_strike"] if striking else frames[gait_idx]
                     rotated = self._pg.transform.rotate(base, math.degrees(pred.heading_rad))
                     self._screen.blit(rotated, rotated.get_rect(center=(cx, cy)))

--- a/packages/quantum-nematode/quantumnematode/env/sprites.py
+++ b/packages/quantum-nematode/quantumnematode/env/sprites.py
@@ -129,10 +129,11 @@ def create_sprites(pg: Any) -> dict[str, Any]:  # noqa: ANN401
     sprites["food"] = _make_food(pg)
     sprites["predator_random"] = _make_predator_random(pg)
     sprites["predator_stationary"] = _make_predator_stationary(pg)
-    sprites["predator_pursuit"] = _make_predator_pursuit(pg)
     # Pursuit-predator animation: a gait cycle + a strike pose, all facing +x so the
-    # continuous renderer can orient them by the predator's heading.
-    pursuit_anim = make_predator_pursuit_frames(pg)
+    # continuous renderer can orient them by the predator's heading. The static
+    # predator_pursuit sprite (used by the non-animated grid renderer) is gait frame 0.
+    pursuit_anim = _make_predator_pursuit_frames(pg)
+    sprites["predator_pursuit"] = pursuit_anim["frames"][0]
     sprites["predator_pursuit_frames"] = pursuit_anim["frames"]
     sprites["predator_pursuit_strike"] = pursuit_anim["strike"]
 
@@ -389,7 +390,7 @@ def _draw_mite(pg: Any, surf: Any, leg_phase: float, *, strike: bool) -> None:  
     pg.draw.circle(surf, _MITE_EYE_COLOR, (bx + 3, c + 3), 1)
 
 
-def make_predator_pursuit_frames(pg: Any) -> dict[str, Any]:  # noqa: ANN401
+def _make_predator_pursuit_frames(pg: Any) -> dict[str, Any]:  # noqa: ANN401
     """Build the pursuit-predator (mite) animation frames + the strike pose.
 
     Returns a dict with ``"frames"`` (a gait cycle of ``PREDATOR_PURSUIT_FRAMES``
@@ -404,13 +405,6 @@ def make_predator_pursuit_frames(pg: Any) -> dict[str, Any]:  # noqa: ANN401
     strike = pg.Surface((CELL_SIZE, CELL_SIZE), pg.SRCALPHA)
     _draw_mite(pg, strike, 0.0, strike=True)
     return {"frames": frames, "strike": strike}
-
-
-def _make_predator_pursuit(pg: Any) -> Any:  # noqa: ANN401
-    """Predatory mite facing +x (the static/frame-0 sprite for non-animated renderers)."""
-    surf = pg.Surface((CELL_SIZE, CELL_SIZE), pg.SRCALPHA)
-    _draw_mite(pg, surf, 0.0, strike=False)
-    return surf
 
 
 def create_tinted_head_sprites(

--- a/packages/quantum-nematode/quantumnematode/env/sprites.py
+++ b/packages/quantum-nematode/quantumnematode/env/sprites.py
@@ -121,7 +121,8 @@ def create_sprites(pg: Any) -> dict[str, Any]:  # noqa: ANN401
     Returns
     -------
     dict[str, Any]
-        Mapping of sprite name to pygame.Surface.
+        Mapping of sprite name to a pygame.Surface, except ``predator_pursuit_frames``
+        which is a ``list`` of pygame.Surface (the pursuit-predator gait cycle).
     """
     sprites: dict[str, Any] = {}
 
@@ -337,12 +338,12 @@ def _make_predator_stationary(pg: Any) -> Any:  # noqa: ANN401
 
 
 # Pursuit-predator (mite) animation: gait-cycle frame count + per-leg phase spread.
-PREDATOR_PURSUIT_FRAMES = 4
+PREDATOR_PURSUIT_FRAMES: int = 4
 # Four legs per side; each entry is (attach_x_offset, forward_fan) where fan < 0 rakes
 # a leg toward the rear and fan > 0 toward the front. Drawn for a mite FACING +x
 # (right), so the renderer can rotate a single canonical sprite by ``heading_rad``.
 _MITE_LEGS: tuple[tuple[int, float], ...] = ((-5, -0.9), (-2, -0.3), (1, 0.3), (4, 0.9))
-_MITE_EYE_COLOR = (40, 20, 20)
+_MITE_EYE_COLOR: tuple[int, int, int] = (40, 20, 20)
 
 
 def _draw_mite(pg: Any, surf: Any, leg_phase: float, *, strike: bool) -> None:  # noqa: ANN401
@@ -365,8 +366,11 @@ def _draw_mite(pg: Any, surf: Any, leg_phase: float, *, strike: bool) -> None:  
             swing = math.sin(ph)
             knee_x = ax + (fan * 4.0 + 0.6 * swing) * reach
             knee_y = ay + side * 5.0 * reach
-            tip_x = knee_x + (fan * 3.5 + 1.6 * swing) * reach
-            tip_y = knee_y + side * 4.5 * reach
+            # Clamp the tips into the canvas so the wider strike splay (reach 1.35)
+            # cannot push the outermost legs past the 32x32 edge and clip.
+            edge = float(CELL_SIZE - 1)
+            tip_x = min(edge, max(0.0, knee_x + (fan * 3.5 + 1.6 * swing) * reach))
+            tip_y = min(edge, max(0.0, knee_y + side * 4.5 * reach))
             pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (ax, ay), (knee_x, knee_y), 2)
             pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (knee_x, knee_y), (tip_x, tip_y), 1)
 
@@ -397,7 +401,7 @@ def _make_predator_pursuit_frames(pg: Any) -> dict[str, Any]:  # noqa: ANN401
     surfaces) and ``"strike"`` (the lunge pose). All sprites face +x so the renderer
     orients them by rotating with the predator's ``heading_rad``.
     """
-    frames = []
+    frames: list[Any] = []
     for f in range(PREDATOR_PURSUIT_FRAMES):
         surf = pg.Surface((CELL_SIZE, CELL_SIZE), pg.SRCALPHA)
         _draw_mite(pg, surf, 2.0 * math.pi * f / PREDATOR_PURSUIT_FRAMES, strike=False)

--- a/packages/quantum-nematode/quantumnematode/env/sprites.py
+++ b/packages/quantum-nematode/quantumnematode/env/sprites.py
@@ -130,6 +130,11 @@ def create_sprites(pg: Any) -> dict[str, Any]:  # noqa: ANN401
     sprites["predator_random"] = _make_predator_random(pg)
     sprites["predator_stationary"] = _make_predator_stationary(pg)
     sprites["predator_pursuit"] = _make_predator_pursuit(pg)
+    # Pursuit-predator animation: a gait cycle + a strike pose, all facing +x so the
+    # continuous renderer can orient them by the predator's heading.
+    pursuit_anim = make_predator_pursuit_frames(pg)
+    sprites["predator_pursuit_frames"] = pursuit_anim["frames"]
+    sprites["predator_pursuit_strike"] = pursuit_anim["strike"]
 
     # Directional head sprites
     for direction in ("up", "down", "left", "right"):
@@ -330,17 +335,81 @@ def _make_predator_stationary(pg: Any) -> Any:  # noqa: ANN401
     return surf
 
 
-def _make_predator_pursuit(pg: Any) -> Any:  # noqa: ANN401
-    """Predatory mite -- small arachnid shape in orange-red."""
-    surf = pg.Surface((CELL_SIZE, CELL_SIZE), pg.SRCALPHA)
+# Pursuit-predator (mite) animation: gait-cycle frame count + per-leg phase spread.
+PREDATOR_PURSUIT_FRAMES = 4
+# Four legs per side; each entry is (attach_x_offset, forward_fan) where fan < 0 rakes
+# a leg toward the rear and fan > 0 toward the front. Drawn for a mite FACING +x
+# (right), so the renderer can rotate a single canonical sprite by ``heading_rad``.
+_MITE_LEGS: tuple[tuple[int, float], ...] = ((-5, -0.9), (-2, -0.3), (1, 0.3), (4, 0.9))
+_MITE_EYE_COLOR = (40, 20, 20)
+
+
+def _draw_mite(pg: Any, surf: Any, leg_phase: float, *, strike: bool) -> None:  # noqa: ANN401
+    """Draw a top-down predatory mite facing +x onto ``surf`` at a gait phase.
+
+    The eight legs scuttle in an alternating-tripod gait driven by ``leg_phase``; on
+    ``strike`` the legs splay wide, the body lunges forward, and the chelicerae open —
+    used when the predator is within striking range of the worm.
+    """
     c = CELL_SIZE // 2
-    pg.draw.ellipse(surf, PREDATOR_PURSUIT_COLOR, (c - 6, c - 8, 12, 16))
-    pg.draw.circle(surf, PREDATOR_PURSUIT_HIGHLIGHT, (c, c - 10), 5)
-    for dy, spread in [(-4, 10), (-1, 12), (2, 11), (5, 9)]:
-        pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (c - 2, c + dy), (c - spread, c + dy - 3), 1)
-        pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (c + 2, c + dy), (c + spread, c + dy - 3), 1)
-    pg.draw.circle(surf, (40, 20, 20), (c - 2, c - 12), 1)
-    pg.draw.circle(surf, (40, 20, 20), (c + 2, c - 12), 1)
+    body_dx = 1 if strike else 0  # lunge forward on strike
+    bx = c + body_dx
+
+    # Legs first (behind the body). Two-segment (femur + tarsus) polylines.
+    reach = 1.35 if strike else 1.0
+    for side in (-1, 1):  # -1 = top (screen up), +1 = bottom
+        for i, (ax_off, fan) in enumerate(_MITE_LEGS):
+            ax, ay = bx + ax_off, c + side * 4
+            ph = leg_phase + i * 1.7 + (0.0 if side < 0 else math.pi)
+            swing = math.sin(ph)
+            knee_x = ax + (fan * 4.0 + 0.6 * swing) * reach
+            knee_y = ay + side * 5.0 * reach
+            tip_x = knee_x + (fan * 3.5 + 1.6 * swing) * reach
+            tip_y = knee_y + side * 4.5 * reach
+            pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (ax, ay), (knee_x, knee_y), 2)
+            pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (knee_x, knee_y), (tip_x, tip_y), 1)
+
+    # Idiosoma (main body oval) + a lighter dorsal sheen.
+    pg.draw.ellipse(surf, PREDATOR_PURSUIT_COLOR, (bx - 7, c - 6, 14, 12))
+    pg.draw.ellipse(surf, PREDATOR_PURSUIT_DARK, (bx - 7, c - 6, 14, 12), 1)
+    pg.draw.circle(surf, PREDATOR_PURSUIT_HIGHLIGHT, (bx - 2, c - 2), 3)
+
+    # Gnathosoma (mouth cone) + chelicerae/fangs pointing forward (+x).
+    pg.draw.polygon(
+        surf,
+        PREDATOR_PURSUIT_COLOR,
+        [(bx + 5, c - 3), (bx + 5, c + 3), (bx + 10, c)],
+    )
+    fang_spread = 4 if strike else 2
+    pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (bx + 8, c - 1), (bx + 13, c - fang_spread), 1)
+    pg.draw.line(surf, PREDATOR_PURSUIT_DARK, (bx + 8, c + 1), (bx + 13, c + fang_spread), 1)
+
+    # Eyes near the front of the idiosoma.
+    pg.draw.circle(surf, _MITE_EYE_COLOR, (bx + 3, c - 3), 1)
+    pg.draw.circle(surf, _MITE_EYE_COLOR, (bx + 3, c + 3), 1)
+
+
+def make_predator_pursuit_frames(pg: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Build the pursuit-predator (mite) animation frames + the strike pose.
+
+    Returns a dict with ``"frames"`` (a gait cycle of ``PREDATOR_PURSUIT_FRAMES``
+    surfaces) and ``"strike"`` (the lunge pose). All sprites face +x so the renderer
+    orients them by rotating with the predator's ``heading_rad``.
+    """
+    frames = []
+    for f in range(PREDATOR_PURSUIT_FRAMES):
+        surf = pg.Surface((CELL_SIZE, CELL_SIZE), pg.SRCALPHA)
+        _draw_mite(pg, surf, 2.0 * math.pi * f / PREDATOR_PURSUIT_FRAMES, strike=False)
+        frames.append(surf)
+    strike = pg.Surface((CELL_SIZE, CELL_SIZE), pg.SRCALPHA)
+    _draw_mite(pg, strike, 0.0, strike=True)
+    return {"frames": frames, "strike": strike}
+
+
+def _make_predator_pursuit(pg: Any) -> Any:  # noqa: ANN401
+    """Predatory mite facing +x (the static/frame-0 sprite for non-animated renderers)."""
+    surf = pg.Surface((CELL_SIZE, CELL_SIZE), pg.SRCALPHA)
+    _draw_mite(pg, surf, 0.0, strike=False)
     return surf
 
 

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
@@ -104,9 +104,13 @@ class TestSprites:
         from quantumnematode.env.sprites import CELL_SIZE, create_sprites
 
         sprites = create_sprites(_pg)
-        for name, surf in sprites.items():
-            assert surf.get_width() == CELL_SIZE, f"{name} width mismatch"
-            assert surf.get_height() == CELL_SIZE, f"{name} height mismatch"
+        for name, value in sprites.items():
+            # Animation entries (e.g. predator_pursuit_frames) are lists of surfaces;
+            # every frame must still be CELL_SIZE x CELL_SIZE.
+            surfaces = value if isinstance(value, list) else [value]
+            for surf in surfaces:
+                assert surf.get_width() == CELL_SIZE, f"{name} width mismatch"
+                assert surf.get_height() == CELL_SIZE, f"{name} height mismatch"
 
     def test_entity_sprites_have_alpha(self) -> None:
         """Entity sprites (not soil) should use SRCALPHA for zone transparency."""

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
@@ -92,6 +92,8 @@ class TestSprites:
             "predator_random",
             "predator_stationary",
             "predator_pursuit",
+            "predator_pursuit_frames",
+            "predator_pursuit_strike",
             "head_up",
             "head_down",
             "head_left",
@@ -123,10 +125,15 @@ class TestSprites:
             "predator_random",
             "predator_stationary",
             "predator_pursuit",
+            "predator_pursuit_frames",  # list of gait-cycle surfaces
+            "predator_pursuit_strike",
         ]
         for name in alpha_sprites:
-            surf = sprites[name]
-            assert surf.get_flags() & _pg.SRCALPHA, f"{name} should have SRCALPHA"
+            value = sprites[name]
+            # Animation entries are lists of surfaces; every surface must be SRCALPHA.
+            surfaces = value if isinstance(value, list) else [value]
+            for surf in surfaces:
+                assert surf.get_flags() & _pg.SRCALPHA, f"{name} should have SRCALPHA"
 
     def test_create_zone_overlay(self) -> None:
         """Verify zone overlays are SRCALPHA and correct size."""

--- a/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
+++ b/packages/quantum-nematode/tests/quantumnematode_tests/env/test_pixel_theme.py
@@ -103,9 +103,23 @@ class TestSprites:
 
     def test_sprite_surfaces_are_correct_size(self) -> None:
         """Verify all sprites are CELL_SIZE x CELL_SIZE."""
-        from quantumnematode.env.sprites import CELL_SIZE, create_sprites
+        from quantumnematode.env.sprites import (
+            CELL_SIZE,
+            PREDATOR_PURSUIT_FRAMES,
+            create_sprites,
+        )
 
         sprites = create_sprites(_pg)
+
+        # The pursuit animation has a specific container contract: a list of
+        # PREDATOR_PURSUIT_FRAMES gait surfaces + a single strike surface.
+        frames = sprites["predator_pursuit_frames"]
+        assert isinstance(frames, list), "predator_pursuit_frames must be a list"
+        assert len(frames) == PREDATOR_PURSUIT_FRAMES
+        assert isinstance(sprites["predator_pursuit_strike"], _pg.Surface), (
+            "predator_pursuit_strike must be a single Surface"
+        )
+
         for name, value in sprites.items():
             # Animation entries (e.g. predator_pursuit_frames) are lists of surfaces;
             # every frame must still be CELL_SIZE x CELL_SIZE.


### PR DESCRIPTION
Gives the continuous-2D pursuit predator a real visual presence for the demo GIF: it now animates, turns to face its movement direction, and lunges on a strike. Render-only — no effect on the simulation, determinism, or headless training (a seed-7 episode is byte-identical before/after).

## What changed

- **New animated predatory-mite sprite** (`sprites.py`): detailed orange-red mite (idiosoma + dorsal sheen, gnathosoma + chelicerae/fangs, eyes, 8 two-segment legs) built as a 4-frame scuttling-leg gait cycle plus a splayed-leg **strike** pose. All frames face +x so the renderer orients them by rotation. The static `predator_pursuit` sprite (grid/console renderers) is gait frame 0.
- **Renderer** (`pygame_renderer.py` `_render_entities`): for pursuit predators, cycle the gait frame off the per-frame clock (with a per-predator offset so multiple mites don't scuttle in lockstep), **rotate to face `heading_rad`** (the true pursuit/wander direction), and snap to the strike pose within 3 mm of the worm.
- **Test** (`test_pixel_theme.py`): the sprite-size test now flattens the list-valued animation frames (each frame is still `CELL_SIZE`).
- **README**: refreshed the pursuit-predator entity description.

## Why

The old pursuit predator was a static, fixed-orientation sprite — it never turned or animated. This makes the predator read as a live, hunting creature in the fidelity renderer.

## Validation

- Sprite art + orientation verified via rendered montages (0°→right, 90°→up, …) and an in-situ mock scene.
- Real `pixel_continuous` path runs full episodes with the animated predators — no errors; seed-7 outcome byte-identical (render-only).
- Branch reviewed (no correctness/cross-file bugs found); three low-severity review nits fixed (per-predator gait offset, static-sprite dedup, private helper naming).
- Full pre-commit gate passes: ruff, ruff-format, pyright, mdformat, markdownlint, and the test suite (59 renderer/sprite tests among them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pursuit predators are now rendered as animated orange-red mites, with scuttling gait motion and automatic strike-pose switching when close to the worm.
  * Pursuit sprites are drawn using gait-cycle frames with heading-aligned rotation for direction-matching visuals.
* **Documentation**
  * Updated the simulation visualization “Entities” table to describe the pursuit predator as an orange-red mite with scuttling-leg behavior and strike-facing posture.
* **Tests**
  * Expanded sprite expectations and assertions to support animation frames for the pixel theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->